### PR TITLE
chore(ci): Add CI/CD pipeline with linting and coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install Poetry
+        run: pipx install poetry
+      - name: Cache virtualenv
+        uses: actions/cache@v4
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-3.12-${{ hashFiles('poetry.lock') }}
+      - name: Install dependencies
+        run: poetry install
+      - name: Download spaCy model
+        run: poetry run python -m spacy download en_core_web_sm
+      - name: Lint
+        run: poetry run ruff check src/ tests/
+      - name: Test
+        run: poetry run pytest tests/ -v

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.1.0"
+version = "0.2.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}
@@ -28,4 +28,11 @@ requires = ["poetry-core>=2.0.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [dependency-groups]
-dev = ["pytest>=9.0.2,<10.0.0"]
+dev = ["pytest>=9.0.2,<10.0.0", "pytest-cov (>=7.0.0,<8.0.0)", "ruff (>=0.15.5,<0.16.0)"]
+
+[tool.ruff]
+target-version = "py312"
+line-length = 120
+
+[tool.pytest.ini_options]
+addopts = "--cov=src/vre --cov-fail-under=70"

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -22,6 +22,21 @@ from vre.core.policy import Cardinality, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
 
+__all__ = [
+    "VRE",
+    "PrimitiveRepository",
+    "ConceptResolver",
+    "GroundingEngine",
+    "GroundingResult",
+    "DepthLevel",
+    "Provenance",
+    "ProvenanceSource",
+    "Cardinality",
+    "PolicyResult",
+    "PolicyCallContext",
+    "PolicyGate",
+]
+
 
 class VRE:
     """

--- a/tests/vre/test_claude_code.py
+++ b/tests/vre/test_claude_code.py
@@ -7,7 +7,6 @@ Unit tests for vre.integrations.claude_code — install, uninstall, and _run_hoo
 
 import io
 import json
-import stat
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -244,7 +244,8 @@ def test_vre_guard_callable_concepts_stored_on_attribute():
     """
     from vre.guard import vre_guard
 
-    fn = lambda: ["file"]
+    def fn():
+        return ["file"]
     mock_vre = _mock_vre(_grounding())
 
     @vre_guard(mock_vre, concepts=fn)

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -2,7 +2,6 @@
 Unit tests for GroundingResult.__str__ and PolicyResult.__str__.
 """
 
-from uuid import uuid4
 
 from vre.core.models import (
     Depth,

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -5,7 +5,7 @@ Uses a stub repository to avoid Neo4j dependency.
 """
 
 from collections import deque
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from vre import VRE
 from vre.core.models import (


### PR DESCRIPTION
## Summary

Adds a GitHub Actions CI/CD pipeline that runs on every push and PR to `main`, along with ruff linting, pytest-cov coverage enforcement, and a version bump to 0.2.0.

## Changes

- Add `.github/workflows/ci.yml` — single-job workflow with lint and test steps
- Add `ruff` and `pytest-cov` as dev dependencies
- Configure ruff (Python 3.12, 120 char line length) in `pyproject.toml`
- Configure pytest-cov with `--cov-fail-under=70` threshold
- Fix 6 ruff violations (unused imports, lambda assignment)
- Add `__all__` to `src/vre/__init__.py` for explicit re-exports
- Bump version from 0.1.0 to 0.2.0

## VRE Design Alignment

Pure infrastructure — no impact on the epistemic model, grounding, policy evaluation, or gap detection.

## Test Plan

- [x] `poetry run ruff check src/ tests/` passes cleanly
- [x] `poetry run pytest tests/ -v` — 139 tests pass
- [x] Coverage at 72%, clears 70% floor
- [ ] Verify workflow runs green on this PR

## Notes

- Coverage floor set at 70%, just below current 72%. The two low-coverage files are `core/graph.py` (49%, Neo4j driver methods mocked in tests) and `core/policy/wizard.py` (0%, interactive CLI with no tests). This prevents regressions without forcing coverage of those modules now.
- Branch protection with required status checks can be enabled after the workflow has a successful run.

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)