### PR TITLE
feat: depth-gated relata traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,11 @@ Each primitive is grounded across a hierarchy of **depth levels**:
 | D3    | CONSTRAINTS | Under what conditions does that hold? |
 | D4+   | IMPLICATIONS | What follows if it happens? |
 
-Depth is **monotonic**: D3 grounding implies D0–D2 are also grounded. Execution of any tool requires D3. 
-An agent cannot claim to understand file deletion if it only has an identity-level model of what a file is.
+Depth is **monotonic**: D3 grounding implies D0–D2 are also grounded. Depth requirements are derived from the graph 
+structure itself — edges carry a source depth that determines when they become visible and a target depth that 
+determines when they resolve. An integrator can also enforce a minimum depth floor (e.g. D3 for execution) as a 
+secondary safety lever. An agent cannot claim to understand file deletion if it only has an identity-level model 
+of what a file is.
 
 ### Relata
 
@@ -125,14 +128,15 @@ ollama pull qwen3:8b
 
 ## Seeding the Graph
 
-VRE ships with several seed scripts that populates the graph with select testing scenarios,
-including a fully grounded graph and a graph with missing depth and relational requirements.
+VRE ships with seed scripts that populate the graph with select testing scenarios. Each script clears the graph before seeding to ensure a clean slate. See `scripts/README.md` for full details.
 
 ```bash
+# Fully grounded graph — 16 primitives, all at D3 with complete relata
 python -m scripts.seed_all --neo4j-uri <uri> --neo4j-user <user> --neo4j-password <password>
-```
 
-This creates primitives for: `operating_system`, `filesystem`, `file`, `directory`, `path`, `permission`, `user`, `group`, `create`, `read`, `write`, `delete`, `list`, `move`, `copy`.
+# Gap demonstration graph — 10 primitives, deliberately shaped to produce each gap type
+python -m scripts.seed_gaps --neo4j-uri <uri> --neo4j-user <user> --neo4j-password <password>
+```
 
 ---
 
@@ -163,7 +167,10 @@ print(result.gaps)       # [] or list of KnowledgeGap instances
 print(result)            # Full formatted epistemic trace
 ```
 
-`vre.check()` always evaluates at D3 (CONSTRAINTS). If any concept is unknown, lacks the required depth, has an unmet relational dependency, or is disconnected from the other submitted concepts, `grounded` is `False` and the corresponding gaps are surfaced.
+`vre.check()` derives depth requirements from graph structure — edges that live at higher source depths are only 
+visible when the source primitive is grounded to that depth. An optional `min_depth` parameter lets integrators enforce 
+a stricter floor (e.g. D3 for execution). If any concept is unknown, lacks the required depth, has an unmet relational 
+dependency, or is disconnected from the other submitted concepts, `grounded` is `False` and the corresponding gaps are surfaced.
 
 ### Using the Trace as Agent Context
 
@@ -219,7 +226,7 @@ def write_file(path: str, content: str) -> str:
 Each call runs the following sequence:
 
 1. **Resolve concepts** — map names to canonical primitives via the graph
-2. **Ground at D3** — verify the full subgraph meets CONSTRAINTS depth
+2. **Ground** — verify the subgraph meets depth requirements (graph-derived + optional `min_depth` floor)
 3. **Fire `on_trace`** — surface the epistemic result to the caller
 4. **If not grounded** — return the `GroundingResult` immediately; the function does not execute
 5. **Evaluate policies** — check all `APPLIES_TO` relata for applicable policy gates
@@ -283,7 +290,7 @@ def on_trace(grounding: GroundingResult) -> None:
 ```
 
 `GroundingResult` carries:
-- `grounded: bool` — whether all concepts cleared D3 with no gaps
+- `grounded: bool` — whether all concepts are grounded with no gaps
 - `resolved: list[str]` — canonical primitive names (or original if unresolvable)
 - `gaps: list[KnowledgeGap]` — structured gap descriptions (`ExistenceGap`, `DepthGap`, `RelationalGap`, `ReachabilityGap`)
 - `trace: EpistemicResponse | None` — the full subgraph with all primitives, depths, relata, and pathway
@@ -396,8 +403,7 @@ operation, the guard evaluates this policy and, if it applies, surfaces the conf
 ## Claude Code Integration
 
 VRE ships with a [PreToolUse hook](https://docs.anthropic.com/en/docs/claude-code/hooks) for [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) that intercepts every Bash tool call before 
-execution and gates it through VRE grounding and policy evaluation. Commands whose concepts are not grounded at 
-D3 are blocked and knowledge gaps are surfaced directly to the model. Commands that trigger a policy gate 
+execution and gates it through VRE grounding and policy evaluation. Commands whose concepts are not grounded are blocked and knowledge gaps are surfaced directly to the model. Commands that trigger a policy gate
 surface a confirmation prompt via Claude Code's TUI approval dialog — human consent, not model consent.
 
 ### Install the hook
@@ -420,7 +426,7 @@ The hook command uses the absolute path of the current Python interpreter, so it
 When Claude Code invokes a Bash command:
 
 1. The hook reads the command from stdin and maps it to VRE concepts via `parse_bash_primitives` (`rm foo.txt` → `["delete", "file"]`)
-2. Those concepts are grounded against the graph at D3
+2. Those concepts are grounded against the graph
 3. **If not grounded** — the hook exits with code 2 and writes the full grounding trace to stderr, which Claude Code feeds back to the model as context. The command does not execute.
 4. **If a policy fires (`PENDING`)** — the hook returns `permissionDecision: "ask"`, deferring to Claude Code's native TUI approval prompt. The user sees the policy's confirmation message and decides directly.
 5. **If a policy blocks (`BLOCK`)** — the hook exits with code 2 and the policy result is fed to the model.
@@ -465,7 +471,7 @@ epistemic model of networking — not that the request was malformed. The agent 
 
 ### The gate holds at any graph depth
 
-VRE does not require a complete or richly-detailed graph to be useful. The enforcement mechanism is structural — if a concept is not grounded at D3, the action is blocked, regardless of how much or how little else the graph contains. A minimal graph with a single primitive grounded to D3 enforces the contract correctly.
+VRE does not require a complete or richly-detailed graph to be useful. The enforcement mechanism is structural — depth requirements are derived from the graph itself (edge placement gates visibility) and optionally raised by the integrator via `min_depth`. A minimal graph with a single primitive and its edges enforces the contract correctly.
 
 What a detailed graph adds is not stronger enforcement, but better context. More primitives, more relata, and deeper property descriptions give the agent richer epistemic material to reason from. The guard stays honest either way; a richer graph makes the agent more capable within those honest bounds.
 
@@ -489,10 +495,6 @@ The learning through failure paradigm is already emerging naturally, it just nee
 ### Meta-epistemic discussion mode
 
 Structured conversation about the agent's epistemic state: asking why a concept is unknown, providing domain knowledge to populate a depth, or refining relata through dialogue. User input in this mode becomes a source for graph population rather than a trigger for action.
-
-### Scoped policy gates for non-destructive actions
-
-An `ActionPrimitive` subclass carrying a `required_policy_scope` field, allowing read-only or exploratory operations (list, read) to pass with lighter grounding requirements than write or delete operations, without weakening the D3 constraint for execution.
 
 ### VRE Networks
 
@@ -525,7 +527,7 @@ src/vre/
     graph.py               # PrimitiveRepository (Neo4j)
     grounding/
       resolver.py          # ConceptResolver — spaCy lemmatization + name lookup
-      engine.py            # GroundingEngine — D3 query, gap detection
+      engine.py            # GroundingEngine — depth-gated query, gap detection
       models.py            # GroundingResult
     policy/
       models.py            # Policy, Cardinality, PolicyResult
@@ -538,7 +540,9 @@ src/vre/
     claude_code.py         # Claude Code PreToolUse hook — install/uninstall/run
 
 scripts/
-  seed.py                  # Seed the graph with core epistemic primitives
+  clear_graph.py           # Clear all primitives from the Neo4j graph
+  seed_all.py              # Seed fully grounded graph (16 primitives)
+  seed_gaps.py             # Seed gap-demonstration graph (10 primitives)
 
 demo/
   main.py                  # Entry point — argparse + agent setup

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,72 @@
+# Scripts
+
+Utility scripts for managing the VRE Neo4j graph. All scripts accept
+`--neo4j-uri`, `--neo4j-user`, and `--neo4j-password` arguments
+(defaults: `neo4j://localhost:7687`, `neo4j`, `password`).
+
+## clear_graph.py
+
+Deletes every `Primitive` node and its relationships from the graph.
+Called automatically by both seed scripts to ensure a clean slate, but
+can also be run standalone.
+
+```bash
+poetry run python scripts/clear_graph.py
+```
+
+## seed_all.py
+
+Seeds the fully grounded epistemic graph — 15 primitives covering the
+filesystem domain end-to-end. Every primitive is grounded to D3
+(CONSTRAINTS) with complete structural relata (DEPENDS_ON, REQUIRES,
+INCLUDES, APPLIES_TO, CONSTRAINED_BY).
+
+Primitives: `operating_system`, `filesystem`, `path`, `permission`,
+`directory`, `file`, `user`, `group`, `create`, `read`, `write`,
+`delete`, `list`, `move`, `copy`
+
+```bash
+poetry run python scripts/seed_all.py
+```
+
+## seed_gaps.py
+
+Seeds a deliberately shaped graph (10 primitives) designed to
+demonstrate depth-gated traversal and the full gap taxonomy. Each
+action primitive is truncated or structured to produce a specific gap
+type when queried.
+
+```bash
+poetry run python scripts/seed_gaps.py
+```
+
+### Primitives
+
+| Primitive | Depths | Role |
+|---|---|---|
+| `operating_system` | D0–D3 | Fully grounded substrate |
+| `filesystem` | D0–D3 | Fully grounded substrate |
+| `path` | D0–D3 | Fully grounded structural |
+| `permission` | D0–D3 | Fully grounded structural |
+| `directory` | D0–D3 | Fully grounded entity — target for safe ops |
+| `file` | D0–D1 | Shallow entity — triggers RelationalGap when targeted |
+| `read` | D0–D2 | Safe action, APPLIES_TO@D2 visible |
+| `list` | D0–D2 | Safe action, APPLIES_TO@D2 visible |
+| `delete` | D0–D2 | Destructive action, APPLIES_TO@D3 omitted (D3 not seeded) |
+| `create` | D0–D1 + D3 | Destructive action, APPLIES_TO@D3 gated (D2 missing) |
+
+### Expected Gap Scenarios
+
+| Query | Gaps | Why |
+|---|---|---|
+| `["list", "directory"]` | None | list@D2 sees APPLIES_TO@D2; directory@D3 >= target D2 |
+| `["read", "file"]` | RelationalGap(read→file, req=D2, cur=D1) | read@D2 sees APPLIES_TO@D2, but file@D1 < target D2 |
+| `["delete", "file"]` | ReachabilityGap(file) | APPLIES_TO lives at D3 in seed_all; D3 omitted here, no edges exist |
+| `["delete", "directory"]` | ReachabilityGap(directory) | Same — no visible connection between delete and directory |
+| `["create", "file"]` | DepthGap(create, req=D3, cur=D1) + ReachabilityGap(file) | create contiguous max=D1; APPLIES_TO@D3 gated, nodes disconnected |
+| `["create", "directory"]` | DepthGap(create, req=D3, cur=D1) + ReachabilityGap(directory) | Same mechanism — edge gated, target unreachable |
+| Unknown concept (e.g. `["frobnicate"]`) | ExistenceGap | Concept not in graph |
+
+> Query with `min_depth=DepthLevel.CONSTRAINTS` to additionally produce
+> DepthGap on any root primitive that doesn't reach D3 (read, list,
+> delete, file).

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -1,0 +1,43 @@
+"""
+Clear all primitives and relationships from the VRE Neo4j graph.
+
+Can be run standalone or imported by seed scripts to ensure a clean slate.
+
+Run: poetry run python scripts/clear_graph.py
+"""
+import argparse
+from typing import LiteralString, cast
+
+from vre.core.graph import PrimitiveRepository
+
+
+def clear_graph(repo: PrimitiveRepository) -> int:
+    """
+    Delete every Primitive node and its relationships. Returns the count deleted.
+    """
+    with repo._driver.session(database=repo._database) as session:
+        result = session.run(
+            cast(
+                LiteralString,
+                "MATCH (p:Primitive) DETACH DELETE p RETURN count(p) AS deleted",
+            ),
+        ).single()
+        return result["deleted"] if result else 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Clear all VRE graph data")
+    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
+    parser.add_argument("--neo4j-user", default="neo4j")
+    parser.add_argument("--neo4j-password", default="password")
+    args = parser.parse_args()
+
+    repo = PrimitiveRepository(
+        uri=args.neo4j_uri,
+        user=args.neo4j_user,
+        password=args.neo4j_password,
+    )
+
+    with repo:
+        deleted = clear_graph(repo)
+        print(f"Cleared {deleted} primitive(s) from the graph.")

