### PR TITLE
Fix 7 pre-existing test failures in resolver and shell tests

### DIFF
--- a/tests/vre/test_resolver.py
+++ b/tests/vre/test_resolver.py
@@ -123,7 +123,7 @@ def test_resolver_lookup_returns_none_for_unknown():
     """
     repo = _stub_repo(["file"])
     resolver = ConceptResolver(repo)
-    name_map = resolver._build_name_map()
+    name_map = resolver.build_name_map()
     assert resolver.lookup("unknownxyz123", name_map) is None
 
 
@@ -133,7 +133,7 @@ def test_resolver_lookup_returns_canonical():
     """
     repo = _stub_repo(["file"])
     resolver = ConceptResolver(repo)
-    name_map = resolver._build_name_map()
+    name_map = resolver.build_name_map()
     assert resolver.lookup("file", name_map) == "file"
 
 
@@ -141,7 +141,7 @@ def test_resolver_build_name_map_lowercases_keys():
     """_build_name_map keys are always lowercase."""
     repo = _stub_repo(["File", "Write"])
     resolver = ConceptResolver(repo)
-    name_map = resolver._build_name_map()
+    name_map = resolver.build_name_map()
     assert "file" in name_map
     assert "write" in name_map
 

--- a/tests/vre/test_shell.py
+++ b/tests/vre/test_shell.py
@@ -6,23 +6,23 @@ from vre.builtins.shell import SHELL_ALIASES, parse_bash_primitives
 
 
 def test_rm_maps_to_delete_file():
-    assert parse_bash_primitives("rm -rf /tmp/foo") == ["delete", "file"]
+    assert sorted(parse_bash_primitives("rm -rf /tmp/foo")) == ["delete", "file"]
 
 
 def test_mkdir_maps_to_create_directory():
-    assert parse_bash_primitives("mkdir /tmp/newdir") == ["create", "directory"]
+    assert sorted(parse_bash_primitives("mkdir /tmp/newdir")) == ["create", "directory"]
 
 
 def test_cat_maps_to_read_file():
-    assert parse_bash_primitives("cat /etc/hosts") == ["read", "file"]
+    assert sorted(parse_bash_primitives("cat /etc/hosts")) == ["file", "read"]
 
 
 def test_curl_maps_to_network_request():
-    assert parse_bash_primitives("curl https://example.com") == ["network", "request"]
+    assert sorted(parse_bash_primitives("curl https://example.com")) == ["network", "request"]
 
 
 def test_chmod_maps_to_permission_file():
-    assert parse_bash_primitives("chmod 755 script.sh") == ["permission", "file"]
+    assert sorted(parse_bash_primitives("chmod 755 script.sh")) == ["file", "permission"]
 
 
 def test_unknown_command_returns_empty():
@@ -35,7 +35,7 @@ def test_empty_string_returns_empty():
 
 def test_path_prefix_stripped():
     """Full path to executable is handled correctly."""
-    assert parse_bash_primitives("/usr/bin/rm -f file.txt") == ["delete", "file"]
+    assert sorted(parse_bash_primitives("/usr/bin/rm -f file.txt")) == ["delete", "file"]
 
 
 def test_all_aliases_are_lists_of_strings():
@@ -45,4 +45,4 @@ def test_all_aliases_are_lists_of_strings():
 
 
 def test_ls_maps_to_list_directory():
-    assert parse_bash_primitives("ls -la") == ["list", "directory"]
+    assert sorted(parse_bash_primitives("ls -la")) == ["directory", "list"]


### PR DESCRIPTION
## Summary

- Fix stale `_build_name_map()` references in `test_resolver.py` (renamed to public `build_name_map()`)
- Fix non-deterministic set ordering assertions in `test_shell.py` using `sorted()`
- Harden 2 additional fragile-but-passing shell tests with the same pattern

## Test plan

- [x] All 108 tests pass (`poetry run pytest tests/ -v`)
- [x] Verify no regressions in CI

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)