### PR TITLE
feat: provenance as first-class attribute

### DIFF
--- a/scripts/seed_all.py
+++ b/scripts/seed_all.py
@@ -7,8 +7,10 @@ import argparse
 
 from scripts.clear_graph import clear_graph
 from vre.core.graph import PrimitiveRepository
-from vre.core.models import Depth, DepthLevel, Primitive, Relatum, RelationType
+from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 from vre.core.policy.models import Cardinality, Policy
+
+SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
@@ -21,10 +23,12 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
     """
     os_prim = Primitive(
         name="operating_system",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The software layer that manages hardware resources and provides "
                                    "services to applications. Mediates all access to storage, memory, "
@@ -34,6 +38,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Provides filesystems, process management, user/group identity, "
                                    "permission enforcement, environment variables, and inter-process "
@@ -49,6 +54,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Behavior varies across OS families (POSIX vs Windows). Resource "
                                    "limits, security policies, and kernel capabilities bound what is "
@@ -77,10 +83,12 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     filesystem = Primitive(
         name="filesystem",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A hierarchical system for organizing, storing, and retrieving "
                                    "persistent data. Provides the namespace (paths) and structure "
@@ -90,6 +98,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Organizes data into files and directories via a path-based "
                                    "hierarchy. Supports mounting, traversal, and metadata tracking "
@@ -106,11 +115,13 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Filesystem type determines supported features (max path length, "
                                    "case sensitivity, symlinks, permissions model). Must be mounted "
@@ -140,10 +151,12 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
     """
     directory = Primitive(
         name="directory",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A named container within a filesystem that holds files and "
                                    "other directories, forming the hierarchical structure of "
@@ -155,11 +168,13 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be created, deleted, listed, renamed, and traversed. "
                                    "Serves as the scope and destination context for file operations.",
@@ -170,11 +185,13 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=filesystem.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Must have a valid path within a mounted filesystem. Deleting "
                                    "requires the directory to be empty or deletion to be recursive. "
@@ -193,12 +210,12 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
                         relation_type=RelationType.CONSTRAINED_BY,
                         target_id=permission.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "list": "requires read permission on the directory",
                             "create_child": "requires write permission on the directory",
                             "delete": "requires write permission on the parent directory",
                             "rename": "requires write permission on both source and destination parent",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -220,10 +237,12 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
     """
     path = Primitive(
         name="path",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A string that uniquely addresses a location within a "
                                    "filesystem's hierarchy. Composed of segments separated "
@@ -234,6 +253,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be resolved to a filesystem entity, joined with other "
                                    "paths, normalized, and decomposed into parent and basename. "
@@ -245,11 +265,13 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=filesystem.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Maximum length and valid characters are filesystem-dependent. "
                                    "Delimiter is OS-dependent (/ vs \\). Resolution may fail if "
@@ -279,10 +301,12 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
     """
     file = Primitive(
         name="file",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A persistent, named unit of data stored on a filesystem and addressed by path.",
                     "attributes": ["path", "name", "extension", "size", "content"],
@@ -292,11 +316,13 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be created, read, written, deleted, moved, copied, and renamed.",
                     "operations": ["create", "read", "write", "delete", "move", "copy", "rename"],
@@ -306,11 +332,13 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=filesystem.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Operations are subject to filesystem permissions, path validity, "
                                    "available disk space, and OS-level locking.",
@@ -327,13 +355,13 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
                         relation_type=RelationType.CONSTRAINED_BY,
                         target_id=permission.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "read": "requires read permission on the file",
                             "write": "requires write permission on the file",
                             "execute": "requires execute permission on the file",
                             "create": "requires write permission on the parent directory",
                             "delete": "requires write permission on the parent directory",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -356,10 +384,12 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     permission = Primitive(
         name="permission",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A rule that governs whether an actor is allowed to perform "
                                    "a specific operation on a specific target. Expressed as a "
@@ -370,6 +400,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be checked, granted, revoked, and inherited. Multiple "
                                    "permission models exist; the specific model is determined "
@@ -381,6 +412,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "enforcement": "kernel-level",
                             "models": ["posix_rwx", "acl", "capabilities"],
@@ -390,6 +422,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Only the granting authority can modify permissions. "
                                    "Inherited permissions may be overridden by explicit grants. "
@@ -417,16 +450,19 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     """
     create = Primitive(
         name="create",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that brings a new entity into existence where none previously existed.",
                 },
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target type, an optional destination context, and optional "
                                    "initial state. Produces a new instance of the target type.",
@@ -436,6 +472,7 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The destination context must exist and permit new entities. "
                                    "The target type must be known. The entity must not already exist "
@@ -452,18 +489,18 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
                         },
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -485,10 +522,12 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     """
     read = Primitive(
         name="read",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that retrieves the contents or state of an "
                                    "existing entity without modifying it.",
@@ -496,6 +535,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and returns its contents or state. "
                                    "Read is inherently non-destructive — the target is unchanged "
@@ -508,6 +548,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "retrieval": "returns file contents as bytes or decoded text",
                             "partial": "supports offset and range for partial reads",
@@ -518,6 +559,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The target entity must exist. The actor must have sufficient "
                                    "permission to access it. The entity must be in a state that "
@@ -546,10 +588,12 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
     """
     copy = Primitive(
         name="copy",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that duplicates an entity, producing a new "
                                    "independent instance with identical contents. The source "
@@ -558,6 +602,7 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a source entity and a destination context. Produces "
                                    "a new entity at the destination with contents identical to "
@@ -571,11 +616,13 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "recursive": "copying a directory copies all of its contents",
                         },
@@ -584,6 +631,7 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "source": "path identifies the entity to copy",
                             "destination": "path identifies where to place the copy",
@@ -593,6 +641,7 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The source entity must exist. The destination context must "
                                    "exist and have sufficient capacity. The actor must have read "
@@ -625,10 +674,12 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
     """
     move = Primitive(
         name="move",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that relocates an entity from one context to "
                                    "another. The entity ceases to exist at the source location "
@@ -637,6 +688,7 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and a destination context. "
                                    "Produces the entity at the destination and removes it "
@@ -650,6 +702,7 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "source": "path identifies the entity to move",
                             "destination": "path identifies where to move it",
@@ -659,6 +712,7 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The source entity must exist. The destination context must "
                                    "exist and permit the entity. The actor must have sufficient "
@@ -678,11 +732,13 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "recursive": "moving a directory moves all of its contents",
                         },
@@ -705,10 +761,12 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
     """
     list_prim = Primitive(
         name="list",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that enumerates the contents or members of a "
                                    "container entity. Returns a collection of contained entities "
@@ -717,6 +775,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a container entity and returns its contents. May "
                                    "support filtering, sorting, and recursive enumeration. "
@@ -729,6 +788,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "contents": "returns files and subdirectories",
                             "recursive": "may enumerate contents of subdirectories recursively",
@@ -740,6 +800,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The container entity must exist. The actor must have "
                                    "sufficient permission to enumerate its contents. List is "
@@ -767,10 +828,12 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     """
     delete = Primitive(
         name="delete",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that removes an existing entity from existence. "
                                    "The inverse of create. After deletion, the entity no longer "
@@ -779,6 +842,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and removes it. May support "
                                    "recursive deletion for composite entities. Deletion is "
@@ -789,6 +853,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The target entity must exist. The actor must have sufficient "
                                    "permission to remove it. Deletion is irreversible by default. "
@@ -805,6 +870,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         policies=[
                             Policy(
                                 name="BulkFileDeletePolicy",
@@ -818,6 +884,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "recursive": "directory deletion may require recursive removal of contents",
                             "empty_check": "some systems require the directory to be empty first",
@@ -842,10 +909,12 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     """
     write = Primitive(
         name="write",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that modifies the contents or state of an "
                                    "existing entity. Unlike create, the entity must already "
@@ -854,6 +923,7 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and new content or state. Produces "
                                    "a modified version of the entity. Write is destructive — "
@@ -864,6 +934,7 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The target entity must exist. The actor must have sufficient "
                                    "permission to modify it. The entity must be in a state that "
@@ -880,6 +951,7 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "modes": ["overwrite", "append", "insert_at_offset"],
                             "encoding": "content may require encoding (utf-8, binary)",
@@ -904,10 +976,12 @@ def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     user = Primitive(
         name="user",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An entity recognized by the operating system as a principal of "
                                    "action. Has a unique identity within the OS's user management "
@@ -918,6 +992,7 @@ def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can own files and directories, belong to groups, and run "
                                    "processes. The OS evaluates permissions against the user's "
@@ -929,11 +1004,13 @@ def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "User identity must be recognized by the OS. Operations are "
                                    "constrained by permissions granted directly to the user or "
@@ -965,10 +1042,12 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
     """
     group = Primitive(
         name="group",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A named collection of users recognized by the operating system. "
                                    "Groups aggregate permissions and ownership, allowing multiple users "
@@ -978,6 +1057,7 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can contain multiple users. Permissions granted to a group apply "
                                    "to all its members. The OS evaluates group membership when "
@@ -989,16 +1069,19 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                     Relatum(
                         relation_type=RelationType.INCLUDES,
                         target_id=user.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Group membership is the mechanism by which permissions are "
                                    "inherited collectively. Membership and identity are managed "
@@ -1048,11 +1131,13 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.INCLUDES,
                 target_id=file.id,
                 target_depth=DepthLevel.EXISTENCE,
+                provenance=SEED_PROVENANCE,
             ),
             Relatum(
                 relation_type=RelationType.INCLUDES,
                 target_id=directory.id,
                 target_depth=DepthLevel.EXISTENCE,
+                provenance=SEED_PROVENANCE,
             ),
         ])
         repo.save_primitive(filesystem)
@@ -1068,73 +1153,75 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.APPLIES_TO,
                 target_id=user.id,
                 target_depth=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=group.id,
                 target_depth=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=read.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may perform a read operation",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=write.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may perform a write operation",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=delete.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may perform a delete operation",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=create.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may perform a create operation",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=list_prim.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may enumerate the contents of a directory",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=move.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may relocate an entity across contexts",
-                    "provenance": "authored",
                 },
             ),
             Relatum(
                 relation_type=RelationType.APPLIES_TO,
                 target_id=copy.id,
                 target_depth=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "Permission governs whether an actor may duplicate an entity into a new context",
-                    "provenance": "authored",
                 },
             ),
         ])
@@ -1151,9 +1238,9 @@ def main(repository: PrimitiveRepository) -> None:
                     relation_type=RelationType.CONSTRAINED_BY,
                     target_id=permission.id,
                     target_depth=DepthLevel.IDENTITY,
+                    provenance=SEED_PROVENANCE,
                     metadata={
                         "description": f"The {action_prim.name} action requires the actor to hold the corresponding permission on the target",
-                        "provenance": "authored",
                     },
                 )
             )