--- a/scripts/seed_all.py
+++ b/scripts/seed_all.py
@@ -1,12 +1,14 @@
 """
 Seed script for populating VRE with epistemic primitives.
 
-Run: poetry run python scripts/seed.py
+Run: poetry run python scripts/seed_all.py
 """
 import argparse
 
+from scripts.clear_graph import clear_graph
 from vre.core.graph import PrimitiveRepository
 from vre.core.models import Depth, DepthLevel, Primitive, Relatum, RelationType
+from vre.core.policy.models import Cardinality, Policy
 
 
 def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
@@ -431,6 +433,20 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                     "inputs": ["target_type", "destination_context", "initial_state"],
                     "outputs": ["new_entity_instance"],
                 },
+            ),
+            Depth(
+                level=DepthLevel.CONSTRAINTS,
+                properties={
+                    "description": "The destination context must exist and permit new entities. "
+                                   "The target type must be known. The entity must not already exist "
+                                   "at the destination unless replacement is explicitly intended.",
+                    "constraints": [
+                        "Destination context must exist",
+                        "Destination context must permit creation",
+                        "Target type must be known",
+                        "Entity must not already exist at destination unless replacement is explicit",
+                    ],
+                },
                 relata=[
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
@@ -451,20 +467,6 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         },
                     ),
                 ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The destination context must exist and permit new entities. "
-                                   "The target type must be known. The entity must not already exist "
-                                   "at the destination unless replacement is explicitly intended.",
-                    "constraints": [
-                        "Destination context must exist",
-                        "Destination context must permit creation",
-                        "Target type must be known",
-                        "Entity must not already exist at destination unless replacement is explicit",
-                    ],
-                },
             ),
         ],
     )
@@ -645,19 +647,6 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                 },
                 relata=[
                     Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=directory.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "recursive": "moving a directory moves all of its contents",
-                        },
-                    ),
-                    Relatum(
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
@@ -684,6 +673,21 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                         "Move across filesystem boundaries may degrade to copy-then-delete",
                     ],
                 },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=file.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                    ),
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=directory.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        metadata={
+                            "recursive": "moving a directory moves all of its contents",
+                        },
+                    ),
+                ],
             ),
         ],
     )
@@ -782,22 +786,6 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                     "inputs": ["target_entity"],
                     "outputs": ["confirmation_of_removal"],
                 },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=directory.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "recursive": "directory deletion may require recursive removal of contents",
-                            "empty_check": "some systems require the directory to be empty first",
-                        },
-                    ),
-                ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
@@ -812,6 +800,30 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         "Some entities may be protected from deletion",
                     ],
                 },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=file.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        policies=[
+                            Policy(
+                                name="BulkFileDeletePolicy",
+                                requires_confirmation=True,
+                                trigger_cardinality=Cardinality.MULTIPLE,
+                                confirmation_message="Bulk file deletion requires user approval. Proceed?",
+                            ),
+                        ],
+                    ),
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=directory.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        metadata={
+                            "recursive": "directory deletion may require recursive removal of contents",
+                            "empty_check": "some systems require the directory to be empty first",
+                        },
+                    ),
+                ],
             ),
         ],
     )
@@ -849,18 +861,6 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                     "inputs": ["target_entity", "new_content_or_state"],
                     "outputs": ["modified_entity"],
                 },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "modes": ["overwrite", "append", "insert_at_offset"],
-                            "encoding": "content may require encoding (utf-8, binary)",
-                            "atomicity": "write may not be atomic — partial writes are possible on failure",
-                        },
-                    ),
-                ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
@@ -875,6 +875,18 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                         "Write is destructive — previous state may be lost",
                     ],
                 },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=file.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        metadata={
+                            "modes": ["overwrite", "append", "insert_at_offset"],
+                            "encoding": "content may require encoding (utf-8, binary)",
+                            "atomicity": "write may not be atomic — partial writes are possible on failure",
+                        },
+                    ),
+                ],
             ),
         ],
     )
@@ -1010,6 +1022,8 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
 def main(repository: PrimitiveRepository) -> None:
     with repository as repo:
         repo.ensure_constraints()
+        deleted = clear_graph(repo)
+        print(f"Cleared {deleted} existing primitive(s).\n")
         os_prim = seed_operating_system(repo)
         filesystem = seed_filesystem(repo, os_prim)
         path = seed_path(repo, filesystem)
@@ -1195,7 +1209,7 @@ def main(repository: PrimitiveRepository) -> None:
         repo.save_primitive(copy)
         print(f"Updated: copy with CONSTRAINED_BY permission at D3")
 
-        print("\nDone. Seeded 16 primitives.")
+        print("\nDone. Seeded 15 primitives.")
 
 
 if __name__ == "__main__":

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -1,21 +1,30 @@
 """
-Seed script for populating VRE with epistemic primitives.
+Seed script for demonstrating depth-gated traversal and gap detection.
 
-Run: poetry run python scripts/seed.py
+Seeds a deliberately shaped graph (10 primitives) where each action
+primitive is truncated or structured to produce a specific gap type
+when queried by the grounding engine.
+
+See scripts/README.md for the full primitive table and expected gap scenarios.
+
+Run: poetry run python scripts/seed_gaps.py
 """
 import argparse
 
+from scripts.clear_graph import clear_graph
 from vre.core.graph import PrimitiveRepository
 from vre.core.models import Depth, DepthLevel, Primitive, Relatum, RelationType
