### PR TITLE
Add Claude Code integration and PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Changes
+
+- <!-- List key changes -->
+
+## VRE Design Alignment
+
+<!-- How does this change fit within the VRE epistemic model?
+     - Does it affect grounding, policy evaluation, or gap detection?
+     - Does it introduce new primitives, relation types, or depth semantics?
+     - Does it preserve epistemic honesty as a first-class invariant? -->
+
+## Test Plan
+
+- [ ] <!-- How was this tested? -->
+
+## Notes
+
+<!-- Anything reviewers should know — trade-offs, open questions, follow-up work -->

--- a/README.md
+++ b/README.md
@@ -393,6 +393,57 @@ operation, the guard evaluates this policy and, if it applies, surfaces the conf
 
 ---
 
+## Claude Code Integration
+
+VRE ships with a [PreToolUse hook](https://docs.anthropic.com/en/docs/claude-code/hooks) for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) that intercepts every Bash tool call before 
+execution and gates it through VRE grounding and policy evaluation. Commands whose concepts are not grounded at 
+D3 are blocked and knowledge gaps are surfaced directly to the model. Commands that trigger a policy gate 
+surface a confirmation prompt via Claude Code's TUI approval dialog — human consent, not model consent.
+
+### Install the hook
+
+```python
+from vre.integrations.claude_code import install
+
+install("neo4j://localhost:7687", "neo4j", "password")
+```
+
+This does two things:
+
+1. Writes your Neo4j connection details to `~/.vre/config.json`
+2. Injects a `PreToolUse` hook entry into `~/.claude/settings.json` that matches all `Bash` tool calls
+
+The hook command uses the absolute path of the current Python interpreter, so it runs in the same virtualenv where VRE is installed. Safe to call multiple times — existing VRE hook entries are replaced, not duplicated.
+
+### How the hook works
+
+When Claude Code invokes a Bash command:
+
+1. The hook reads the command from stdin and maps it to VRE concepts via `parse_bash_primitives` (`rm foo.txt` → `["delete", "file"]`)
+2. Those concepts are grounded against the graph at D3
+3. **If not grounded** — the hook exits with code 2 and writes the full grounding trace to stderr, which Claude Code feeds back to the model as context. The command does not execute.
+4. **If a policy fires (`PENDING`)** — the hook returns `permissionDecision: "ask"`, deferring to Claude Code's native TUI approval prompt. The user sees the policy's confirmation message and decides directly.
+5. **If a policy blocks (`BLOCK`)** — the hook exits with code 2 and the policy result is fed to the model.
+6. **If grounded with no policy** — the hook exits with code 0 and `permissionDecision: "allow"`. The command proceeds.
+
+The hook fails open: if no VRE concepts are recognized in the command, or if the VRE config file is absent, the command is allowed through. Unknown commands are never silently blocked.
+
+### Remove the hook
+
+```python
+from vre.integrations.claude_code import uninstall
+
+uninstall()
+```
+
+This removes the VRE hook entry from `~/.claude/settings.json` and leaves `~/.vre/config.json` in place.
+
+### Notes
+- The current hook is designed for Bash commands. It can be extended to other tool types by adding additional hook 
+entries with different concept parsers, but for the sake of simplicity and demonstration, it only targets Bash for now.
+
+---
+
 ## Knowledge Gaps
 
 When a grounding check fails, VRE returns structured gap objects rather than a generic error. There are four gap types:
@@ -478,6 +529,8 @@ src/vre/
       wizard.py            # Interactive policy attachment CLI
   builtins/
     shell.py               # SHELL_ALIASES + parse_bash_primitives()
+  integrations/
+    claude_code.py         # Claude Code PreToolUse hook — install/uninstall/run
 
 scripts/
   seed.py                  # Seed the graph with core epistemic primitives

--- a/src/vre/integrations/__init__.py
+++ b/src/vre/integrations/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0

--- a/src/vre/integrations/claude_code.py
+++ b/src/vre/integrations/claude_code.py
@@ -1,0 +1,220 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Claude Code PreToolUse hook integration for VRE.
+
+Intercepts every Bash tool call before execution and gates it through
+VRE grounding and policy evaluation. Commands whose concepts are not
+grounded at D3 are blocked and knowledge gaps are surfaced. Commands
+that are grounded but trigger a policy gate surface a confirmation
+prompt via Claude Code's TUI approval dialog — human consent, not model consent.
+
+Setup::
+
+    from vre.integrations.claude_code import install
+    install("neo4j://localhost:7687", "neo4j", "password")
+
+Removal::
+
+    from vre.integrations.claude_code import uninstall
+    uninstall()
+
+Hook protocol::
+
+    Exit 0 + JSON stdout with permissionDecision "allow" → command proceeds.
+    Exit 2 + stderr message → command blocked, stderr fed to Claude.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+from pathlib import Path
+
+_SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
+_VRE_CONFIG_PATH = Path.home() / ".vre" / "config.json"
+
+
+_MODULE = "vre.integrations.claude_code"
+
+
+def _hook_command() -> str:
+    """
+    Build the hook command string using the current interpreter's absolute path.
+
+    This ensures the hook runs in the same virtualenv where VRE is installed,
+    regardless of what `python` resolves to in Claude Code's shell.
+    """
+    return f"{shlex.quote(sys.executable)} -m {_MODULE}"
+
+
+def _is_vre_hook(hook_entry: dict) -> bool:
+    """
+    Check whether a hook entry belongs to VRE, regardless of interpreter path.
+    """
+    return _MODULE in json.dumps(hook_entry)
+
+_EXIT_ALLOW = 0
+_EXIT_BLOCK = 2
+
+
+def _allow(reason: str | None = None) -> None:
+    """
+    Exit the hook allowing tool execution to proceed.
+
+    Writes a JSON response with permissionDecision "allow" to stdout
+    and exits with code 0.
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+        }
+    }
+    if reason:
+        output["hookSpecificOutput"]["permissionDecisionReason"] = reason
+    print(json.dumps(output))
+    sys.exit(_EXIT_ALLOW)
+
+
+def _block(message: str) -> None:
+    """
+    Exit the hook blocking tool execution.
+
+    Writes the message to stderr (which Claude Code feeds to the model)
+    and exits with code 2.
+    """
+    print(message, file=sys.stderr)
+    sys.exit(_EXIT_BLOCK)
+
+
+def install(uri: str, user: str, password: str, database: str = "neo4j") -> None:
+    """
+    Install the VRE PreToolUse hook into Claude Code's settings.
+
+    Writes Neo4j connection details to ~/.vre/config.json and injects
+    the hook entry into ~/.claude/settings.json. Safe to call multiple
+    times — existing VRE hook entries are replaced, not duplicated.
+    """
+    _VRE_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _VRE_CONFIG_PATH.write_text(json.dumps(
+        {"uri": uri, "user": user, "password": password, "database": database},
+        indent=2,
+    ))
+    _VRE_CONFIG_PATH.chmod(0o600)
+
+    _SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    settings: dict = {}
+    if _SETTINGS_PATH.exists():
+        settings = json.loads(_SETTINGS_PATH.read_text())
+
+    pre_tool_use: list = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    pre_tool_use[:] = [h for h in pre_tool_use if not _is_vre_hook(h)]
+    pre_tool_use.append({
+        "matcher": "Bash",
+        "hooks": [{"type": "command", "command": _hook_command()}],
+    })
+
+    _SETTINGS_PATH.write_text(json.dumps(settings, indent=2))
+    print(f"VRE hook installed. Config: {_VRE_CONFIG_PATH}")
+
+
+def uninstall() -> None:
+    """
+    Remove the VRE PreToolUse hook from Claude Code's settings.
+    """
+    if not _SETTINGS_PATH.exists():
+        return
+
+    settings = json.loads(_SETTINGS_PATH.read_text())
+    pre_tool_use: list = settings.get("hooks", {}).get("PreToolUse", [])
+    pre_tool_use[:] = [h for h in pre_tool_use if not _is_vre_hook(h)]
+    _SETTINGS_PATH.write_text(json.dumps(settings, indent=2))
+    print("VRE hook removed.")
+
+
+def _ask(reason: str) -> None:
+    """
+    Exit the hook deferring the decision to the user via Claude Code's TUI.
+
+    Returns permissionDecision "ask", which causes Claude Code to show its
+    normal approval prompt. The reason is displayed to the user alongside
+    the prompt so they can make an informed decision.
+    """
+    output = {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "ask",
+            "permissionDecisionReason": reason,
+        }
+    }
+    print(json.dumps(output))
+    sys.exit(_EXIT_ALLOW)
+
+
+def _run_hook() -> None:
+    """
+    Hook entry point invoked by Claude Code for every Bash tool call.
+
+    Reads the tool call payload from stdin, extracts the command, maps
+    it to VRE concepts via parse_bash_primitives, then runs grounding
+    followed by policy evaluation.
+
+    - Ungrounded: exit 2, grounding trace to stderr (fed to Claude).
+    - Policy PENDING: defers to Claude Code's TUI approval prompt so
+      the human can accept or reject the action directly.
+    - Policy BLOCK: exit 2, policy result to stderr.
+    - Grounded and no policy: exit 0 with permissionDecision "allow".
+
+    Fails open (allows) when no concepts are recognised or when the
+    VRE config is absent — unknown commands are never silently blocked.
+    """
+    try:
+        payload = json.loads(sys.stdin.read())
+        command: str = payload.get("tool_input", {}).get("command", "")
+
+        if not command:
+            _allow()
+
+        from vre.builtins.shell import parse_bash_primitives
+        concepts = parse_bash_primitives(command)
+
+        if not concepts:
+            _allow("No recognised VRE concepts in command")
+
+        if not _VRE_CONFIG_PATH.exists():
+            _allow("No VRE config found")
+
+        config = json.loads(_VRE_CONFIG_PATH.read_text())
+
+        from vre import VRE
+        from vre.core.graph import PrimitiveRepository
+
+        with PrimitiveRepository(
+            config["uri"], config["user"], config["password"], config.get("database", "neo4j")
+        ) as repo:
+            vre = VRE(repo)
+            grounding = vre.check(concepts)
+
+            if not grounding.grounded:
+                _block(str(grounding))
+
+            policy = vre.check_policy(grounding)
+
+        if policy.action == "PENDING":
+            _ask(policy.confirmation_message or "This action requires confirmation.")
+
+        if policy.action == "BLOCK":
+            _block(str(policy))
+
+        _allow()
+    except SystemExit:
+        raise
+    except Exception:
+        _allow("VRE hook error — failing open")
+
+
+if __name__ == "__main__":
+    _run_hook()

--- a/tests/vre/test_claude_code.py
+++ b/tests/vre/test_claude_code.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Unit tests for vre.integrations.claude_code — install, uninstall, and _run_hook.
+"""
+
+import io
+import json
+import stat
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vre.core.grounding import GroundingResult
+from vre.core.policy import PolicyResult
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _stdin(payload: dict) -> io.StringIO:
+    return io.StringIO(json.dumps(payload))
+
+
+def _tool_payload(command: str = "") -> dict:
+    return {"tool_input": {"command": command}}
+
+
+# ── install ──────────────────────────────────────────────────────────────────
+
+
+class TestInstall:
+
+    def test_creates_config_with_restricted_permissions(self, tmp_path, monkeypatch):
+        settings = tmp_path / ".claude" / "settings.json"
+        config = tmp_path / ".vre" / "config.json"
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._SETTINGS_PATH", settings
+        )
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+
+        from vre.integrations.claude_code import install
+
+        install("neo4j://localhost:7687", "neo4j", "pass")
+
+        assert config.exists()
+        mode = config.stat().st_mode & 0o777
+        assert mode == 0o600
+
+    def test_creates_claude_parent_directory(self, tmp_path, monkeypatch):
+        settings = tmp_path / ".claude" / "settings.json"
+        config = tmp_path / ".vre" / "config.json"
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._SETTINGS_PATH", settings
+        )
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+
+        from vre.integrations.claude_code import install
+
+        install("neo4j://localhost:7687", "neo4j", "pass")
+
+        assert settings.parent.is_dir()
+        assert settings.exists()
+
+    def test_idempotent_no_duplicate_hooks(self, tmp_path, monkeypatch):
+        settings = tmp_path / ".claude" / "settings.json"
+        config = tmp_path / ".vre" / "config.json"
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._SETTINGS_PATH", settings
+        )
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+
+        from vre.integrations.claude_code import install
+
+        install("neo4j://localhost:7687", "neo4j", "pass")
+        install("neo4j://localhost:7687", "neo4j", "pass")
+
+        data = json.loads(settings.read_text())
+        hooks = data["hooks"]["PreToolUse"]
+        assert len(hooks) == 1
+
+
+# ── uninstall ────────────────────────────────────────────────────────────────
+
+
+class TestUninstall:
+
+    def test_removes_hook_entry(self, tmp_path, monkeypatch):
+        settings = tmp_path / ".claude" / "settings.json"
+        config = tmp_path / ".vre" / "config.json"
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._SETTINGS_PATH", settings
+        )
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+
+        from vre.integrations.claude_code import install, uninstall
+
+        install("neo4j://localhost:7687", "neo4j", "pass")
+        uninstall()
+
+        data = json.loads(settings.read_text())
+        assert data["hooks"]["PreToolUse"] == []
+
+    def test_safe_when_no_settings_file(self, tmp_path, monkeypatch):
+        settings = tmp_path / ".claude" / "settings.json"
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._SETTINGS_PATH", settings
+        )
+
+        from vre.integrations.claude_code import uninstall
+
+        # Should not raise
+        uninstall()
+
+
+# ── _run_hook ────────────────────────────────────────────────────────────────
+
+
+class TestRunHook:
+
+    def test_allows_empty_command(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", _stdin(_tool_payload("")))
+
+        from vre.integrations.claude_code import _run_hook
+
+        with pytest.raises(SystemExit) as exc:
+            _run_hook()
+
+        assert exc.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_allows_unrecognised_concepts(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            "sys.stdin", _stdin(_tool_payload("some_unknown_binary --flag"))
+        )
+        monkeypatch.setattr(
+            "vre.builtins.shell.parse_bash_primitives", lambda _: []
+        )
+
+        from vre.integrations.claude_code import _run_hook
+
+        with pytest.raises(SystemExit) as exc:
+            _run_hook()
+
+        assert exc.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+    def test_blocks_ungrounded_concepts(self, tmp_path, monkeypatch, capsys):
+        config = tmp_path / ".vre" / "config.json"
+        config.parent.mkdir(parents=True)
+        config.write_text(json.dumps({
+            "uri": "neo4j://localhost:7687",
+            "user": "neo4j",
+            "password": "pass",
+            "database": "neo4j",
+        }))
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+        monkeypatch.setattr(
+            "sys.stdin", _stdin(_tool_payload("rm -rf /"))
+        )
+        monkeypatch.setattr(
+            "vre.builtins.shell.parse_bash_primitives", lambda _: ["Delete"]
+        )
+
+        grounding = GroundingResult(grounded=False, resolved=["Delete"], gaps=[])
+        mock_repo = MagicMock()
+        mock_repo.__enter__ = MagicMock(return_value=mock_repo)
+        mock_repo.__exit__ = MagicMock(return_value=False)
+
+        mock_vre = MagicMock()
+        mock_vre.check.return_value = grounding
+
+        with patch("vre.core.graph.PrimitiveRepository", return_value=mock_repo), \
+             patch("vre.VRE", return_value=mock_vre):
+            from vre.integrations.claude_code import _run_hook
+
+            with pytest.raises(SystemExit) as exc:
+                _run_hook()
+
+        assert exc.value.code == 2
+
+    def test_defers_pending_policy_to_tui(self, tmp_path, monkeypatch, capsys):
+        config = tmp_path / ".vre" / "config.json"
+        config.parent.mkdir(parents=True)
+        config.write_text(json.dumps({
+            "uri": "neo4j://localhost:7687",
+            "user": "neo4j",
+            "password": "pass",
+            "database": "neo4j",
+        }))
+        monkeypatch.setattr(
+            "vre.integrations.claude_code._VRE_CONFIG_PATH", config
+        )
+        monkeypatch.setattr(
+            "sys.stdin", _stdin(_tool_payload("ls /etc"))
+        )
+        monkeypatch.setattr(
+            "vre.builtins.shell.parse_bash_primitives", lambda _: ["Read"]
+        )
+
+        grounding = GroundingResult(grounded=True, resolved=["Read"], gaps=[])
+        policy = PolicyResult(
+            action="PENDING",
+            confirmation_message="Read access requires confirmation.",
+        )
+
+        mock_repo = MagicMock()
+        mock_repo.__enter__ = MagicMock(return_value=mock_repo)
+        mock_repo.__exit__ = MagicMock(return_value=False)
+
+        mock_vre = MagicMock()
+        mock_vre.check.return_value = grounding
+        mock_vre.check_policy.return_value = policy
+
+        with patch("vre.core.graph.PrimitiveRepository", return_value=mock_repo), \
+             patch("vre.VRE", return_value=mock_vre):
+            from vre.integrations.claude_code import _run_hook
+
+            with pytest.raises(SystemExit) as exc:
+                _run_hook()
+
+        assert exc.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+    def test_fails_open_on_unexpected_exception(self, monkeypatch, capsys):
+        monkeypatch.setattr("sys.stdin", io.StringIO("NOT JSON{{{"))
+
+        from vre.integrations.claude_code import _run_hook
+
+        with pytest.raises(SystemExit) as exc:
+            _run_hook()
+
+        assert exc.value.code == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "allow"
+        assert "failing open" in out["hookSpecificOutput"].get("permissionDecisionReason", "")


### PR DESCRIPTION
## Summary

- Add a PreToolUse hook integration that gates Claude Code Bash tool calls through VRE grounding and policy evaluation before execution
- Add a pull request template for the repository
- Document the Claude Code integration in the README with setup, usage, and removal instructions

## Changes

- `src/vre/integrations/claude_code.py` — PreToolUse hook with `install()`, `uninstall()`, and hook entry point
- `src/vre/integrations/__init__.py` — package init
- `README.md` — new "Claude Code Integration" section, updated project structure
- `.github/pull_request_template.md` — PR template with VRE design alignment section

## VRE Design Alignment

This integration applies VRE's existing grounding and policy enforcement to Claude Code's Bash tool calls via the hooks protocol. No changes to the epistemic model, primitives, or depth semantics. The hook is a new mechanical safety integration point — it uses `vre.check()` and `vre.check_policy()` as-is.

## Test Plan

- [x] Hook install writes correct entries to `~/.claude/settings.json` and `~/.vre/config.json`
- [x] Hook blocks ungrounded commands (exit 2, grounding trace to stderr)
- [x] Hook defers policy PENDING to Claude Code's TUI approval dialog
- [x] Hook allows grounded commands with no policy gates
- [x] Hook fails open when no VRE concepts are recognized

## Notes

The hook currently targets Bash tool calls only. It can be extended to other tool types by adding additional hook entries with different concept parsers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)