@@ -1166,9 +1253,9 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.CONSTRAINED_BY,
                 target_id=permission.id,
                 target_depth=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "The list action requires read permission on the target directory to enumerate its contents",
-                    "provenance": "authored",
                 },
             )
         )
@@ -1181,11 +1268,11 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.CONSTRAINED_BY,
                 target_id=permission.id,
                 target_depth=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "The move action requires write permission on both source and destination contexts — the source must permit removal and the destination must permit creation",
                     "source_permission": "write (delete-equivalent) on the source context",
                     "destination_permission": "write (create-equivalent) on the destination context",
-                    "provenance": "authored",
                 },
             )
         )
@@ -1198,11 +1285,11 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.CONSTRAINED_BY,
                 target_id=permission.id,
                 target_depth=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 metadata={
                     "description": "The copy action requires read permission on the source and write permission on the destination context",
                     "source_permission": "read on the source entity",
                     "destination_permission": "write (create-equivalent) on the destination context",
-                    "provenance": "authored",
                 },
             )
         )

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -13,7 +13,9 @@ import argparse
 
 from scripts.clear_graph import clear_graph
 from vre.core.graph import PrimitiveRepository
-from vre.core.models import Depth, DepthLevel, Primitive, Relatum, RelationType
+from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
+
+SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 # ── Fully grounded substrates (D0–D3) ─────────────────────────────────────
@@ -28,10 +30,12 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
     """
     os_prim = Primitive(
         name="operating_system",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "The software layer that manages hardware resources and provides "
                                    "services to applications. Mediates all access to storage, memory, "
@@ -41,6 +45,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Provides filesystems, process management, user/group identity, "
                                    "permission enforcement, environment variables, and inter-process "
@@ -56,6 +61,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Behavior varies across OS families (POSIX vs Windows). Resource "
                                    "limits, security policies, and kernel capabilities bound what is "
@@ -83,10 +89,12 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     filesystem = Primitive(
         name="filesystem",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A hierarchical system for organizing, storing, and retrieving "
                                    "persistent data. Provides the namespace (paths) and structure "
@@ -96,6 +104,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Organizes data into files and directories via a path-based "
                                    "hierarchy. Supports mounting, traversal, and metadata tracking "
@@ -112,11 +121,13 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Filesystem type determines supported features (max path length, "
                                    "case sensitivity, symlinks, permissions model). Must be mounted "
@@ -145,10 +156,12 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
     """
     path = Primitive(
         name="path",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A string that uniquely addresses a location within a "
                                    "filesystem's hierarchy. Composed of segments separated "
@@ -159,6 +172,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be resolved to a filesystem entity, joined with other "
                                    "paths, normalized, and decomposed into parent and basename. "
@@ -170,11 +184,13 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=filesystem.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Maximum length and valid characters are filesystem-dependent. "
                                    "Delimiter is OS-dependent (/ vs \\). Resolution may fail if "
@@ -204,10 +220,12 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     """
     permission = Primitive(
         name="permission",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A rule that governs whether an actor is allowed to perform "
                                    "a specific operation on a specific target. Expressed as a "
@@ -218,6 +236,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be checked, granted, revoked, and inherited. Multiple "
                                    "permission models exist; the specific model is determined "
@@ -229,6 +248,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=os_prim.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "enforcement": "kernel-level",
                             "models": ["posix_rwx", "acl", "capabilities"],
@@ -238,6 +258,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Only the granting authority can modify permissions. "
                                    "Inherited permissions may be overridden by explicit grants. "
@@ -277,10 +298,12 @@ def seed_directory(
     """
     directory = Primitive(
         name="directory",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A named container within a filesystem that holds files and "
                                    "other directories, forming the hierarchical structure of "
@@ -292,11 +315,13 @@ def seed_directory(
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Can be created, deleted, listed, renamed, and traversed. "
                                    "Serves as the scope and destination context for file operations.",
@@ -307,11 +332,13 @@ def seed_directory(
                         relation_type=RelationType.DEPENDS_ON,
                         target_id=filesystem.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Must have a valid path within a mounted filesystem. Deleting "
                                    "requires the directory to be empty or deletion to be recursive. "
@@ -330,12 +357,12 @@ def seed_directory(
                         relation_type=RelationType.CONSTRAINED_BY,
                         target_id=permission.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "list": "requires read permission on the directory",
                             "create_child": "requires write permission on the directory",
                             "delete": "requires write permission on the parent directory",
                             "rename": "requires write permission on both source and destination parent",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -360,10 +387,12 @@ def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
     """
     file = Primitive(
         name="file",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "A persistent, named unit of data stored on a filesystem and addressed by path.",
                     "attributes": ["path", "name", "extension", "size", "content"],
@@ -373,6 +402,7 @@ def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
                         relation_type=RelationType.REQUIRES,
                         target_id=path.id,
                         target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
                     ),
                 ],
             ),
@@ -396,10 +426,12 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     """
     read = Primitive(
         name="read",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that retrieves the contents or state of an "
                                    "existing entity without modifying it.",
@@ -407,6 +439,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and returns its contents or state. "
                                    "Read is inherently non-destructive — the target is unchanged "
@@ -419,9 +452,9 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "retrieval": "returns file contents as bytes or decoded text",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -443,10 +476,12 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
     """
     list_prim = Primitive(
         name="list",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that enumerates the contents or members of a "
                                    "container entity. Returns a collection of contained entities "
@@ -455,6 +490,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a container entity and returns its contents. May "
                                    "support filtering, sorting, and recursive enumeration. "
@@ -467,10 +503,10 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "contents": "returns files and subdirectories",
                             "recursive": "may enumerate contents of subdirectories recursively",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -496,10 +532,12 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     """
     delete = Primitive(
         name="delete",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that removes an existing entity from existence. "
                                    "The inverse of create. After deletion, the entity no longer "
@@ -508,6 +546,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
             Depth(
                 level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "Accepts a target entity and removes it. May support "
                                    "recursive deletion for composite entities. Deletion is "
@@ -538,10 +577,12 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     """
     create = Primitive(
         name="create",
+        provenance=SEED_PROVENANCE,
         depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
             Depth(
                 level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
                 properties={
                     "description": "An operation that brings a new entity into existence where "
                                    "none previously existed.",
@@ -552,24 +593,25 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             # learned its capabilities. This gates all D3 edges.
             Depth(
                 level=DepthLevel.CONSTRAINTS,
+                provenance=SEED_PROVENANCE,
                 properties={},
                 relata=[
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=file.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
                         },
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
                         target_id=directory.id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
                         metadata={
                             "default_destination": "current working directory when no path is specified",
-                            "provenance": "authored",
                         },
                     ),
                 ],
@@ -615,11 +657,13 @@ def main(repository: PrimitiveRepository) -> None:
                 relation_type=RelationType.INCLUDES,
                 target_id=file.id,
                 target_depth=DepthLevel.EXISTENCE,
+                provenance=SEED_PROVENANCE,
             ),
             Relatum(
                 relation_type=RelationType.INCLUDES,
                 target_id=directory.id,
                 target_depth=DepthLevel.EXISTENCE,
+                provenance=SEED_PROVENANCE,
             ),
         ])
         repo.save_primitive(filesystem)

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -17,7 +17,7 @@ Usage::
 
 from vre.core.graph import PrimitiveRepository
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
-from vre.core.models import DepthLevel
+from vre.core.models import DepthLevel, Provenance, ProvenanceSource
 from vre.core.policy import Cardinality, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate

--- a/src/vre/core/__init__.py
+++ b/src/vre/core/__init__.py
@@ -1,2 +1,6 @@
 # Copyright 2026 Andrew Greene
 # Licensed under the Apache License, Version 2.0
+
+from vre.core.models import Provenance, ProvenanceSource
+
+__all__ = ["Provenance", "ProvenanceSource"]

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -20,6 +20,7 @@ from vre.core.models import (
     DepthLevel,
     EpistemicStep,
     Primitive,
+    Provenance,
     Relatum,
     RelationType,
     ResolvedSubgraph,
@@ -90,12 +91,13 @@ class PrimitiveRepository:
         """
         stripped = []
         for depth in depths:
-            stripped.append(
-                {
-                    "level": int(depth.level),
-                    "properties": depth.properties,
-                }
-            )
+            entry: dict[str, Any] = {
+                "level": int(depth.level),
+                "properties": depth.properties,
+            }
+            if depth.provenance:
+                entry["provenance"] = depth.provenance.model_dump(mode="json")
+            stripped.append(entry)
         return json.dumps(stripped)
 
     @staticmethod
@@ -112,6 +114,7 @@ class PrimitiveRepository:
             depth = Depth(
                 level=DepthLevel(rd["level"]),
                 properties=rd.get("properties", {}),
+                provenance=Provenance(**rd["provenance"]) if rd.get("provenance") else None,
             )
             depths_by_level[int(depth.level)] = depth
 
@@ -126,12 +129,19 @@ class PrimitiveRepository:
             policies_data = json.loads(policies) if policies else []
             policies = [parse_policy(p) for p in policies_data]
 
+            rel_prov_json = rel_props.get("provenance")
+            rel_prov = None
+            if rel_prov_json:
+                rel_prov_data = json.loads(rel_prov_json) if isinstance(rel_prov_json, str) else rel_prov_json
+                rel_prov = Provenance(**rel_prov_data)
+
             relatum = Relatum(
                 relation_type=RelationType(rel["rel_type"]),
                 target_id=UUID(rel["target_id"]),
                 target_depth=DepthLevel(target_depth_val),
                 metadata=metadata,
                 policies=policies,
+                provenance=rel_prov,
             )
 
             if source_depth is not None and source_depth in depths_by_level:
@@ -139,16 +149,24 @@ class PrimitiveRepository:
 
         sorted_depths = sorted(depths_by_level.values(), key=lambda d: int(d.level))
 
+        node_prov_json = node_data.get("provenance")
+        node_prov = None
+        if node_prov_json:
+            node_prov_data = json.loads(node_prov_json) if isinstance(node_prov_json, str) else node_prov_json
+            node_prov = Provenance(**node_prov_data)
+
         return Primitive(
             id=UUID(node_data["id"]),
             name=node_data["name"],
             depths=sorted_depths,
+            provenance=node_prov,
         )
 
     def save_primitive(self, primitive: Primitive) -> None:
         """
         Persist a Primitive — full replace of depths and relata.
         """
+        primitive.validate_provenance()
         depths_json = self._depths_to_json(primitive.depths)
 
         relata_params: list[dict[str, Any]] = []
@@ -162,21 +180,25 @@ class PrimitiveRepository:
                         "target_depth": int(relatum.target_depth),
                         "metadata_json": json.dumps(relatum.metadata) if relatum.metadata else "{}",
                         "policies": json.dumps([p.model_dump() for p in relatum.policies]) if relatum.policies else "[]",
+                        "provenance": json.dumps(relatum.provenance.model_dump(mode="json")) if relatum.provenance else None,
                     }
                 )
 
         rel_types = [rt.value for rt in RelationType]
+
+        node_provenance = json.dumps(primitive.provenance.model_dump(mode="json")) if primitive.provenance else None
 
         def _tx(tx: Any) -> None:
             tx.run(
                 cast(
                     LiteralString,
                     "MERGE (p:Primitive {id: $id}) "
-                    "SET p.name = $name, p.depths_json = $depths_json",
+                    "SET p.name = $name, p.depths_json = $depths_json, p.provenance = $provenance",
                 ),
                 id=str(primitive.id),
                 name=primitive.name,
                 depths_json=depths_json,
+                provenance=node_provenance,
             )
 
             for rt in rel_types:
@@ -198,7 +220,8 @@ class PrimitiveRepository:
                         f"source_depth: $source_depth, "
                         f"target_depth: $target_depth, "
                         f"metadata_json: $metadata_json, "
-                        f"policies: $policies"
+                        f"policies: $policies, "
+                        f"provenance: $provenance"
                         f"}}]->(t)",
                     ),
                     source_id=str(primitive.id),
@@ -207,6 +230,7 @@ class PrimitiveRepository:
                     target_depth=rp["target_depth"],
                     metadata_json=rp["metadata_json"],
                     policies=rp["policies"],
+                    provenance=rp["provenance"],
                 )
 
         with self._driver.session(database=self._database) as session:
@@ -235,13 +259,15 @@ class PrimitiveRepository:
               p.id AS id,
               p.name AS name,
               p.depths_json AS depths_json,
+              p.provenance AS provenance,
               collect({
                 rel_type: type(r),
                 target_id: t.id,
                 source_depth: r.source_depth,
                 target_depth: r.target_depth,
                 metadata_json: coalesce(r.metadata_json, "{}"),
-                policies: coalesce(r.policies, "[]")
+                policies: coalesce(r.policies, "[]"),
+                provenance: r.provenance
               }) AS rels
             """,
         )
@@ -255,6 +281,7 @@ class PrimitiveRepository:
                 "id": record["id"],
                 "name": record["name"],
                 "depths_json": record["depths_json"],
+                "provenance": record["provenance"],
             }
             relationships = [
                 {
@@ -265,6 +292,7 @@ class PrimitiveRepository:
                         "target_depth": r["target_depth"],
                         "metadata_json": r.get("metadata_json") or "{}",
                         "policies": r.get("policies") or "[]",
+                        "provenance": r.get("provenance"),
                     },
                 }
                 for r in record["rels"]
@@ -286,13 +314,15 @@ class PrimitiveRepository:
               p.id AS id,
               p.name AS name,
               p.depths_json AS depths_json,
+              p.provenance AS provenance,
               collect({
                 rel_type: type(r),
                 target_id: t.id,
                 source_depth: r.source_depth,
                 target_depth: r.target_depth,
                 metadata_json: coalesce(r.metadata_json, "{}"),
-                policies: coalesce(r.policies, "[]")
+                policies: coalesce(r.policies, "[]"),
+                provenance: r.provenance
               }) AS rels
             """,
         )
@@ -306,6 +336,7 @@ class PrimitiveRepository:
                 "id": record["id"],
                 "name": record["name"],
                 "depths_json": record["depths_json"],
+                "provenance": record["provenance"],
             }
             relationships = [
                 {
@@ -316,6 +347,7 @@ class PrimitiveRepository:
                         "target_depth": r["target_depth"],
                         "metadata_json": r.get("metadata_json") or "{}",
                         "policies": r.get("policies") or "[]",
+                        "provenance": r.get("provenance"),
                     },
                 }
                 for r in record["rels"]
@@ -371,13 +403,14 @@ class PrimitiveRepository:
             OPTIONAL MATCH (src)-[r]->(tgt:Primitive)
             WHERE tgt IN nodes
             RETURN
-              [r IN roots | {id: r.id, name: r.name, depths_json: r.depths_json}] AS roots,
-              [n IN nodes | {id: n.id, name: n.name, depths_json: n.depths_json}] AS nodes,
+              [r IN roots | {id: r.id, name: r.name, depths_json: r.depths_json, provenance: r.provenance}] AS roots,
+              [n IN nodes | {id: n.id, name: n.name, depths_json: n.depths_json, provenance: n.provenance}] AS nodes,
               [e IN collect({
                   source_id: src.id, target_id: tgt.id, rel_type: type(r),
                   source_depth: r.source_depth, target_depth: r.target_depth,
                   metadata_json: coalesce(r.metadata_json, "{}"),
-                  policies: coalesce(r.policies, "[]")
+                  policies: coalesce(r.policies, "[]"),
+                  provenance: r.provenance
               }) WHERE e.rel_type IS NOT NULL] AS edges
             """,
         )
@@ -407,6 +440,7 @@ class PrimitiveRepository:
                         "target_depth": e["target_depth"],
                         "metadata_json": e.get("metadata_json", "{}"),
                         "policies": e.get("policies", "[]"),
+                        "provenance": e.get("provenance"),
                     },
                 })
 

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -233,10 +233,14 @@ class GroundingEngine:
         collected_ids = {n.id for n in all_nodes}
         return [
             Primitive(
-                id=p.id, name=p.name,
+                id=p.id,
+                name=p.name,
+                provenance=p.provenance,
                 depths=[
                     Depth(
-                        level=d.level, properties=d.properties,
+                        level=d.level,
+                        properties=d.properties,
+                        provenance=d.provenance,
                         relata=[r for r in d.relata if r.target_id in collected_ids],
                     )
                     for d in p.depths

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -47,7 +47,7 @@ def _fmt_gap(gap: Any) -> str:
 
 def _fmt_relatum(r: Any, id_to_name: dict) -> list[str]:
     """
-    Format a single Relatum as display lines, including metadata and policy count if present.
+    Format a single Relatum as display lines, including metadata, policy count, and provenance.
     """
     target_name = id_to_name.get(r.target_id, str(r.target_id))
     lines = [f"      → {target_name}  [{r.relation_type.value}, target@D{r.target_depth.value}]"]
@@ -58,6 +58,9 @@ def _fmt_relatum(r: Any, id_to_name: dict) -> list[str]:
         n = len(r.policies)
         word = "policy" if n == 1 else "policies"
         lines.append(f"        policies: {n} {word}")
+    if r.provenance:
+        date_str = r.provenance.created_at.strftime("%Y-%m-%d")
+        lines.append(f"        provenance: {r.provenance.source.value} ({date_str})")
     return lines
 
 
@@ -65,7 +68,8 @@ def _fmt_depth(depth: Any, id_to_name: dict) -> list[str]:
     """
     Format a single Depth level as display lines, including its relata.
     """
-    lines = [f"  D{depth.level.value} {depth.level.name}"]
+    prov_tag = f"  [{depth.provenance.source.value}]" if depth.provenance else ""
+    lines = [f"  D{depth.level.value} {depth.level.name}{prov_tag}"]
     if depth.properties:
         lines.append("    properties:")
         for k, v in depth.properties.items():
@@ -84,6 +88,10 @@ def _fmt_primitive(primitive: Any, id_to_name: dict) -> list[str]:
     name = primitive.name
     header = f"═══ {name} {'═' * max(0, 50 - len(name))}"
     lines = [header]
+
+    if primitive.provenance:
+        date_str = primitive.provenance.created_at.strftime("%Y-%m-%d")
+        lines.append(f"  provenance: {primitive.provenance.source.value} ({date_str})")
 
     if not primitive.depths:
         return lines

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -5,6 +5,7 @@
 Core epistemic models for the Volute Reasoning Engine.
 """
 
+from datetime import datetime, timezone
 from enum import Enum, IntEnum
 from typing import Annotated, Any, Literal, NamedTuple
 from uuid import UUID, uuid4
@@ -38,6 +39,27 @@ class RelationType(str, Enum):
     INCLUDES = "INCLUDES"
 
 
+class ProvenanceSource(str, Enum):
+    """
+    Origin category for knowledge in the epistemic graph.
+    """
+
+    AUTHORED = "authored"
+    LEARNED = "learned"
+    CONVERSATIONAL = "conversational"
+
+
+class Provenance(BaseModel):
+    """
+    Structured provenance record for epistemic knowledge.
+    """
+
+    source: ProvenanceSource
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    detail: str | None = None
+
+
 class Relatum(BaseModel):
     """
     Directional, typed, depth-aware relationship.
@@ -48,6 +70,17 @@ class Relatum(BaseModel):
     target_depth: DepthLevel
     metadata: dict[str, Any] = Field(default_factory=dict)
     policies: list[Policy] = Field(default_factory=list)
+    provenance: Provenance | None = None
+
+    def validate_provenance(self, context: str = "") -> None:
+        """
+        Raise ValueError if provenance is missing.
+        """
+        if self.provenance is None:
+            raise ValueError(
+                f"{context}relatum {self.relation_type.value} → "
+                f"{self.target_id} is missing provenance"
+            )
 
 
 class Depth(BaseModel):
@@ -58,6 +91,21 @@ class Depth(BaseModel):
     level: DepthLevel
     properties: dict[str, Any] = Field(default_factory=dict)
     relata: list[Relatum] = Field(default_factory=list)
+    provenance: Provenance | None = None
+
+    def validate_provenance(self, context: str = "") -> None:
+        """
+        Raise ValueError if provenance is missing on this depth or any of its relata.
+        """
+        if self.provenance is None:
+            raise ValueError(
+                f"{context}depth D{self.level.value} ({self.level.name}) "
+                f"is missing provenance"
+            )
+        for relatum in self.relata:
+            relatum.validate_provenance(
+                context=f"{context}depth D{self.level.value} "
+            )
 
 
 class Primitive(BaseModel):
@@ -68,6 +116,18 @@ class Primitive(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     name: str
     depths: list[Depth] = Field(default_factory=list)
+    provenance: Provenance | None = None
+
+    def validate_provenance(self) -> None:
+        """
+        Raise ValueError if provenance is missing on this primitive, any depth, or any relatum.
+        """
+        if self.provenance is None:
+            raise ValueError(
+                f"Primitive '{self.name}' is missing provenance"
+            )
+        for depth in self.depths:
+            depth.validate_provenance(context=f"Primitive '{self.name}' ")
 
 
 class EpistemicQuery(BaseModel):

--- a/tests/vre/test_provenance.py
+++ b/tests/vre/test_provenance.py
@@ -1,0 +1,397 @@
+"""
+Unit tests for Provenance as a first-class attribute on Primitive, Depth, and Relatum.
+"""
+
+import json
+import re
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    Primitive,
+    Provenance,
+    ProvenanceSource,
+    Relatum,
+    RelationType,
+)
+from vre.core.graph import PrimitiveRepository
+from vre.core.grounding.models import _fmt_depth, _fmt_primitive, _fmt_relatum
+
+
+# ── Model construction ───────────────────────────────────────────────────────
+
+def test_provenance_defaults():
+    """
+    Provenance constructed with only source gets auto-set timestamps and None detail.
+    """
+    p = Provenance(source=ProvenanceSource.AUTHORED)
+    assert p.source == ProvenanceSource.AUTHORED
+    assert isinstance(p.created_at, datetime)
+    assert isinstance(p.updated_at, datetime)
+    assert p.detail is None
+
+
+def test_provenance_enum_values():
+    """
+    ProvenanceSource enum maps to the three canonical string values from CLAUDE.md §7.2.
+    """
+    assert ProvenanceSource.AUTHORED.value == "authored"
+    assert ProvenanceSource.LEARNED.value == "learned"
+    assert ProvenanceSource.CONVERSATIONAL.value == "conversational"
+
+
+def test_provenance_with_detail():
+    """
+    The optional detail field stores a human-readable context string.
+    """
+    p = Provenance(source=ProvenanceSource.LEARNED, detail="discovered via permission denied")
+    assert p.detail == "discovered via permission denied"
+
+
+def test_provenance_timestamps_auto_set():
+    """
+    Both created_at and updated_at are bracketed by the wall clock at construction time.
+    """
+    before = datetime.now(timezone.utc)
+    p = Provenance(source=ProvenanceSource.AUTHORED)
+    after = datetime.now(timezone.utc)
+    assert before <= p.created_at <= after
+    assert before <= p.updated_at <= after
+
+
+def test_primitive_provenance_optional():
+    """
+    Primitive without provenance defaults to None for backward compatibility.
+    """
+    p = Primitive(name="test")
+    assert p.provenance is None
+
+
+def test_depth_provenance_optional():
+    """
+    Depth without provenance defaults to None for backward compatibility.
+    """
+    d = Depth(level=DepthLevel.EXISTENCE)
+    assert d.provenance is None
+
+
+def test_relatum_provenance_optional():
+    """
+    Relatum without provenance defaults to None for backward compatibility.
+    """
+    r = Relatum(
+        relation_type=RelationType.APPLIES_TO,
+        target_id=uuid4(),
+        target_depth=DepthLevel.CAPABILITIES,
+    )
+    assert r.provenance is None
+
+
+def test_primitive_with_provenance():
+    """
+    Primitive accepts and stores a Provenance instance.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    p = Primitive(name="file", provenance=prov)
+    assert p.provenance is prov
+    assert p.provenance.source == ProvenanceSource.AUTHORED
+
+
+def test_depth_with_provenance():
+    """
+    Depth accepts and stores a Provenance instance.
+    """
+    prov = Provenance(source=ProvenanceSource.LEARNED)
+    d = Depth(level=DepthLevel.CONSTRAINTS, provenance=prov)
+    assert d.provenance is prov
+
+
+def test_relatum_with_provenance():
+    """
+    Relatum accepts and stores a Provenance instance.
+    """
+    prov = Provenance(source=ProvenanceSource.CONVERSATIONAL)
+    r = Relatum(
+        relation_type=RelationType.APPLIES_TO,
+        target_id=uuid4(),
+        target_depth=DepthLevel.CAPABILITIES,
+        provenance=prov,
+    )
+    assert r.provenance is prov
+
+
+# ── Persistence boundary validation ──────────────────────────────────────────
+
+def test_validate_provenance_rejects_primitive_without_provenance():
+    """
+    validate_provenance raises ValueError when the primitive itself has no provenance.
+    """
+    p = Primitive(name="test")
+    with pytest.raises(ValueError, match=re.escape("Primitive 'test' is missing provenance")):
+        p.validate_provenance()
+
+
+def test_validate_provenance_rejects_depth_without_provenance():
+    """
+    validate_provenance raises ValueError when a depth is missing provenance.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    p = Primitive(
+        name="file",
+        provenance=prov,
+        depths=[Depth(level=DepthLevel.EXISTENCE)],
+    )
+    with pytest.raises(ValueError, match="depth D0 .EXISTENCE. is missing provenance"):
+        p.validate_provenance()
+
+
+def test_validate_provenance_rejects_relatum_without_provenance():
+    """
+    validate_provenance raises ValueError when a relatum is missing provenance.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    target_id = uuid4()
+    p = Primitive(
+        name="read",
+        provenance=prov,
+        depths=[
+            Depth(
+                level=DepthLevel.CAPABILITIES,
+                provenance=prov,
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=target_id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                    ),
+                ],
+            ),
+        ],
+    )
+    with pytest.raises(ValueError, match="relatum APPLIES_TO"):
+        p.validate_provenance()
+
+
+def test_validate_provenance_accepts_full_provenance():
+    """
+    validate_provenance succeeds when provenance is set at all levels.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    p = Primitive(
+        name="file",
+        provenance=prov,
+        depths=[
+            Depth(
+                level=DepthLevel.EXISTENCE,
+                provenance=prov,
+            ),
+            Depth(
+                level=DepthLevel.CAPABILITIES,
+                provenance=prov,
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=uuid4(),
+                        target_depth=DepthLevel.CAPABILITIES,
+                        provenance=prov,
+                    ),
+                ],
+            ),
+        ],
+    )
+    p.validate_provenance()  # should not raise
+
+
+# ── Round-trip serialization ─────────────────────────────────────────────────
+
+def test_depths_to_json_includes_provenance():
+    """
+    _depths_to_json serializes depth provenance into the JSON entry.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    depths = [Depth(level=DepthLevel.EXISTENCE, provenance=prov)]
+    result = json.loads(PrimitiveRepository._depths_to_json(depths))
+    assert len(result) == 1
+    assert "provenance" in result[0]
+    assert result[0]["provenance"]["source"] == "authored"
+
+
+def test_depths_to_json_omits_provenance_when_none():
+    """
+    _depths_to_json omits the provenance key entirely when provenance is None.
+    """
+    depths = [Depth(level=DepthLevel.EXISTENCE)]
+    result = json.loads(PrimitiveRepository._depths_to_json(depths))
+    assert "provenance" not in result[0]
+
+
+def test_hydrate_primitive_with_provenance():
+    """
+    Full round-trip: provenance at node, depth, and relatum levels survives serialize → hydrate.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    target_id = uuid4()
+    primitive = Primitive(
+        name="file",
+        provenance=prov,
+        depths=[
+            Depth(
+                level=DepthLevel.EXISTENCE,
+                provenance=prov,
+            ),
+            Depth(
+                level=DepthLevel.CAPABILITIES,
+                provenance=Provenance(source=ProvenanceSource.LEARNED, detail="from failure"),
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=target_id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        provenance=Provenance(source=ProvenanceSource.CONVERSATIONAL),
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    # Serialize
+    depths_json = PrimitiveRepository._depths_to_json(primitive.depths)
+    node_prov_json = json.dumps(prov.model_dump(mode="json"))
+    rel_prov = Provenance(source=ProvenanceSource.CONVERSATIONAL)
+    rel_prov_json = json.dumps(rel_prov.model_dump(mode="json"))
+
+    node_data = {
+        "id": str(primitive.id),
+        "name": "file",
+        "depths_json": depths_json,
+        "provenance": node_prov_json,
+    }
+    relationships = [
+        {
+            "rel_type": "APPLIES_TO",
+            "target_id": str(target_id),
+            "rel_props": {
+                "source_depth": 2,
+                "target_depth": 2,
+                "metadata_json": "{}",
+                "policies": "[]",
+                "provenance": rel_prov_json,
+            },
+        },
+    ]
+
+    # Deserialize
+    hydrated = PrimitiveRepository._hydrate_primitive(node_data, relationships)
+
+    # Node provenance
+    assert hydrated.provenance is not None
+    assert hydrated.provenance.source == ProvenanceSource.AUTHORED
+
+    # Depth provenance
+    d0 = next(d for d in hydrated.depths if d.level == DepthLevel.EXISTENCE)
+    assert d0.provenance is not None
+    assert d0.provenance.source == ProvenanceSource.AUTHORED
+
+    d2 = next(d for d in hydrated.depths if d.level == DepthLevel.CAPABILITIES)
+    assert d2.provenance is not None
+    assert d2.provenance.source == ProvenanceSource.LEARNED
+    assert d2.provenance.detail == "from failure"
+
+    # Relatum provenance
+    assert len(d2.relata) == 1
+    assert d2.relata[0].provenance is not None
+    assert d2.relata[0].provenance.source == ProvenanceSource.CONVERSATIONAL
+
+
+def test_hydrate_primitive_without_provenance():
+    """
+    Hydrating node data with no provenance fields yields None — backward compatible.
+    """
+    node_data = {
+        "id": str(uuid4()),
+        "name": "legacy",
+        "depths_json": json.dumps([{"level": 0, "properties": {}}]),
+    }
+    hydrated = PrimitiveRepository._hydrate_primitive(node_data, [])
+    assert hydrated.provenance is None
+    assert hydrated.depths[0].provenance is None
+
+
+# ── Display formatting ───────────────────────────────────────────────────────
+
+def test_fmt_relatum_with_provenance():
+    """
+    _fmt_relatum includes a 'provenance: source (date)' line when provenance is set.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    target_id = uuid4()
+    r = Relatum(
+        relation_type=RelationType.APPLIES_TO,
+        target_id=target_id,
+        target_depth=DepthLevel.CAPABILITIES,
+        provenance=prov,
+    )
+    lines = _fmt_relatum(r, {target_id: "file"})
+    joined = "\n".join(lines)
+    date_str = prov.created_at.strftime("%Y-%m-%d")
+    assert f"provenance: authored ({date_str})" in joined
+
+
+def test_fmt_relatum_without_provenance():
+    """
+    _fmt_relatum omits provenance line when provenance is None.
+    """
+    target_id = uuid4()
+    r = Relatum(
+        relation_type=RelationType.APPLIES_TO,
+        target_id=target_id,
+        target_depth=DepthLevel.CAPABILITIES,
+    )
+    lines = _fmt_relatum(r, {target_id: "file"})
+    joined = "\n".join(lines)
+    assert "provenance" not in joined
+
+
+def test_fmt_depth_with_provenance():
+    """
+    _fmt_depth appends an inline [source] tag when provenance is set.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    d = Depth(level=DepthLevel.CAPABILITIES, provenance=prov)
+    lines = _fmt_depth(d, {})
+    assert lines[0] == "  D2 CAPABILITIES  [authored]"
+
+
+def test_fmt_depth_without_provenance():
+    """
+    _fmt_depth renders without a provenance tag when provenance is None.
+    """
+    d = Depth(level=DepthLevel.CAPABILITIES)
+    lines = _fmt_depth(d, {})
+    assert lines[0] == "  D2 CAPABILITIES"
+
+
+def test_fmt_primitive_with_provenance():
+    """
+    _fmt_primitive includes a 'provenance: source (date)' line below the header.
+    """
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    p = Primitive(name="file", provenance=prov)
+    lines = _fmt_primitive(p, {})
+    joined = "\n".join(lines)
+    date_str = prov.created_at.strftime("%Y-%m-%d")
+    assert f"provenance: authored ({date_str})" in joined
+
+
+def test_fmt_primitive_without_provenance():
+    """
+    _fmt_primitive omits provenance line when provenance is None.
+    """
+    p = Primitive(name="file")
+    lines = _fmt_primitive(p, {})
+    joined = "\n".join(lines)
+    assert "provenance" not in joined

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -90,7 +90,7 @@ def test_grounding_str_shows_relatum_with_metadata():
         relation_type=RelationType.CONSTRAINED_BY,
         target_id=permission.id,
         target_depth=DepthLevel.CONSTRAINTS,
-        metadata={"provenance": "authored"},
+        metadata={"enforcement": "kernel-level"},
     )
     file_p = _make_primitive("file", [
         _make_depth(DepthLevel.EXISTENCE),
@@ -101,7 +101,7 @@ def test_grounding_str_shows_relatum_with_metadata():
     result = _grounded(["file", "permission"], [file_p, permission])
     s = str(result)
     assert "→ permission  [CONSTRAINED_BY, target@D3]" in s
-    assert "metadata: provenance=authored" in s
+    assert "metadata: enforcement=kernel-level" in s
 
 
 def test_grounding_str_shows_pathway():


### PR DESCRIPTION
## Summary

- Adds `Provenance` model (`source`, `created_at`, `updated_at`, `detail`) and `ProvenanceSource` enum (`authored`, `learned`, `conversational`) to `src/vre/core/models.py`
- Adds optional `provenance` field to `Primitive`, `Depth`, and `Relatum` with cascading `validate_provenance()` methods that enforce completeness at the persistence boundary (`save_primitive`)
- Serializes/deserializes provenance through all Neo4j persistence paths (`_depths_to_json`, `_hydrate_primitive`, `save_primitive`, `find_by_id`, `find_by_name`, `resolve_subgraph`)
- Forwards provenance through the grounding engine (`_filter_depths`) and renders it in display formatting (`_fmt_primitive`, `_fmt_depth`, `_fmt_relatum`)
- Updates both seed scripts to use structured `Provenance` on all constructors, replacing the old `metadata["provenance"]` convention
- Exports `Provenance` and `ProvenanceSource` from `vre.core` and `vre`
- Updates CLAUDE.md §7.2 to reflect the structured provenance model

Closes #6

## Test plan

- [x] 24 new tests in `test_provenance.py` covering model construction, persistence boundary validation, round-trip serialization, backward compatibility, and display formatting
- [x] Updated `test_types.py` assertion from old `metadata: provenance=authored` convention
- [x] Full suite passes (139 tests)
- [ ] `poetry run python scripts/seed_all.py` seeds with structured provenance
- [ ] `vre.check(["read", "file"])` displays provenance in trace output

🤖 Generated with [Claude Code](https://claude.com/claude-code)