+
+
+# ── Fully grounded substrates (D0–D3) ─────────────────────────────────────
 
 
 def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
     """
     Seed the OperatingSystem primitive at D0–D3.
 
-    The OS is the foundational substrate — the environment that provides
-    filesystems, enforces permissions, manages processes, and mediates
-    all interaction between software and hardware.
+    Fully grounded substrate. Provides the environment that provisions
+    filesystems, enforces permissions, and manages processes.
     """
     os_prim = Primitive(
         name="operating_system",
@@ -62,7 +71,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
         ],
     )
     repo.save_primitive(os_prim)
-    print(f"Saved: operating_system ({os_prim.id})")
+    print(f"  operating_system  D0–D3  (substrate)")
     return os_prim
 
 
@@ -70,8 +79,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     Seed the Filesystem primitive at D0–D3.
 
-    The filesystem is the organizational substrate for persistent data.
-    It depends on the OS, which provisions and manages it.
+    Fully grounded substrate. Depends on the OS at D2.
     """
     filesystem = Primitive(
         name="filesystem",
@@ -125,51 +133,15 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(filesystem)
-    print(f"Saved: filesystem ({filesystem.id})")
+    print(f"  filesystem        D0–D3  (substrate)")
     return filesystem
-
-
-def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
-    """
-    Seed the Directory primitive at D0–D3.
-
-    A directory is a container within a filesystem that organizes files
-    and other directories into a hierarchy.
-    """
-    directory = Primitive(
-        name="directory",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "A named container within a filesystem that holds files and "
-                                   "other directories, forming the hierarchical structure of "
-                                   "the filesystem's namespace.",
-                    "attributes": ["path", "name", "parent", "children"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.REQUIRES,
-                        target_id=path.id,
-                        target_depth=DepthLevel.IDENTITY,
-                    ),
-                ],
-            )
-        ],
-    )
-    repo.save_primitive(directory)
-    print(f"Saved: directory ({directory.id})")
-    return directory
 
 
 def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
     """
     Seed the Path primitive at D0–D3.
 
-    A path is the addressing mechanism for locating entities within a
-    filesystem's hierarchy. It is not an entity itself — it is how
-    entities are named and found.
+    Fully grounded structural. Depends on filesystem at D2.
     """
     path = Primitive(
         name="path",
@@ -220,92 +192,15 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(path)
-    print(f"Saved: path ({path.id})")
+    print(f"  path              D0–D3  (structural)")
     return path
-
-
-def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
-    """
-    Seed the File primitive at D0–D3.
-
-    A file is a persistent unit of data that exists within a filesystem.
-    """
-    file = Primitive(
-        name="file",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "A persistent, named unit of data stored on a filesystem and addressed by path.",
-                    "attributes": ["path", "name", "extension", "size", "content"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.REQUIRES,
-                        target_id=path.id,
-                        target_depth=DepthLevel.IDENTITY,
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Can be created, read, written, deleted, moved, copied, and renamed.",
-                    "operations": ["create", "read", "write", "delete", "move", "copy", "rename"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.DEPENDS_ON,
-                        target_id=filesystem.id,
-                        target_depth=DepthLevel.IDENTITY,
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "Operations are subject to filesystem permissions, path validity, "
-                                   "available disk space, and OS-level locking.",
-                    "constraints": [
-                        "Path must be valid for the target filesystem",
-                        "Write requires write permission on the parent directory",
-                        "Read requires read permission on the file",
-                        "Delete requires write permission on the parent directory",
-                        "File must not be locked by another process for exclusive operations",
-                    ],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.CONSTRAINED_BY,
-                        target_id=permission.id,
-                        target_depth=DepthLevel.IDENTITY,
-                        metadata={
-                            "read": "requires read permission on the file",
-                            "write": "requires write permission on the file",
-                            "execute": "requires execute permission on the file",
-                            "create": "requires write permission on the parent directory",
-                            "delete": "requires write permission on the parent directory",
-                            "provenance": "authored",
-                        },
-                    ),
-                ],
-            ),
-        ],
-    )
-    repo.save_primitive(file)
-    print(f"Saved: file ({file.id})")
-    return file
 
 
 def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     Seed the Permission primitive at D0–D3.
 
-    Permission is a general access control concept — a rule governing
-    whether an actor may perform an operation on a target. The primitive
-    itself is generic; domain-specific details (POSIX rwx, ACLs) belong
-    on the relata that connect permission to constrained entities.
+    Fully grounded structural. Depends on OS at D2.
     """
     permission = Primitive(
         name="permission",
@@ -360,81 +255,144 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(permission)
-    print(f"Saved: permission ({permission.id})")
+    print(f"  permission        D0–D3  (structural)")
     return permission
 
 
-def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+# ── Fully grounded entity (D0–D3) ─────────────────────────────────────────
+
+
+def seed_directory(
+    repo: PrimitiveRepository,
+    filesystem: Primitive,
+    path: Primitive,
+    permission: Primitive,
+) -> Primitive:
     """
-    Seed the Create primitive at D0–D3 with APPLIES_TO relata to File and Directory.
+    Seed the Directory primitive at D0–D3.
+
+    Fully grounded entity. Target for safe operations (list) and
+    destructive operations (delete, create). Deep enough (D3) to
+    satisfy any target_depth requirement from APPLIES_TO edges.
     """
-    create = Primitive(
-        name="create",
+    directory = Primitive(
+        name="directory",
         depths=[
             Depth(level=DepthLevel.EXISTENCE),
             Depth(
                 level=DepthLevel.IDENTITY,
                 properties={
-                    "description": "An operation that brings a new entity into existence where none previously existed.",
+                    "description": "A named container within a filesystem that holds files and "
+                                   "other directories, forming the hierarchical structure of "
+                                   "the filesystem's namespace.",
+                    "attributes": ["path", "name", "parent", "children"],
                 },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.REQUIRES,
+                        target_id=path.id,
+                        target_depth=DepthLevel.IDENTITY,
+                    ),
+                ],
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
                 properties={
-                    "description": "Accepts a target type, an optional destination context, and optional "
-                                   "initial state. Produces a new instance of the target type.",
-                    "inputs": ["target_type", "destination_context", "initial_state"],
-                    "outputs": ["new_entity_instance"],
+                    "description": "Can be created, deleted, listed, renamed, and traversed. "
+                                   "Serves as the scope and destination context for file operations.",
+                    "operations": ["create", "delete", "list", "rename", "traverse"],
                 },
                 relata=[
                     Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
-                        },
-                    ),
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=directory.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
-                        },
+                        relation_type=RelationType.DEPENDS_ON,
+                        target_id=filesystem.id,
+                        target_depth=DepthLevel.IDENTITY,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
                 properties={
-                    "description": "The destination context must exist and permit new entities. "
-                                   "The target type must be known. The entity must not already exist "
-                                   "at the destination unless replacement is explicitly intended.",
+                    "description": "Must have a valid path within a mounted filesystem. Deleting "
+                                   "requires the directory to be empty or deletion to be recursive. "
+                                   "The root directory cannot be deleted.",
                     "constraints": [
-                        "Destination context must exist",
-                        "Destination context must permit creation",
-                        "Target type must be known",
-                        "Entity must not already exist at destination unless replacement is explicit",
+                        "Path must be valid within the filesystem",
+                        "Parent directory must exist for creation",
+                        "Delete requires directory to be empty or explicitly recursive",
+                        "Root directory cannot be deleted",
+                        "Listing requires read permission on the directory",
+                        "Creation requires write permission on the parent directory",
                     ],
                 },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.CONSTRAINED_BY,
+                        target_id=permission.id,
+                        target_depth=DepthLevel.IDENTITY,
+                        metadata={
+                            "list": "requires read permission on the directory",
+                            "create_child": "requires write permission on the directory",
+                            "delete": "requires write permission on the parent directory",
+                            "rename": "requires write permission on both source and destination parent",
+                            "provenance": "authored",
+                        },
+                    ),
+                ],
             ),
         ],
     )
-    repo.save_primitive(create)
-    print(f"Saved: create ({create.id})")
-    return create
+    repo.save_primitive(directory)
+    print(f"  directory         D0–D3  (entity, fully grounded)")
+    return directory
+
+
+# ── Shallow entity (D0–D1) ────────────────────────────────────────────────
+
+
+def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
+    """
+    Seed the File primitive at D0–D1 only.
+
+    Deliberately shallow. When an action's APPLIES_TO targets file at
+    target_depth D2, file's contiguous max (D1) is insufficient →
+    RelationalGap.
+    """
+    file = Primitive(
+        name="file",
+        depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                properties={
+                    "description": "A persistent, named unit of data stored on a filesystem and addressed by path.",
+                    "attributes": ["path", "name", "extension", "size", "content"],
+                },
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.REQUIRES,
+                        target_id=path.id,
+                        target_depth=DepthLevel.IDENTITY,
+                    ),
+                ],
+            ),
+        ],
+    )
+    repo.save_primitive(file)
+    print(f"  file              D0–D1  (shallow → RelationalGap when targeted at D2)")
+    return file
+
+
+# ── Safe actions (D0–D2) ──────────────────────────────────────────────────
 
 
 def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     """
-    Seed the Read primitive at D0–D3.
+    Seed the Read primitive at D0–D2.
 
-    Read is the general operation of retrieving the contents or state of
-    an existing entity without modifying it. Domain-specific details
-    (partial reads, format interpretation) belong on the relata.
+    Safe action. APPLIES_TO lives at D2 (source_depth=D2), so the edge
+    is visible when read is grounded to D2. Targets file at target_depth
+    D2, but file is only at D1 → RelationalGap(read→file, req=D2, cur=D1).
     """
     read = Primitive(
         name="read",
@@ -463,196 +421,25 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                         target_depth=DepthLevel.CAPABILITIES,
                         metadata={
                             "retrieval": "returns file contents as bytes or decoded text",
-                            "partial": "supports offset and range for partial reads",
-                            "formats": ["text", "binary"],
+                            "provenance": "authored",
                         },
                     ),
                 ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The target entity must exist. The actor must have sufficient "
-                                   "permission to access it. The entity must be in a state that "
-                                   "permits reading.",
-                    "constraints": [
-                        "Target entity must exist",
-                        "Actor must have read access to the target",
-                        "Target must be in a readable state",
-                        "Read does not modify the entity",
-                    ],
-                },
             ),
         ],
     )
     repo.save_primitive(read)
-    print(f"Saved: read ({read.id})")
+    print(f"  read              D0–D2  (safe action, APPLIES_TO@D2 → file)")
     return read
-
-
-def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
-    """
-    Seed the Copy primitive at D0–D3.
-
-    Copy is the general operation of duplicating an entity into a new
-    context. Unlike move, the source entity is preserved.
-    """
-    copy = Primitive(
-        name="copy",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "An operation that duplicates an entity, producing a new "
-                                   "independent instance with identical contents. The source "
-                                   "entity is preserved unchanged.",
-                },
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Accepts a source entity and a destination context. Produces "
-                                   "a new entity at the destination with contents identical to "
-                                   "the source. The copy is independent — subsequent changes to "
-                                   "either do not affect the other.",
-                    "inputs": ["source_entity", "destination_context"],
-                    "outputs": ["new_entity_instance"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=directory.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "recursive": "copying a directory copies all of its contents",
-                        },
-                    ),
-                    Relatum(
-                        relation_type=RelationType.REQUIRES,
-                        target_id=path.id,
-                        target_depth=DepthLevel.IDENTITY,
-                        metadata={
-                            "source": "path identifies the entity to copy",
-                            "destination": "path identifies where to place the copy",
-                        },
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The source entity must exist. The destination context must "
-                                   "exist and have sufficient capacity. The actor must have read "
-                                   "access to the source and write access to the destination. "
-                                   "The entity must not already exist at the destination unless "
-                                   "replacement is explicitly intended.",
-                    "constraints": [
-                        "Source entity must exist",
-                        "Destination context must exist and have sufficient capacity",
-                        "Actor must have read access at source and write access at destination",
-                        "Entity must not exist at destination unless replacement is explicit",
-                        "Copy is non-destructive to the source",
-                    ],
-                },
-            ),
-        ],
-    )
-    repo.save_primitive(copy)
-    print(f"Saved: copy ({copy.id})")
-    return copy
-
-
-def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
-    """
-    Seed the Move primitive at D0–D3.
-
-    Move is the general operation of relocating an entity from one
-    context to another. The entity ceases to exist at the source
-    and exists at the destination.
-    """
-    move = Primitive(
-        name="move",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "An operation that relocates an entity from one context to "
-                                   "another. The entity ceases to exist at the source location "
-                                   "and exists at the destination. Content is preserved.",
-                },
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Accepts a target entity and a destination context. "
-                                   "Produces the entity at the destination and removes it "
-                                   "from the source. May also rename the entity if the "
-                                   "destination implies a new identity.",
-                    "inputs": ["target_entity", "destination_context"],
-                    "outputs": ["relocated_entity"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=directory.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "recursive": "moving a directory moves all of its contents",
-                        },
-                    ),
-                    Relatum(
-                        relation_type=RelationType.REQUIRES,
-                        target_id=path.id,
-                        target_depth=DepthLevel.IDENTITY,
-                        metadata={
-                            "source": "path identifies the entity to move",
-                            "destination": "path identifies where to move it",
-                        },
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The source entity must exist. The destination context must "
-                                   "exist and permit the entity. The actor must have sufficient "
-                                   "permission at both source and destination. The entity must "
-                                   "not already exist at the destination unless replacement is "
-                                   "explicitly intended.",
-                    "constraints": [
-                        "Source entity must exist",
-                        "Destination context must exist and permit the entity",
-                        "Actor must have access at both source and destination",
-                        "Entity must not exist at destination unless replacement is explicit",
-                        "Move across filesystem boundaries may degrade to copy-then-delete",
-                    ],
-                },
-            ),
-        ],
-    )
-    repo.save_primitive(move)
-    print(f"Saved: move ({move.id})")
-    return move
 
 
 def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
     """
-    Seed the List primitive at D0–D3.
+    Seed the List primitive at D0–D2.
 
-    List is the general operation of enumerating the contents or members
-    of a container. Domain-specific details belong on the relata.
+    Safe action. APPLIES_TO lives at D2 (source_depth=D2), targeting
+    directory at target_depth D2. Directory is grounded to D3, so
+    D3 >= D2 → clean pass, no gaps.
     """
     list_prim = Primitive(
         name="list",
@@ -683,38 +470,29 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
                         metadata={
                             "contents": "returns files and subdirectories",
                             "recursive": "may enumerate contents of subdirectories recursively",
-                            "filtering": "supports glob patterns and type filtering (files only, dirs only)",
-                            "metadata": "may include size, timestamps, permissions per entry",
+                            "provenance": "authored",
                         },
                     ),
                 ],
             ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The container entity must exist. The actor must have "
-                                   "sufficient permission to enumerate its contents. List is "
-                                   "non-destructive.",
-                    "constraints": [
-                        "Container entity must exist",
-                        "Actor must have read access to the container",
-                        "List does not modify the container or its contents",
-                    ],
-                },
-            ),
         ],
     )
     repo.save_primitive(list_prim)
-    print(f"Saved: list ({list_prim.id})")
+    print(f"  list              D0–D2  (safe action, APPLIES_TO@D2 → directory)")
     return list_prim
+
+
+# ── Destructive actions ───────────────────────────────────────────────────
 
 
 def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
     """
-    Seed the Delete primitive at D0–D3.
+    Seed the Delete primitive at D0–D2 only.
 
-    Delete is the general operation of removing an existing entity from
-    existence. It is the inverse of create.
+    Destructive action. In the fully grounded graph (seed_all), delete's
+    APPLIES_TO edges live at D3 (CONSTRAINTS). Here D3 is omitted, so
+    those edges simply don't exist — delete has no visible connection to
+    its targets → ReachabilityGap on file or directory.
     """
     delete = Primitive(
         name="delete",
@@ -737,252 +515,100 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                     "inputs": ["target_entity"],
                     "outputs": ["confirmation_of_removal"],
                 },
+                # No relata — APPLIES_TO lives at D3 in seed_all, omitted here.
+            ),
+        ],
+    )
+    repo.save_primitive(delete)
+    print(f"  delete            D0–D2  (destructive, APPLIES_TO@D3 omitted → ReachabilityGap)")
+    return delete
+
+
+def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+    """
+    Seed the Create primitive at D0–D1 + D3 (non-contiguous).
+
+    Destructive action. Has identity (D0–D1) but is missing D2
+    (CAPABILITIES). APPLIES_TO lives at D3 (source_depth=D3), but
+    contiguous max is D1 (D2 absent breaks the chain). The engine
+    gates the D3 edges → DepthGap(create, req=D3, cur=D1).
+
+    Since the APPLIES_TO edges are gated, file and directory are
+    unreachable from create → ReachabilityGap on the target.
+    """
+    create = Primitive(
+        name="create",
+        depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                properties={
+                    "description": "An operation that brings a new entity into existence where "
+                                   "none previously existed.",
+                },
+            ),
+            # D2 (CAPABILITIES) deliberately omitted — breaks contiguity.
+            # The agent knows create exists and what it is, but hasn't
+            # learned its capabilities. This gates all D3 edges.
+            Depth(
+                level=DepthLevel.CONSTRAINTS,
+                properties={},
                 relata=[
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        metadata={
+                            "default_destination": "current working directory when no path is specified",
+                            "provenance": "authored",
+                        },
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
                         metadata={
-                            "recursive": "directory deletion may require recursive removal of contents",
-                            "empty_check": "some systems require the directory to be empty first",
+                            "default_destination": "current working directory when no path is specified",
+                            "provenance": "authored",
                         },
                     ),
                 ],
             ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The target entity must exist. The actor must have sufficient "
-                                   "permission to remove it. Deletion is irreversible by default. "
-                                   "Some entities may be protected from deletion.",
-                    "constraints": [
-                        "Target entity must exist",
-                        "Actor must have delete access in the target's context",
-                        "Deletion is irreversible by default",
-                        "Some entities may be protected from deletion",
-                    ],
-                },
-            ),
         ],
     )
-    repo.save_primitive(delete)
-    print(f"Saved: delete ({delete.id})")
-    return delete
+    repo.save_primitive(create)
+    print(f"  create            D0–D1+D3  (destructive, APPLIES_TO@D3 gated — D2 missing)")
+    return create
 
 
-def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
-    """
-    Seed the Write primitive at D0–D3.
-
-    Write is the general operation of modifying the contents or state
-    of an existing entity. Domain-specific details (append vs overwrite,
-    encoding) belong on the relata.
-    """
-    write = Primitive(
-        name="write",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "An operation that modifies the contents or state of an "
-                                   "existing entity. Unlike create, the entity must already "
-                                   "exist. Unlike read, the entity is changed.",
-                },
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Accepts a target entity and new content or state. Produces "
-                                   "a modified version of the entity. Write is destructive — "
-                                   "previous state may be lost unless explicitly preserved.",
-                    "inputs": ["target_entity", "new_content_or_state"],
-                    "outputs": ["modified_entity"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.APPLIES_TO,
-                        target_id=file.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                        metadata={
-                            "modes": ["overwrite", "append", "insert_at_offset"],
-                            "encoding": "content may require encoding (utf-8, binary)",
-                            "atomicity": "write may not be atomic — partial writes are possible on failure",
-                        },
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "The target entity must exist. The actor must have sufficient "
-                                   "permission to modify it. The entity must be in a state that "
-                                   "permits modification. Previous state may be irrecoverably lost.",
-                    "constraints": [
-                        "Target entity must exist",
-                        "Actor must have write access to the target",
-                        "Target must be in a writable state",
-                        "Write is destructive — previous state may be lost",
-                    ],
-                },
-            ),
-        ],
-    )
-    repo.save_primitive(write)
-    print(f"Saved: write ({write.id})")
-    return write
-
-
-def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
-    """
-    Seed the User primitive at D0–D3.
-
-    A user is the OS-recognized principal of action — the identity against
-    which permissions are evaluated and ownership is attributed.
-    """
-    user = Primitive(
-        name="user",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "An entity recognized by the operating system as a principal of "
-                                   "action. Has a unique identity within the OS's user management "
-                                   "system. Used to attribute ownership, enforce permissions, and "
-                                   "establish the security context for running processes.",
-                    "attributes": ["identity", "uid", "home_directory", "process_context"],
-                },
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Can own files and directories, belong to groups, and run "
-                                   "processes. The OS evaluates permissions against the user's "
-                                   "identity and group memberships when operations are attempted.",
-                    "operations": ["authenticate", "own_resource", "spawn_process", "elevate"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.DEPENDS_ON,
-                        target_id=os_prim.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "User identity must be recognized by the OS. Operations are "
-                                   "constrained by permissions granted directly to the user or "
-                                   "inherited via group membership. Superuser may bypass most "
-                                   "permission constraints.",
-                    "constraints": [
-                        "A process executes under exactly one effective user identity at a time",
-                        "User identity is resolved at process creation, not re-evaluated during execution",
-                        "Privilege escalation requires an explicit OS-mediated mechanism",
-                        "One user identity is designated as superuser with elevated capabilities",
-                        "A user must exist in the OS identity store before processes can run under it",
-                    ],
-                },
-            ),
-        ],
-    )
-    repo.save_primitive(user)
-    print(f"Saved: user ({user.id})")
-    return user
-
-
-def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -> Primitive:
-    """
-    Seed the Group primitive at D0–D3.
-
-    A group is a named collection of users through which permissions are
-    inherited collectively. The OS resolves group membership when evaluating
-    access control.
-    """
-    group = Primitive(
-        name="group",
-        depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(
-                level=DepthLevel.IDENTITY,
-                properties={
-                    "description": "A named collection of users recognized by the operating system. "
-                                   "Groups aggregate permissions and ownership, allowing multiple users "
-                                   "to share access to resources under a common identity.",
-                    "attributes": ["name", "gid", "members"],
-                },
-            ),
-            Depth(
-                level=DepthLevel.CAPABILITIES,
-                properties={
-                    "description": "Can contain multiple users. Permissions granted to a group apply "
-                                   "to all its members. The OS evaluates group membership when "
-                                   "resolving access control for a user.",
-                    "operations": ["add_member", "remove_member", "resolve_members"],
-                },
-                relata=[
-                    Relatum(
-                        relation_type=RelationType.DEPENDS_ON,
-                        target_id=os_prim.id,
-                        target_depth=DepthLevel.CAPABILITIES,
-                    ),
-                    Relatum(
-                        relation_type=RelationType.INCLUDES,
-                        target_id=user.id,
-                        target_depth=DepthLevel.IDENTITY,
-                    ),
-                ],
-            ),
-            Depth(
-                level=DepthLevel.CONSTRAINTS,
-                properties={
-                    "description": "Group membership is the mechanism by which permissions are "
-                                   "inherited collectively. Membership and identity are managed "
-                                   "exclusively by the OS.",
-                    "constraints": [
-                        "A group identity must be unique within the OS's identity namespace",
-                        "A process inherits group memberships at creation; changes require a new process context",
-                        "The number of simultaneous group memberships per user is OS-bounded",
-                        "A group must exist in the OS identity store before it can be referenced",
-                        "Membership modification requires privileged access",
-                    ],
-                },
-            ),
-        ],
-    )
-    repo.save_primitive(group)
-    print(f"Saved: group ({group.id})")
-    return group
+# ── Main ──────────────────────────────────────────────────────────────────
 
 
 def main(repository: PrimitiveRepository) -> None:
     with repository as repo:
         repo.ensure_constraints()
+        deleted = clear_graph(repo)
+
+        print(f"Cleared {deleted} existing primitive(s).")
+        print("Seeding gap-demonstration graph (10 primitives):\n")
+
+        # Substrates
         os_prim = seed_operating_system(repo)
         filesystem = seed_filesystem(repo, os_prim)
         path = seed_path(repo, filesystem)
         permission = seed_permission(repo, os_prim)
+
+        # Entities
         directory = seed_directory(repo, filesystem, path, permission)
-        file = seed_file(repo, filesystem, path, permission)
-        create = seed_create(repo, file, directory)
+        file = seed_file(repo, path)
+
+        # Actions
         read = seed_read(repo, file)
-        write = seed_write(repo, file)
-        delete = seed_delete(repo, file, directory)
         list_prim = seed_list(repo, directory)
-        move = seed_move(repo, file, directory, path)
-        copy = seed_copy(repo, file, directory, path)
-        user = seed_user(repo, os_prim)
-        group = seed_group(repo, os_prim, user)
+        delete = seed_delete(repo, file, directory)
+        create = seed_create(repo, file, directory)
 
         # Add INCLUDES relata to filesystem now that file and directory exist.
-        # Filesystem's D2 (CAPABILITIES) includes these entities at D0 (EXISTENCE).
         fs_caps = next(d for d in filesystem.depths if d.level == DepthLevel.CAPABILITIES)
         fs_caps.relata.extend([
             Relatum(
@@ -997,164 +623,23 @@ def main(repository: PrimitiveRepository) -> None:
             ),
         ])
         repo.save_primitive(filesystem)
-        print(f"Updated: filesystem with INCLUDES relata")
+        print(f"\n  Updated: filesystem with INCLUDES → file, directory")
 
-        # Add APPLIES_TO relata to permission now that user, group, and action
-        # primitives exist. Permission's D2 (CAPABILITIES) applies to actor types
-        # at D1 (IDENTITY) and to action types at D2 (CAPABILITIES) — permission
-        # governs what actions an actor is allowed to perform.
-        perm_caps = next(d for d in permission.depths if d.level == DepthLevel.CAPABILITIES)
-        perm_caps.relata.extend([
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=user.id,
-                target_depth=DepthLevel.IDENTITY,
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=group.id,
-                target_depth=DepthLevel.IDENTITY,
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=read.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may perform a read operation",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=write.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may perform a write operation",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=delete.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may perform a delete operation",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=create.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may perform a create operation",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=list_prim.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may enumerate the contents of a directory",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=move.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may relocate an entity across contexts",
-                    "provenance": "authored",
-                },
-            ),
-            Relatum(
-                relation_type=RelationType.APPLIES_TO,
-                target_id=copy.id,
-                target_depth=DepthLevel.CAPABILITIES,
-                metadata={
-                    "description": "Permission governs whether an actor may duplicate an entity into a new context",
-                    "provenance": "authored",
-                },
-            ),
-        ])
-        repo.save_primitive(permission)
-        print(f"Updated: permission with APPLIES_TO relata")
+        print("""
+Done. Seeded 10 primitives.
 
-        # Add CONSTRAINED_BY relata to action primitives at D3 (CONSTRAINTS).
-        # read, write, delete, and create all state permission constraints in
-        # prose but have no relatum backing them — this closes that gap.
-        for action_prim in (read, write, delete, create):
-            action_constraints = next(d for d in action_prim.depths if d.level == DepthLevel.CONSTRAINTS)
-            action_constraints.relata.append(
-                Relatum(
-                    relation_type=RelationType.CONSTRAINED_BY,
-                    target_id=permission.id,
-                    target_depth=DepthLevel.IDENTITY,
-                    metadata={
-                        "description": f"The {action_prim.name} action requires the actor to hold the corresponding permission on the target",
-                        "provenance": "authored",
-                    },
-                )
-            )
-            repo.save_primitive(action_prim)
-        print(f"Updated: read, write, delete, create with CONSTRAINED_BY permission at D3")
-
-        list_constraints = next(d for d in list_prim.depths if d.level == DepthLevel.CONSTRAINTS)
-        list_constraints.relata.append(
-            Relatum(
-                relation_type=RelationType.CONSTRAINED_BY,
-                target_id=permission.id,
-                target_depth=DepthLevel.IDENTITY,
-                metadata={
-                    "description": "The list action requires read permission on the target directory to enumerate its contents",
-                    "provenance": "authored",
-                },
-            )
-        )
-        repo.save_primitive(list_prim)
-        print(f"Updated: list with CONSTRAINED_BY permission at D3")
-
-        move_constraints = next(d for d in move.depths if d.level == DepthLevel.CONSTRAINTS)
-        move_constraints.relata.append(
-            Relatum(
-                relation_type=RelationType.CONSTRAINED_BY,
-                target_id=permission.id,
-                target_depth=DepthLevel.IDENTITY,
-                metadata={
-                    "description": "The move action requires write permission on both source and destination contexts — the source must permit removal and the destination must permit creation",
-                    "source_permission": "write (delete-equivalent) on the source context",
-                    "destination_permission": "write (create-equivalent) on the destination context",
-                    "provenance": "authored",
-                },
-            )
-        )
-        repo.save_primitive(move)
-        print(f"Updated: move with CONSTRAINED_BY permission at D3")
-
-        copy_constraints = next(d for d in copy.depths if d.level == DepthLevel.CONSTRAINTS)
-        copy_constraints.relata.append(
-            Relatum(
-                relation_type=RelationType.CONSTRAINED_BY,
-                target_id=permission.id,
-                target_depth=DepthLevel.IDENTITY,
-                metadata={
-                    "description": "The copy action requires read permission on the source and write permission on the destination context",
-                    "source_permission": "read on the source entity",
-                    "destination_permission": "write (create-equivalent) on the destination context",
-                    "provenance": "authored",
-                },
-            )
-        )
-        repo.save_primitive(copy)
-        print(f"Updated: copy with CONSTRAINED_BY permission at D3")
-
-        print("\nDone. Seeded 16 primitives.")
+Expected gap scenarios:
+  ["list", "directory"]    → clean pass
+  ["read", "file"]         → RelationalGap (file too shallow)
+  ["delete", "file"]       → ReachabilityGap (APPLIES_TO@D3 omitted)
+  ["delete", "directory"]  → ReachabilityGap (APPLIES_TO@D3 omitted)
+  ["create", "file"]       → DepthGap + ReachabilityGap (edge gated)
+  ["create", "directory"]  → DepthGap + ReachabilityGap (edge gated)
+""")
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Depth and Relational Gap Seeder")
+    parser = argparse.ArgumentParser(description="Depth-Gated Gap Demonstration Seeder")
     parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
     parser.add_argument("--neo4j-user", default="neo4j")
     parser.add_argument("--neo4j-password", default="password")

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -17,6 +17,7 @@ Usage::
 
 from vre.core.graph import PrimitiveRepository
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
+from vre.core.models import DepthLevel
 from vre.core.policy import Cardinality, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
@@ -43,14 +44,24 @@ class VRE:
         """
         return self._resolver.resolve(concepts)
 
-    def check(self, concepts: list[str]) -> GroundingResult:
+    def check(
+        self,
+        concepts: list[str],
+        min_depth: DepthLevel | None = None,
+    ) -> GroundingResult:
         """
-        Ground concepts at D3 (CONSTRAINTS).
+        Ground concepts with graph-derived depth gating.
 
         Returns a GroundingResult with grounded=True only when all resolved
         concepts are fully grounded with no gaps.
+
+        Parameters
+        ----------
+        min_depth:
+            Optional integrator override — enforces a minimum depth floor
+            on all root primitives. Can only raise the floor, never lower it.
         """
-        return self._engine.ground(concepts, self._resolver)
+        return self._engine.ground(concepts, self._resolver, min_depth=min_depth)
 
     def check_policy(
         self,

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -5,9 +5,13 @@
 Grounding engine for the Volute Reasoning Engine.
 
 Provides GroundingEngine — the single entry point for structured epistemic
-queries. Always checks at DepthLevel.CONSTRAINTS (D3). The agent submits
-concept names; the engine delegates recursive traversal to the repository
-(Cypher), then applies depth gating, gap detection, and closure filtering.
+queries. Depth requirements are derived from graph structure: edges carry
+source_depth indicating the depth level they live at on the source node.
+The engine partitions edges into visible (source grounded deeply enough)
+and gated (source too shallow), producing DepthGaps for the latter.
+
+An optional min_depth parameter provides integrators a secondary safety
+lever to enforce a stricter floor than the graph alone would require.
 """
 
 from __future__ import annotations
@@ -31,9 +35,6 @@ from vre.core.models import (
     RelationalGap,
 )
 
-_REQUIRED_DEPTH = DepthLevel.CONSTRAINTS
-
-
 def _empty_response() -> EpistemicResponse:
     """
     Helper for the empty query case — returns a valid but empty response with no
@@ -47,11 +48,11 @@ def _empty_response() -> EpistemicResponse:
 
 class GroundingEngine:
     """
-    Structured epistemic query resolution at D3 (CONSTRAINTS).
+    Structured epistemic query resolution with graph-derived depth gating.
 
     Stateless between calls. Accepts concept names, delegates graph
-    traversal to the repository, and returns a fully closed epistemic
-    response.
+    traversal to the repository, partitions edges by source depth
+    visibility, and returns a fully closed epistemic response.
     """
 
     def __init__(self, repository: PrimitiveRepository) -> None:
@@ -101,11 +102,38 @@ class GroundingEngine:
         return result
 
     @staticmethod
+    def _partition_edges_by_source_depth(
+        edges: list[EpistemicStep],
+        id_to_prim: dict[UUID, Primitive],
+    ) -> tuple[list[EpistemicStep], list[EpistemicStep]]:
+        """
+        Split edges into visible and gated based on source node grounding.
+
+        An edge is visible when the source node's contiguous max depth >= the
+        edge's source_depth. Otherwise, the edge is gated — the source isn't
+        grounded deeply enough to see the relationship.
+        """
+        visible: list[EpistemicStep] = []
+        gated: list[EpistemicStep] = []
+        for edge in edges:
+            src = id_to_prim.get(edge.source_id)
+            if src is None:
+                continue
+            src_contiguous = GroundingEngine._contiguous_max_depth(src)
+            if src_contiguous is not None and src_contiguous >= edge.source_depth:
+                visible.append(edge)
+            else:
+                gated.append(edge)
+        return visible, gated
+
+    @staticmethod
     def _detect_gaps(
         all_nodes: list[Primitive],
-        edges: list[EpistemicStep],
+        visible_edges: list[EpistemicStep],
+        gated_edges: list[EpistemicStep],
         root_ids: set[UUID],
         transient_ids: set[UUID],
+        min_depth: DepthLevel | None = None,
     ) -> list[DepthGap | ExistenceGap | RelationalGap]:
         """
         Detect existence, depth, and relational gaps across the resolved subgraph.
@@ -118,21 +146,45 @@ class GroundingEngine:
             if node.id in transient_ids:
                 gaps.append(ExistenceGap(primitive=node))
 
-        # Phase 2 — Depth gaps (roots only, always checked at D3)
-        for node in all_nodes:
-            if node.id in transient_ids or node.id not in root_ids:
+        # Phase 2 — Depth gaps from two sources:
+        #   (a) gated edges: source can't see the edge
+        #   (b) min_depth override: integrator safety lever
+        # Deduplicate per-primitive, keeping the higher required_depth.
+        depth_gap_map: dict[UUID, tuple[DepthLevel, DepthLevel | None]] = {}
+
+        # (a) Gated edges → DepthGap on source primitive
+        for edge in gated_edges:
+            src = id_to_prim.get(edge.source_id)
+            if src is None or src.id in transient_ids:
                 continue
-            contiguous = GroundingEngine._contiguous_max_depth(node)
-            if contiguous is None or contiguous < _REQUIRED_DEPTH:
+            src_contiguous = GroundingEngine._contiguous_max_depth(src)
+            existing = depth_gap_map.get(src.id)
+            if existing is None or edge.source_depth > existing[0]:
+                depth_gap_map[src.id] = (edge.source_depth, src_contiguous)
+
+        # (b) min_depth override on roots
+        if min_depth is not None:
+            for node in all_nodes:
+                if node.id in transient_ids or node.id not in root_ids:
+                    continue
+                contiguous = GroundingEngine._contiguous_max_depth(node)
+                if contiguous is None or contiguous < min_depth:
+                    existing = depth_gap_map.get(node.id)
+                    if existing is None or min_depth > existing[0]:
+                        depth_gap_map[node.id] = (min_depth, contiguous)
+
+        for nid, (req, curr) in depth_gap_map.items():
+            prim = id_to_prim.get(nid)
+            if prim is not None:
                 gaps.append(DepthGap(
-                    primitive=node,
-                    required_depth=_REQUIRED_DEPTH,
-                    current_depth=contiguous,
+                    primitive=prim,
+                    required_depth=req,
+                    current_depth=curr,
                 ))
 
-        # Phase 3 — Relatum-depth relational gaps
+        # Phase 3 — Relatum-depth relational gaps (visible edges only)
         relatum_depth_pairs: dict[tuple[UUID, UUID], DepthLevel] = {}
-        for edge in edges:
+        for edge in visible_edges:
             if edge.target_id in transient_ids:
                 continue
             tgt_prim = id_to_prim.get(edge.target_id)
@@ -193,13 +245,27 @@ class GroundingEngine:
             for p in all_nodes
         ]
 
-    def query(self, concepts: list[str]) -> EpistemicResponse:
+    def query(
+        self,
+        concepts: list[str],
+        min_depth: DepthLevel | None = None,
+    ) -> EpistemicResponse:
         """
-        Flat-concept epistemic query at D3 (CONSTRAINTS).
+        Flat-concept epistemic query with graph-derived depth gating.
 
         All submitted concepts are treated symmetrically. Resolves the
-        subgraph for all concepts, then checks that every non-transient
-        concept is in the same connected component (undirected BFS).
+        subgraph for all concepts, partitions edges by source depth
+        visibility, then checks that every non-transient concept is in
+        the same connected component (undirected BFS over visible edges).
+
+        Parameters
+        ----------
+        concepts:
+            Canonical concept names to query.
+        min_depth:
+            Optional integrator override — enforces a minimum depth floor
+            on all root primitives. Can only raise the floor, never lower
+            it below what the graph structure requires.
         """
         if not concepts:
             return _empty_response()
@@ -211,15 +277,22 @@ class GroundingEngine:
         root_ids = {r.id for r in roots}
         all_nodes = list(subgraph.nodes) + transients
 
+        id_to_prim = {n.id: n for n in all_nodes}
+        visible_edges, gated_edges = self._partition_edges_by_source_depth(
+            subgraph.edges, id_to_prim,
+        )
+
         gaps: list = self._detect_gaps(
-            all_nodes, subgraph.edges, root_ids, transient_ids,
+            all_nodes, visible_edges, gated_edges, root_ids, transient_ids,
+            min_depth=min_depth,
         )
 
         # Undirected connectivity check across all non-transient roots
+        # using only visible edges
         non_transient_roots = [r for r in roots if r.id not in transient_ids]
         if len(non_transient_roots) > 1:
             neighbors: dict[UUID, set[UUID]] = {}
-            for edge in subgraph.edges:
+            for edge in visible_edges:
                 neighbors.setdefault(edge.source_id, set()).add(edge.target_id)
                 neighbors.setdefault(edge.target_id, set()).add(edge.source_id)
             anchor = non_transient_roots[0]
@@ -232,13 +305,14 @@ class GroundingEngine:
 
         return EpistemicResponse(
             query=EpistemicQuery(concept_ids=[r.id for r in roots]),
-            result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=subgraph.edges),
+            result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=visible_edges),
         )
 
     def ground(
         self,
         concepts: list[str],
         resolver: ConceptResolver,
+        min_depth: DepthLevel | None = None,
     ) -> GroundingResult:
         """
         Resolve and ground concepts in one step.
@@ -246,7 +320,7 @@ class GroundingEngine:
         Each concept is resolved to its canonical name where possible;
         unknown concepts pass through as-is and become ExistenceGaps in the
         query result. Returns a GroundingResult with grounded=True only when
-        all concepts are grounded at D3 with no gaps.
+        all concepts are grounded with no gaps.
         """
         if not concepts:
             return GroundingResult(grounded=False, resolved=[], gaps=[], trace=None)
@@ -259,7 +333,7 @@ class GroundingEngine:
             for c in concepts
         ]
 
-        response = self.query(canonical)
+        response = self.query(canonical, min_depth=min_depth)
         grounded = len(response.result.gaps) == 0
         return GroundingResult(
             grounded=grounded,

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import functools
 from typing import TYPE_CHECKING, Callable
 
+from vre.core.models import DepthLevel
 from vre.core.policy import PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 
@@ -48,6 +49,7 @@ def vre_guard(
     vre: "VRE",
     concepts: ConceptsInput,
     cardinality: CardinalityInput = None,
+    min_depth: DepthLevel | None = None,
     on_trace: Callable[["GroundingResult"], None] | None = None,
     on_policy: Callable[[str], bool] | None = None,
 ) -> Callable:
@@ -65,6 +67,9 @@ def vre_guard(
         Optional cardinality hint for policy evaluation ("single", "multiple").
         Accepts a static string or a callable that receives (*args, **kwargs)
         and returns str | None.
+    min_depth:
+        Optional integrator override — enforces a minimum depth floor on all
+        root primitives. Can only raise the floor, never lower it.
     on_trace:
         Optional callback called with the GroundingResult after grounding
         (both grounded and ungrounded).
@@ -84,7 +89,7 @@ def vre_guard(
             Run grounding → policy → execution on each call.
             """
             resolved_concepts = concepts(*args, **kwargs) if callable(concepts) else concepts
-            grounding = vre.check(resolved_concepts)
+            grounding = vre.check(resolved_concepts, min_depth=min_depth)
             if on_trace:
                 on_trace(grounding)
 

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -326,12 +326,12 @@ class TestFlatQuery:
         assert len(reachability_gaps) == 1
         assert reachability_gaps[0].primitive.name == "network"
 
-    def test_connected_concept_with_depth_gap(self) -> None:
-        """Concept connected but insufficient depth → DepthGap, no ReachabilityGap."""
+    def test_connected_concept_with_relational_gap(self) -> None:
+        """Concept connected but target too shallow → RelationalGap, no ReachabilityGap."""
         file_p = _make_primitive("file", [
             _depth(DepthLevel.EXISTENCE),
             _depth(DepthLevel.IDENTITY),
-            # Missing CAPABILITIES and CONSTRAINTS — always requires D3
+            # Missing CAPABILITIES and CONSTRAINTS
         ])
         create_p = _make_primitive("create", [
             _depth(DepthLevel.EXISTENCE),
@@ -345,8 +345,11 @@ class TestFlatQuery:
 
         resp = engine.query(["create", "file"])
 
-        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
-        assert any(g.primitive.name == "file" for g in depth_gaps)
+        # Edge is visible (create at D3 >= source_depth D2). Target file at D1 < D3 → RelationalGap.
+        relational = [g for g in resp.result.gaps if g.kind == "RELATIONAL"]
+        assert len(relational) == 1
+        assert relational[0].target.name == "file"
+        assert relational[0].required_depth == DepthLevel.CONSTRAINTS
         reachability_gaps = [g for g in resp.result.gaps if g.kind == "REACHABILITY"]
         assert len(reachability_gaps) == 0
 
@@ -372,17 +375,41 @@ class TestFlatQuery:
 
 class TestMonotonicDepth:
 
-    def test_missing_intermediate_depth_is_a_gap(self) -> None:
-        """D0 + D3 present but D1/D2 missing → DepthGap with current_depth=D0."""
+    def test_missing_intermediate_depth_produces_depth_gap_via_gated_edge(self) -> None:
+        """D0 + D3 present but D1/D2 missing → edge at D2 is gated → DepthGap."""
+        target = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        # create has D0 and D3, but D1/D2 absent → contiguous max = D0.
+        # Edge lives at D2 (CAPABILITIES) so it's gated.
         p = _make_primitive("create", [
             _depth(DepthLevel.EXISTENCE),
-            _depth(DepthLevel.CONSTRAINTS),   # D1 and D2 absent
+            _depth(DepthLevel.CAPABILITIES, [
+                _relatum(target.id, RelationType.APPLIES_TO, DepthLevel.CAPABILITIES),
+            ]),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        engine = GroundingEngine(StubRepository([p, target]))
+        resp = engine.query(["create", "file"])
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].primitive.name == "create"
+        assert depth_gaps[0].required_depth == DepthLevel.CAPABILITIES
+        assert depth_gaps[0].current_depth == DepthLevel.EXISTENCE
+
+    def test_no_edges_no_depth_gap_without_min_depth(self) -> None:
+        """Root with no edges → no DepthGap (graph structure determines requirements)."""
+        p = _make_primitive("create", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.CONSTRAINTS),   # D1 and D2 absent, but no edges
         ])
         engine = GroundingEngine(StubRepository([p]))
         resp = engine.query(["create"])
         depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
-        assert len(depth_gaps) == 1
-        assert depth_gaps[0].current_depth == DepthLevel.EXISTENCE
+        assert len(depth_gaps) == 0
 
     def test_contiguous_depths_pass_grounding(self) -> None:
         """D0 through D3 all present → no gaps."""
@@ -438,3 +465,172 @@ class TestMonotonicDepth:
         resp = engine.query(["directory"])
         primitive_names = {p.name for p in resp.result.primitives}
         assert "permission" in primitive_names
+
+
+# ---------------------------------------------------------------------------
+# Tests: source depth gating
+# ---------------------------------------------------------------------------
+
+
+class TestSourceDepthGating:
+    """Graph-structural depth enforcement via edge source_depth."""
+
+    @staticmethod
+    def _gated_delete_and_file():
+        """
+        Shared fixture: delete has D0+D1 (contiguous max = D1) with a
+        relatum at D3 pointing to file. The D2 gap breaks contiguity,
+        so the D3 edge is gated.
+        """
+        file_p = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        delete_p = _make_primitive("delete", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CONSTRAINTS, [
+                _relatum(file_p.id, RelationType.APPLIES_TO, DepthLevel.CAPABILITIES),
+            ]),
+        ])
+        return delete_p, file_p
+
+    def test_edge_at_d3_gated_when_source_at_d1(self) -> None:
+        """
+        Edge at D3 on source, source contiguous to D1 → DepthGap + ReachabilityGap.
+        """
+        delete_p, file_p = self._gated_delete_and_file()
+        engine = GroundingEngine(StubRepository([delete_p, file_p]))
+
+        resp = engine.query(["delete", "file"])
+
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].primitive.name == "delete"
+        assert depth_gaps[0].required_depth == DepthLevel.CONSTRAINTS
+        assert depth_gaps[0].current_depth == DepthLevel.IDENTITY
+        # Gated edge excluded from connectivity → roots are disconnected
+        reachability_gaps = [g for g in resp.result.gaps if g.kind == "REACHABILITY"]
+        assert len(reachability_gaps) == 1
+
+    def test_edge_at_d2_visible_when_source_at_d2(self) -> None:
+        """
+        Edge at D2, source contiguous to D2 → visible, no gaps.
+        """
+        file_p = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        read_p = _make_primitive("read", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES, [
+                _relatum(file_p.id, RelationType.APPLIES_TO, DepthLevel.CAPABILITIES),
+            ]),
+        ])
+        engine = GroundingEngine(StubRepository([read_p, file_p]))
+
+        resp = engine.query(["read", "file"])
+
+        assert len(resp.result.gaps) == 0
+
+    def test_visible_edge_with_shallow_target_produces_relational_gap(self) -> None:
+        """
+        Source sees the edge, but target too shallow → RelationalGap.
+        """
+        file_p = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+        ])
+        create_p = _make_primitive("create", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES, [
+                _relatum(file_p.id, RelationType.APPLIES_TO, DepthLevel.CAPABILITIES),
+            ]),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        engine = GroundingEngine(StubRepository([create_p, file_p]))
+
+        resp = engine.query(["create", "file"])
+
+        relational = [g for g in resp.result.gaps if g.kind == "RELATIONAL"]
+        assert len(relational) == 1
+        assert relational[0].source.name == "create"
+        assert relational[0].target.name == "file"
+        assert relational[0].required_depth == DepthLevel.CAPABILITIES
+        assert relational[0].current_depth == DepthLevel.IDENTITY
+
+    def test_min_depth_produces_depth_gap_on_shallow_root(self) -> None:
+        """
+        min_depth=D3 on a root at D2 → DepthGap even without gated edges.
+        """
+        read_p = _make_primitive("read", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        engine = GroundingEngine(StubRepository([read_p]))
+
+        resp = engine.query(["read"], min_depth=DepthLevel.CONSTRAINTS)
+
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].primitive.name == "read"
+        assert depth_gaps[0].required_depth == DepthLevel.CONSTRAINTS
+        assert depth_gaps[0].current_depth == DepthLevel.CAPABILITIES
+
+    def test_default_min_depth_no_gap_without_gated_edges(self) -> None:
+        """
+        No min_depth and no gated edges → no DepthGap.
+        """
+        read_p = _make_primitive("read", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        engine = GroundingEngine(StubRepository([read_p]))
+
+        resp = engine.query(["read"])
+
+        assert len(resp.result.gaps) == 0
+
+    def test_gated_only_edges_produce_reachability_gap(self) -> None:
+        """
+        Two roots connected only by gated edges → ReachabilityGap.
+        """
+        delete_p, file_p = self._gated_delete_and_file()
+        engine = GroundingEngine(StubRepository([delete_p, file_p]))
+
+        resp = engine.query(["delete", "file"])
+
+        reachability_gaps = [g for g in resp.result.gaps if g.kind == "REACHABILITY"]
+        assert len(reachability_gaps) == 1
+
+    def test_min_depth_cannot_lower_gated_edge_requirement(self) -> None:
+        """
+        min_depth=D2 does NOT suppress a DepthGap from a gated edge at D3.
+        """
+        delete_p, file_p = self._gated_delete_and_file()
+        engine = GroundingEngine(StubRepository([delete_p, file_p]))
+
+        resp = engine.query(["delete", "file"], min_depth=DepthLevel.CAPABILITIES)
+
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].primitive.name == "delete"
+        assert depth_gaps[0].required_depth == DepthLevel.CONSTRAINTS  # D3, not D2
+
+    def test_gated_edges_excluded_from_pathway(self) -> None:
+        """
+        Gated edges do not appear in the response pathway.
+        """
+        delete_p, file_p = self._gated_delete_and_file()
+        engine = GroundingEngine(StubRepository([delete_p, file_p]))
+
+        resp = engine.query(["delete", "file"])
+
+        assert len(resp.result.pathway) == 0

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -263,11 +263,13 @@ def test_vre_guard_callable_concepts_result_is_grounded():
         return "executed"
 
     my_fn("logs/")
-    mock_vre.check.assert_called_once_with(["directory"])
+    mock_vre.check.assert_called_once_with(["directory"], min_depth=None)
 
 
 def test_vre_guard_callable_concepts_stored_on_attribute():
-    """_vre_concepts stores the callable itself for introspection."""
+    """
+    _vre_concepts stores the callable itself for introspection.
+    """
     from vre.guard import vre_guard
 
     fn = lambda: ["file"]
@@ -283,7 +285,9 @@ def test_vre_guard_callable_concepts_stored_on_attribute():
 # ── callable cardinality ──────────────────────────────────────────────────────
 
 def test_vre_guard_callable_cardinality_evaluated_on_call():
-    """When cardinality is callable, it is evaluated on the single-phase call."""
+    """
+    When cardinality is callable, it is evaluated on the single-phase call.
+    """
     from vre.guard import vre_guard
 
     received = []
@@ -338,3 +342,36 @@ def test_vre_guard_callable_cardinality_passed_to_check_policy():
     assert call_args[1] == "multiple"  # second positional arg is cardinality
 
 
+# ── min_depth passthrough ────────────────────────────────────────────────────
+
+def test_vre_guard_min_depth_passed_to_check():
+    """
+    min_depth parameter is forwarded to vre.check().
+    """
+    from vre.guard import vre_guard
+    from vre.core.models import DepthLevel
+
+    mock_vre = _mock_vre(_grounding())
+
+    @vre_guard(mock_vre, concepts=["file"], min_depth=DepthLevel.CONSTRAINTS)
+    def my_fn():
+        return "executed"
+
+    my_fn()
+    mock_vre.check.assert_called_once_with(["file"], min_depth=DepthLevel.CONSTRAINTS)
+
+
+def test_vre_guard_no_min_depth_passes_none():
+    """
+    Without min_depth, vre.check() is called with min_depth=None.
+    """
+    from vre.guard import vre_guard
+
+    mock_vre = _mock_vre(_grounding())
+
+    @vre_guard(mock_vre, concepts=["file"])
+    def my_fn():
+        return "executed"
+
+    my_fn()
+    mock_vre.check.assert_called_once_with(["file"], min_depth=None)

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -172,7 +172,27 @@ class TestVRECheck:
         result = vre.resolve(["file"])
         assert isinstance(result, list)
 
+    def test_check_min_depth_passthrough(self):
+        """
+        min_depth is forwarded through VRE.check to the engine.
+        """
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+        # file is at D3 — min_depth=D3 should still pass
+        result = vre.check(["file"], min_depth=DepthLevel.CONSTRAINTS)
+        assert result.grounded is True
+        # min_depth=D4 should produce DepthGap
+        result = vre.check(["file"], min_depth=DepthLevel.IMPLICATIONS)
+        assert result.grounded is False
+        depth_gaps = [g for g in result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].required_depth == DepthLevel.IMPLICATIONS
+
     def test_check_policy_returns_policy_result(self):
+        """
+        VRE.check_policy returns a PolicyResult with action PASS, PENDING, or BLOCK.
+        :return:
+        """
         file_p = _make_fully_grounded("file")
         vre = _make_vre_with_stub([file_p])
         result = vre.check_policy(["file"])


### PR DESCRIPTION
## Summary
- Replace hardcoded D3 grounding with graph-derived depth gating — edges carry `source_depth` that gates visibility based on the source node's contiguous grounding, and `target_depth` that gates resolution based on the target's grounding
- Add optional `min_depth` parameter to `GroundingEngine.query()`, `GroundingEngine.ground()`, `VRE.check()`, and `vre_guard` as a secondary integrator safety lever
- Rewrite `seed_gaps.py` to demonstrate the full gap taxonomy (ExistenceGap, DepthGap, RelationalGap, ReachabilityGap) through deliberately shaped primitives
- Add `clear_graph.py` utility script, called by both seed scripts to ensure a clean slate
- Add `BulkFileDeletePolicy` to `seed_all.py` on delete→file APPLIES_TO relatum (triggers on `Cardinality.MULTIPLE`)
- Add `scripts/README.md` documenting all scripts with the full primitives table and expected gap scenarios
- Update root README to remove all claims of absolute D3 grounding, reflecting the new graph-structural enforcement paradigm
- Fix primitive count in `seed_all.py` (15, not 16)

## Test plan
- [x] All 120 existing tests pass (StubRepository-based, no Neo4j dependency)
- [x] New engine tests cover `_contiguous_max_depth`, `_partition_edges_by_source_depth`, `min_depth` override, and gated-edge DepthGap detection
- [x] New guard tests verify `min_depth` passthrough from decorator to engine
- [x] New VRE API test verifies `min_depth` passthrough from `VRE.check()` to engine
- [ ] Manual verification: seed both graphs against a live Neo4j instance and query expected gap scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)