### PR TITLE
feat(learning): Auto-learning loop for iterative knowledge gap resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,13 @@ Each call runs the following sequence:
 1. **Resolve concepts** — map names to canonical primitives via the graph
 2. **Ground** — verify the subgraph meets depth requirements (graph-derived + optional `min_depth` floor)
 3. **Fire `on_trace`** — surface the epistemic result to the caller
-4. **If not grounded** — return the `GroundingResult` immediately; the function does not execute
-5. **Evaluate policies** — check all `APPLIES_TO` relata for applicable policy gates
-6. **If PENDING** — call `on_policy` for confirmation; block if declined or no handler
-7. **If BLOCK** — return the `PolicyResult`; the function does not execute
-8. **Execute** — call the original function and return its result
+4. **If not grounded and `on_learn` is present** — enter the auto-learning loop (see [Auto-Learning](#auto-learning))
+5. **Fire `on_trace` again** — surface the post-learning epistemic result
+6. **If still not grounded** — return the `GroundingResult` immediately; the function does not execute
+7. **Evaluate policies** — check all `APPLIES_TO` relata for applicable policy gates
+8. **If PENDING** — call `on_policy` for confirmation; block if declined or no handler
+9. **If BLOCK** — return the `PolicyResult`; the function does not execute
+10. **Execute** — call the original function and return its result
 
 ### Parameters
 
@@ -241,8 +243,10 @@ vre_guard(
     vre,                 # VRE instance
     concepts,            # list[str] or Callable(*args, **kwargs) -> list[str]
     cardinality=None,    # str | None or Callable(*args, **kwargs) -> str | None
+    min_depth=None,      # DepthLevel | None — enforces a minimum depth floor
     on_trace=None,       # Callable[[GroundingResult], None]
     on_policy=None,      # Callable[[str], bool]
+    on_learn=None,       # LearningCallback — auto-learning loop for knowledge gaps
 )
 ```
 
@@ -304,7 +308,7 @@ VRE Epistemic Check
 │   └── REQUIRES    →  filesystem (target D3)
 ├── ◈ file   ● ● ● ●
 │   └── CONSTRAINED_BY  →  permission  (target D3)
-└── ✓ Grounded at D3 — EPISTEMIC PERMISSION GRANTED
+└── ✓ Grounded — EPISTEMIC PERMISSION GRANTED
 ```
 
 Green dots (`●`) represent grounded depth levels. A red `✗` at a depth level indicates a gap. Relata flagged with `✗` indicate relational gaps where the target does not meet the required depth.
@@ -334,6 +338,93 @@ If `on_policy` is not provided and a policy requires confirmation, the guard ret
 <img width="1968" height="1592" alt="image" src="https://github.com/user-attachments/assets/81257f0f-4273-4235-85ca-dcb50c21439b" />
 
 <img width="1392" height="714" alt="image" src="https://github.com/user-attachments/assets/8b701635-d4ca-4511-98e3-cda82a5dde38" />
+
+### `on_learn`
+
+Called when grounding fails and the guard enters the auto-learning loop. See [Auto-Learning](#auto-learning) for details.
+
+---
+
+## Auto-Learning
+
+When grounding fails and an `on_learn` callback is present, VRE enters an iterative learning loop that transforms knowledge gaps into graph growth. Rather than simply blocking the action, VRE surfaces structured templates for each gap, invokes the callback to fill them, and persists accepted knowledge back to the graph — then re-grounds to see if the action is now justified.
+
+This is VRE's answer to its primary adoption bottleneck: manual graph authoring. The graph grows through use.
+
+### How it works
+
+1. **Gap detected** — grounding check reveals one or more knowledge gaps
+2. **Template created** — VRE generates a structured candidate template based on the gap type
+3. **Callback invoked** — the integrator's `on_learn` callback receives the template, the full grounding result, and the specific gap. The callback fills the template (via LLM, user input, or any other mechanism) and returns a decision.
+4. **Persistence** — accepted or modified candidates are persisted to the graph with provenance tracking
+5. **Re-ground** — VRE re-checks grounding. The gap landscape may have shifted — new gaps may have appeared, existing ones may be resolved. The loop continues until grounded, all gaps are addressed, or the user rejects.
+
+### Candidate types
+
+Each gap type has a corresponding candidate model. Candidates carry only what's *new* — all context (primitive IDs, existing depths, required depths) lives on the gap itself.
+
+| Gap Type | Candidate | What the agent fills in |
+|---|---|---|
+| `ExistenceGap` | `ExistenceCandidate` | D1 identity for a new concept (D0 is auto-generated) |
+| `DepthGap` | `DepthCandidate` | Missing depth levels with properties |
+| `RelationalGap` | `RelationalCandidate` | Missing depth levels on the edge target |
+| `ReachabilityGap` | `ReachabilityCandidate` | Edge placement: target name, relation type, source/target depth levels |
+
+`ExistenceCandidate`, `DepthCandidate`, and `RelationalCandidate` all use `ProposedDepth` — the agent-facing depth model:
+
+```python
+from vre.learning.models import ProposedDepth
+
+ProposedDepth(
+    level=DepthLevel.CAPABILITIES,
+    properties={"operations": ["read", "write"], "attributes": ["size", "permissions"]},
+)
+```
+
+`ProposedDepth` carries only `level` and `properties` — descriptive attributes intrinsic to the concept at that depth. Relata and provenance are structural concerns handled by the engine during persistence.
+
+### Decisions and provenance
+
+The callback returns one of four decisions, and provenance is derived from what actually happened:
+
+| Decision | Effect | Provenance |
+|---|---|---|
+| `ACCEPTED` | Persist as proposed | `learned` |
+| `MODIFIED` | Persist after user refinement | `conversational` |
+| `SKIPPED` | Intentionally dismissed — loop continues to next gap | — |
+| `REJECTED` | Discard — stops the learning loop entirely | — |
+
+`SKIPPED` is particularly important for reachability gaps: the absence of an edge can itself be an enforcement mechanism. If a concept *should not* be connected, the user skips rather than placing an edge.
+
+### Two-phase edge placement
+
+Reachability candidates focus solely on edge placement — they declare *where* the edge goes, not what depths need to exist. If the source or target lacks the declared depth level, the engine automatically synthesizes a `DepthGap` and invokes the callback to learn the missing depths *before* placing the edge. If depth learning is rejected, the edge placement is abandoned.
+
+This keeps each candidate type focused on its single concern while handling cascading dependencies naturally.
+
+### The `LearningCallback` ABC
+
+```python
+from vre.learning.callback import LearningCallback
+from vre.learning.models import LearningCandidate, CandidateDecision
+
+class MyLearner(LearningCallback):
+    def __call__(self, candidate, grounding, gap) -> tuple[LearningCandidate | None, CandidateDecision]:
+        # Fill the template, present to user, return (filled, decision)
+        ...
+```
+
+`LearningCallback` is an abstract base class with `__call__` as the only required method. It also supports context manager lifecycle via `__enter__` and `__exit__` (with default no-op implementations) — `learn_all` wraps the session in `with callback:`, allowing callbacks to manage state across a learning session without the guard knowing about callback internals.
+
+### Demo implementation
+
+The demo's `DemoLearner` uses ChatOllama structured output to fill templates and Rich to present proposals:
+
+1. The user is prompted to enter learning mode (once per session, via `__enter__`/`__exit__` lifecycle)
+2. The LLM fills the candidate template using the epistemic trace as context
+3. The proposal is rendered as a Rich panel showing all proposed knowledge
+4. The user chooses: accept, modify (provide feedback → LLM re-proposes), skip, or reject
+5. Accepted knowledge is persisted and grounding is re-checked
 
 ---
 
@@ -372,6 +463,7 @@ from vre.guard import vre_guard
     cardinality=get_cardinality,  # inspects flags/globs → "single" or "multiple"
     on_trace=on_trace,         # renders epistemic tree to terminal
     on_policy=on_policy,       # Rich Confirm.ask prompt
+    on_learn=on_learn,         # auto-learning callback for knowledge gaps
 )
 def shell_tool(command: str) -> str:
     result = subprocess.run(command, shell=True, capture_output=True, text=True, cwd=sandbox)
@@ -483,22 +575,18 @@ What a detailed graph adds is not stronger enforcement, but better context. More
 
 When a mechanical failure occurs during execution — permission denied, missing dependency, invalid path — the failure reveals a constraint that was not modeled. The agent reasoned correctly within its knowledge boundary; the failure exposes a gap *beyond* that boundary.
 
-A future meta-epistemic layer will treat execution failures as candidates for graph growth: the agent proposes the missing relatum (e.g. `create --[CONSTRAINED_BY]--> permission`), seeks human validation, and persists the new knowledge. Depth was honest before the failure and more complete after. No contradiction — just growth.
-
-Provenance will travel with each piece of learned knowledge — `authored`, `learned`, or `conversational` — so the audit trail lives inside the epistemic structure itself rather than in a separate log.
-
-The learning through failure paradigm is already emerging naturally, it just needs to be codified. The below image was taken as I was conducting tests for this README. Without being prompted, the demo agent continued to try and execute an ungrounded command with missing graph Primitives and eventually ceded, but not before proposing a solution for the knowledge gaps it was encountering.
-
-<img width="3210" height="1522" alt="image" src="https://github.com/user-attachments/assets/c9d0ea91-d0e9-471a-9f5e-e05fdcea60a9" />
-
-
-### Meta-epistemic discussion mode
-
-Structured conversation about the agent's epistemic state: asking why a concept is unknown, providing domain knowledge to populate a depth, or refining relata through dialogue. User input in this mode becomes a source for graph population rather than a trigger for action.
+This is distinct from the [auto-learning loop](#auto-learning), which addresses gaps discovered *before* execution. Learning through failure would be triggered *after* execution — the graph said "go ahead" but reality disagreed. The agent proposes the missing relatum (e.g. `create --[CONSTRAINED_BY]--> permission`), seeks human validation, and persists the new knowledge. Depth was honest before the failure and more complete after. No contradiction — just growth.
 
 ### VRE Networks
 
 An agentic network of agents that share grounded knowledge across different epistemic graphs while applying the same enforcement mechanisms. Agents in the network expose and consume epistemic subgraphs from peer VRE instances, preserving grounding guarantees across trust boundaries. A concept grounded at D3 in one agent's graph carries its epistemic justification with it — the network does not collapse knowledge into a shared mutable store, but federates it while keeping each agent's epistemic contract intact.
+
+### Epistemic Memory
+
+A new class of memory that stores not just information but the agent's epistemic relationship to that information.
+Memories are indexed by concept and depth, and can be queried by the agent to inform its reasoning process. 
+Memories will decay or be reinforced based on usage and grounding history and affect the agent's confidence in 
+related concepts.
 
 ---
 
@@ -520,10 +608,10 @@ An agentic network of agents that share grounded knowledge across different epis
 
 ```
 src/vre/
-  __init__.py              # VRE public interface
-  guard.py                 # vre_guard decorator
+  __init__.py              # VRE public interface (check, learn, learn_all, check_policy)
+  guard.py                 # vre_guard decorator (grounding → learning → policy → execution)
   core/
-    models.py              # Primitive, Depth, Relatum, RelationType, DepthLevel, gaps
+    models.py              # Primitive, Depth, Relatum, RelationType, DepthLevel, gaps, Provenance
     graph.py               # PrimitiveRepository (Neo4j)
     grounding/
       resolver.py          # ConceptResolver — spaCy lemmatization + name lookup
@@ -534,6 +622,11 @@ src/vre/
       gate.py              # PolicyGate — evaluates violations against a trace
       callback.py          # PolicyCallContext, PolicyCallback protocol
       wizard.py            # Interactive policy attachment CLI
+  learning/
+    callback.py            # LearningCallback ABC — __call__, __enter__, __exit__
+    models.py              # Candidate models, CandidateDecision, LearningResult
+    templates.py           # TemplateFactory — gap → structured candidate template
+    engine.py              # LearningEngine — template → callback → validate → persist
   builtins/
     shell.py               # SHELL_ALIASES + parse_bash_primitives()
   integrations/
@@ -548,7 +641,8 @@ demo/
   main.py                  # Entry point — argparse + agent setup
   agent.py                 # ToolAgent — LangChain + Ollama streaming loop
   tools.py                 # shell_tool with vre_guard applied
-  callbacks.py             # on_trace (Rich tree), on_policy (Rich Confirm)
+  callbacks.py             # on_trace (Rich tree), on_policy (Rich Confirm), make_on_learn
+  learner.py               # DemoLearner — ChatOllama structured output + Rich UI
   repl.py                  # Streaming REPL with Rich Live display
 ```
 

--- a/demo/callbacks.py
+++ b/demo/callbacks.py
@@ -1,5 +1,6 @@
 """
-Demo callbacks for vre_guard: trace renderer and policy confirmation.
+Demo callbacks for vre_guard: trace renderer, policy confirmation, and
+auto-learning via meta-epistemic dialogue with the agent.
 """
 
 from __future__ import annotations
@@ -9,6 +10,7 @@ from typing import TYPE_CHECKING
 from rich.prompt import Confirm
 from rich.tree import Tree
 
+from demo.learner import DemoLearner
 from demo.repl import console
 from vre.builtins.shell import parse_bash_primitives
 
@@ -72,7 +74,7 @@ def on_trace(grounding: "GroundingResult") -> None:
         for gap in grounding.gaps:
             tree.add(f"[yellow]⚠  {_gap_description(gap)}[/]")
         tree.add(
-            "[bold green]✓ Grounded at D3 — epistemic permission granted[/]"
+            "[bold green]✓ Grounded — epistemic permission granted[/]"
             if grounding.grounded
             else "[bold red]✗ Not grounded — action blocked[/]"
         )
@@ -115,7 +117,7 @@ def on_trace(grounding: "GroundingResult") -> None:
         tree.add(f"[yellow]⚠  {_gap_description(gap)}[/]")
 
     tree.add(
-        "[bold green]✓ Grounded at D3 — EPISTEMIC PERMISSION GRANTED[/]"
+        "[bold green]✓ Grounded — EPISTEMIC PERMISSION GRANTED[/]"
         if grounding.grounded
         else "[bold red]✗ Not grounded — COMMAND EXECUTION IS BLOCKED[/]"
     )
@@ -125,3 +127,10 @@ def on_trace(grounding: "GroundingResult") -> None:
 
 def on_policy(message: str) -> bool:
     return Confirm.ask(f"[yellow]⚠  Policy gate:[/] {message}")
+
+
+def make_on_learn(model: str = "qwen3:8b") -> DemoLearner:
+    """
+    Create a learning callback for the demo agent.
+    """
+    return DemoLearner(model=model)

--- a/demo/learner.py
+++ b/demo/learner.py
@@ -1,0 +1,335 @@
+"""
+Demo auto-learning module — meta-epistemic dialogue with the agent.
+
+Uses ChatOllama structured output to fill candidate templates, then
+presents proposals to the user via Rich for review.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import questionary
+from langchain_ollama import ChatOllama
+from rich.panel import Panel
+from rich.prompt import Confirm, Prompt
+
+from demo.repl import console
+from vre.learning.callback import LearningCallback
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    LearningCandidate,
+    ReachabilityCandidate,
+    RelationalCandidate,
+)
+
+if TYPE_CHECKING:
+    from vre.core.grounding.models import GroundingResult
+    from vre.core.models import KnowledgeGap
+
+
+# ---------------------------------------------------------------------------
+# System prompt
+# ---------------------------------------------------------------------------
+
+_LEARN_SYSTEM = """\
+You are a knowledge engineer for the Volute Reasoning Engine (VRE).
+VRE is an epistemic safety framework where knowledge is organized as
+conceptual primitives with depth levels:
+
+  D0 EXISTENCE  — does this concept exist?
+  D1 IDENTITY   — what is it, in principle?
+  D2 CAPABILITIES — what can it do / what can happen to it?
+  D3 CONSTRAINTS  — under what conditions does that hold?
+  D4+ IMPLICATIONS — what follows if it happens?
+
+Each depth carries `properties` — descriptive attributes intrinsic to
+the concept at that level. Properties describe what something IS, what
+it CAN DO, or what CONDITIONS apply to it. 
+
+You are given an epistemic trace showing the current state of the
+knowledge graph and a gap that needs to be filled. Propose knowledge
+to fill the gap based on the trace context and your understanding
+of the domain.
+
+CRITICAL:
+Relationships between concepts (edges) are separate graph structures managed by the engine;
+they are not properties.
+"""
+
+# ---------------------------------------------------------------------------
+# Per-gap-type prompts
+# ---------------------------------------------------------------------------
+
+_EXISTENCE_PROMPT = """\
+The concept '{name}' does not exist in the knowledge graph.
+
+Propose a D1 (IDENTITY) depth for this concept. D0 (EXISTENCE) will
+be created automatically. Fill in the `d1` field with level=1 and
+properties that describe what this concept is in principle — its
+intrinsic attributes as an entity.
+
+Epistemic trace:
+{trace}
+"""
+
+_DEPTH_PROMPT = """\
+The concept '{name}' exists but is only grounded to D{current} ({current_name}).
+It needs to be grounded to at least D{required} ({required_name}).
+
+Propose the missing depth levels. Fill in `new_depths` for each missing
+level between D{next_level} and D{required} inclusive. Each entry needs
+`level` (int) and `properties` — descriptive attributes intrinsic to the
+concept at that depth level.
+
+Existing depths:
+{existing}
+
+Epistemic trace:
+{trace}
+"""
+
+_RELATIONAL_PROMPT = """\
+The relationship from '{source}' to '{target}' requires '{target}' to be
+grounded to D{required} ({required_name}), but it is only at D{current} ({current_name}).
+
+Propose the missing depth levels for '{target}'. Fill in `new_depths` for
+each missing level. Each entry needs `level` (int) and `properties` —
+descriptive attributes intrinsic to '{target}' at that depth level.
+
+Existing depths on '{target}':
+{existing}
+
+Epistemic trace:
+{trace}
+"""
+
+_REACHABILITY_PROMPT = """\
+The concept '{source}' is not connected to other concepts in the subgraph.
+
+Available targets:
+{targets}
+
+Existing depths on '{source}':
+{source_depths}
+
+Propose an edge connecting '{source}' to one of the available targets.
+You MUST fill in ALL of the following fields:
+
+1. target_name — name of the target concept
+2. relation_type — one of: APPLIES_TO, REQUIRES, CONSTRAINED_BY, DEPENDS_ON, INCLUDES
+3. source_depth_level — int, which depth on '{source}' to place the edge at
+4. target_depth_level — int, the minimum depth required on the target for the edge to resolve
+
+Do NOT propose new depths. Focus only on edge placement. Any missing depths
+will be handled separately after the edge is placed.
+
+Epistemic trace:
+{trace}
+"""
+
+
+# ---------------------------------------------------------------------------
+# Formatting helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_existing_depths(primitive) -> str:
+    lines = []
+    for d in sorted(primitive.depths, key=lambda d: d.level):
+        props = ", ".join(f"{k}={v}" for k, v in d.properties.items()) if d.properties else "none"
+        lines.append(f"  D{d.level.value} {d.level.name}: {props}")
+    return "\n".join(lines) or "  (none)"
+
+
+def _fmt_available_targets(grounding: GroundingResult, source_id) -> str:
+    lines = []
+    if grounding.trace:
+        for p in grounding.trace.result.primitives:
+            if p.id == source_id:
+                continue
+            lines.append(f"  {p.name}:")
+            if p.depths:
+                for d in sorted(p.depths, key=lambda d: d.level):
+                    props = ", ".join(f"{k}={v}" for k, v in d.properties.items()) if d.properties else "none"
+                    lines.append(f"    D{d.level.value} {d.level.name}: {props}")
+            else:
+                lines.append("    (no depths)")
+    return "\n".join(lines) or "  (none)"
+
+
+def build_prompt(candidate: LearningCandidate, grounding: GroundingResult, gap) -> str:
+    """
+    Build the LLM prompt for a given gap type and candidate template.
+    """
+    trace = str(grounding)
+    if isinstance(candidate, ExistenceCandidate):
+        return _EXISTENCE_PROMPT.format(name=candidate.name, trace=trace)
+    if isinstance(candidate, DepthCandidate):
+        current = gap.current_depth.value if gap.current_depth is not None else -1
+        current_name = gap.current_depth.name if gap.current_depth is not None else "none"
+        next_level = current + 1
+        return _DEPTH_PROMPT.format(
+            name=gap.primitive.name,
+            current=current,
+            current_name=current_name,
+            required=gap.required_depth.value,
+            required_name=gap.required_depth.name,
+            next_level=next_level,
+            existing=_fmt_existing_depths(gap.primitive),
+            trace=trace,
+        )
+    if isinstance(candidate, RelationalCandidate):
+        current = gap.current_depth.value if gap.current_depth is not None else -1
+        current_name = gap.current_depth.name if gap.current_depth is not None else "none"
+        return _RELATIONAL_PROMPT.format(
+            source=gap.source.name,
+            target=gap.target.name,
+            required=gap.required_depth.value,
+            required_name=gap.required_depth.name,
+            current=current,
+            current_name=current_name,
+            existing=_fmt_existing_depths(gap.target),
+            trace=trace,
+        )
+    if isinstance(candidate, ReachabilityCandidate):
+        return _REACHABILITY_PROMPT.format(
+            source=gap.primitive.name,
+            targets=_fmt_available_targets(grounding, gap.primitive.id),
+            source_depths=_fmt_existing_depths(gap.primitive),
+            trace=trace,
+        )
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Candidate rendering
+# ---------------------------------------------------------------------------
+
+def render_candidate(candidate: LearningCandidate, gap) -> None:
+    """
+    Render a filled candidate to the console via Rich.
+    """
+    if isinstance(candidate, ExistenceCandidate):
+        console.print(Panel(
+            f"[bold]Concept:[/] {candidate.name}\n"
+            f"[bold]D1 Identity:[/] {candidate.d1.properties if candidate.d1 else '(empty)'}",
+            title="[bold yellow]Existence Proposal[/]",
+            border_style="yellow",
+        ))
+    elif isinstance(candidate, DepthCandidate):
+        depths_str = "\n".join(
+            f"  D{d.level.value} {d.level.name}: {d.properties}" for d in candidate.new_depths
+        ) or "  (none)"
+        console.print(Panel(
+            f"[bold]Concept:[/] {gap.primitive.name}\n"
+            f"[bold]New depths:[/]\n{depths_str}",
+            title="[bold yellow]Depth Proposal[/]",
+            border_style="yellow",
+        ))
+    elif isinstance(candidate, RelationalCandidate):
+        depths_str = "\n".join(
+            f"  D{d.level.value} {d.level.name}: {d.properties}" for d in candidate.new_depths
+        ) or "  (none)"
+        console.print(Panel(
+            f"[bold]Source:[/] {gap.source.name} → [bold]Target:[/] {gap.target.name}\n"
+            f"[bold]New depths on target:[/]\n{depths_str}",
+            title="[bold yellow]Relational Proposal[/]",
+            border_style="yellow",
+        ))
+    elif isinstance(candidate, ReachabilityCandidate):
+        console.print(Panel(
+            f"[bold]Source:[/] {gap.primitive.name}\n"
+            f"[bold]Target:[/] {candidate.target_name or '(none)'}\n"
+            f"[bold]Relation:[/] {candidate.relation_type.value if candidate.relation_type else '(none)'}\n"
+            f"[bold]Source depth:[/] D{candidate.source_depth_level.value if candidate.source_depth_level else '?'}\n"
+            f"[bold]Target depth:[/] D{candidate.target_depth_level.value if candidate.target_depth_level else '?'}\n\n"
+            f"[dim italic]Edge placement is a safety-critical decision. The depth at which an edge\n"
+            f"is placed determines when an agent can reason about this relationship.\n"
+            f"If this concept should NOT be connected — if the absence of this edge is\n"
+            f"itself an enforcement mechanism — choose Skip.[/]",
+            title="[bold yellow]Reachability Proposal[/]",
+            border_style="yellow",
+        ))
+
+
+# ---------------------------------------------------------------------------
+# DemoLearner — the callback implementation
+# ---------------------------------------------------------------------------
+
+class DemoLearner(LearningCallback):
+    """
+    Learning callback that uses ChatOllama to fill candidate templates
+    and presents them to the user for review via Rich.
+
+    Flow: agent proposes → user reviews → accept/modify/skip/reject.
+    If the user requests modifications, the agent re-proposes with feedback
+    until the user is satisfied.
+    """
+
+    def __init__(self, model: str = "qwen3:8b") -> None:
+        self._model = model
+        self._active = False
+
+    def __enter__(self) -> DemoLearner:
+        self._active = False
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        self._active = False
+
+    def _invoke_llm(
+        self,
+        candidate: LearningCandidate,
+        messages: list[dict[str, str]],
+    ) -> LearningCandidate:
+        llm = ChatOllama(model=self._model).with_structured_output(type(candidate))
+        return llm.invoke(messages)
+
+    def __call__(
+        self,
+        candidate: LearningCandidate,
+        grounding: GroundingResult,
+        gap: KnowledgeGap,
+    ) -> tuple[LearningCandidate | None, CandidateDecision]:
+
+        if not self._active:
+            if not Confirm.ask("\n[bold cyan]Knowledge gap detected.[/] Enter learning mode?"):
+                return None, CandidateDecision.REJECTED
+            self._active = True
+
+        messages = [
+            {"role": "system", "content": _LEARN_SYSTEM},
+            {"role": "user", "content": build_prompt(candidate, grounding, gap)},
+        ]
+
+        console.print("\n[dim]Agent is proposing knowledge...[/]")
+        filled = self._invoke_llm(candidate, messages)
+        render_candidate(filled, gap)
+
+        was_modified = False
+        while True:
+            choice = questionary.select(
+                "Decision:",
+                choices=["accept", "modify", "skip", "reject"],
+                default="accept",
+            ).ask()
+
+            if choice is None:  # Ctrl-C
+                return None, CandidateDecision.REJECTED
+            if choice == "accept":
+                decision = CandidateDecision.MODIFIED if was_modified else CandidateDecision.ACCEPTED
+                return filled, decision
+            if choice == "skip":
+                return None, CandidateDecision.SKIPPED
+            if choice == "reject":
+                return None, CandidateDecision.REJECTED
+            if choice == "modify":
+                was_modified = True
+                messages.append({"role": "assistant", "content": filled.model_dump_json()})
+                feedback = Prompt.ask("[bold]What should be changed?[/]")
+                messages.append({"role": "user", "content": feedback})
+                console.print("\n[dim]Agent is revising...[/]")
+                filled = self._invoke_llm(candidate, messages)
+                render_candidate(filled, gap)

--- a/demo/main.py
+++ b/demo/main.py
@@ -16,7 +16,7 @@ from vre import VRE
 from vre.core.graph import PrimitiveRepository
 
 from demo.agent import make_agent
-from demo.callbacks import get_concepts, get_cardinality, on_policy, on_trace
+from demo.callbacks import get_concepts, get_cardinality, make_on_learn, on_policy, on_trace
 from demo.repl import run
 from demo.tools import init_tools
 
@@ -26,7 +26,7 @@ def main() -> None:
     parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
     parser.add_argument("--neo4j-user", default="neo4j")
     parser.add_argument("--neo4j-password", default="password")
-    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--model", default="qwen3.5:latest")
     parser.add_argument("--sandbox", default="demo/workspace")
     args = parser.parse_args()
 
@@ -35,13 +35,15 @@ def main() -> None:
     repo = PrimitiveRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
     vre = VRE(repo)
 
+    on_learn = make_on_learn(model=args.model)
     shell_fn = init_tools(
         vre,
         args.sandbox,
         get_concepts,
         get_cardinality,
         on_trace,
-        on_policy
+        on_policy,
+        on_learn,
     )
     shell_tool = StructuredTool.from_function(
         shell_fn,

--- a/demo/tools.py
+++ b/demo/tools.py
@@ -17,6 +17,7 @@ def init_tools(
     cardinality: Callable,
     on_trace: Callable,
     on_policy: Callable,
+    on_learn: Callable | None = None,
 ):
     @vre_guard(
         vre,
@@ -24,6 +25,7 @@ def init_tools(
         cardinality=cardinality,
         on_trace=on_trace,
         on_policy=on_policy,
+        on_learn=on_learn,
     )
     def shell_tool(command: str) -> str:
         """Execute a shell command inside the sandbox directory."""

--- a/docs/index.html
+++ b/docs/index.html
@@ -874,7 +874,10 @@ const NODES = [
           Each <code>vre_guard</code> call follows a strict sequence:
           <strong>resolve</strong> concept names to canonical primitives →
           <strong>ground</strong> the subgraph against depth requirements → fire
-          <strong>on_trace</strong> with the result → if not grounded,
+          <strong>on_trace</strong> with the result → if not grounded and
+          <strong>on_learn</strong> is provided, enter the
+          <strong>learning loop</strong> to resolve gaps → re-ground and fire
+          <strong>on_trace</strong> again → if still not grounded,
           <strong>block</strong> and return gaps → evaluate
           <strong>policies</strong> on APPLIES_TO relata → if PENDING, call
           <strong>on_policy</strong> for human confirmation → if approved,
@@ -947,8 +950,10 @@ const NODES = [
           &nbsp;&nbsp;&nbsp;&nbsp;vre,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="cc"># VRE instance</span><br>
           &nbsp;&nbsp;&nbsp;&nbsp;concepts,&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="cc"># list[str] | Callable → list[str]</span><br>
           &nbsp;&nbsp;&nbsp;&nbsp;cardinality=<span class="ck">None</span>,&nbsp;<span class="cc"># str | Callable → str | None</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;min_depth=<span class="ck">None</span>,&nbsp;&nbsp;&nbsp;<span class="cc"># DepthLevel | None — floor override</span><br>
           &nbsp;&nbsp;&nbsp;&nbsp;on_trace=<span class="ck">None</span>,&nbsp;&nbsp;&nbsp;&nbsp;<span class="cc"># Callable[[GroundingResult], None]</span><br>
           &nbsp;&nbsp;&nbsp;&nbsp;on_policy=<span class="ck">None</span>,&nbsp;&nbsp;&nbsp;<span class="cc"># Callable[[str], bool]</span><br>
+          &nbsp;&nbsp;&nbsp;&nbsp;on_learn=<span class="ck">None</span>,&nbsp;&nbsp;&nbsp;&nbsp;<span class="cc"># LearningCallback | None</span><br>
           )
         </div>
         <ul style="margin-left:0.8rem">
@@ -963,6 +968,9 @@ const NODES = [
           </li>
           <li>
               <strong>on_policy</strong> — called when a policy gate requires human confirmation.
+          </li>
+          <li>
+            <strong>on_learn</strong> — a <code>LearningCallback</code> that enables the auto-learning loop when grounding fails.
           </li>
         </ul>
         <div class="code-block">
@@ -1017,7 +1025,7 @@ const NODES = [
           </div>
           <div>
             <span class="td2">└──</span>
-            <span class="tg">✓ Grounded at D3 — EPISTEMIC PERMISSION GRANTED</span>
+            <span class="tg">✓ Grounded — EPISTEMIC PERMISSION GRANTED</span>
           </div>
         </div>
         <p style="margin-top:1.5rem;margin-bottom:0.5rem">
@@ -1043,6 +1051,108 @@ const NODES = [
     }
   },
   {
+    id: 'learning',
+    label: 'LEARNING',
+    ring: 2,
+    color: { r: 240, g: 197, b: 77 },
+    hex: '#F0C54D',
+    threeColor: 0xF0C54D,
+    content: {
+      depth: 'LEARNING',
+      title: 'Ignorance is surfaced. Knowledge is earned.',
+      body: `
+        <p>
+          When grounding fails, VRE does not simply block the agent. It surfaces
+          <strong>structured knowledge gaps</strong> that describe exactly what is
+          missing. The auto-learning loop turns these gaps into proposals that a
+          human reviews before anything enters the graph.
+        </p>
+        <p style="margin-top:1.5rem;margin-bottom:0.5rem">
+          <strong style="color:var(--tb);font-family:'JetBrains Mono',monospace;font-size:0.65rem;letter-spacing:0.1rem">
+            THE LEARNING LOOP
+          </strong>
+        </p>
+        <p>
+          Each gap type produces a <strong>candidate template</strong> that an
+          agent fills in. The human reviews, modifies, or rejects the proposal.
+          Accepted candidates are persisted with provenance tracking.
+        </p>
+        <div style="margin:0.8rem 0 1.2rem">
+          <div class="depth-row">
+            <div class="depth-indicator d0">1</div>
+            <div class="depth-text">
+              <div class="depth-label">GAP DETECTED</div>
+              <div class="depth-question">Grounding fails → structured gap surfaced</div>
+            </div>
+          </div>
+          <div class="depth-row">
+            <div class="depth-indicator d1">2</div>
+            <div class="depth-text">
+              <div class="depth-label">TEMPLATE CREATED</div>
+              <div class="depth-question">Engine builds a candidate from the gap type</div>
+            </div>
+          </div>
+          <div class="depth-row">
+            <div class="depth-indicator d2">3</div>
+            <div class="depth-text">
+              <div class="depth-label">AGENT PROPOSES</div>
+              <div class="depth-question">LLM fills the template with domain knowledge</div>
+            </div>
+          </div>
+          <div class="depth-row">
+            <div class="depth-indicator d3">4</div>
+            <div class="depth-text">
+              <div class="depth-label">HUMAN REVIEWS</div>
+              <div class="depth-question">Accept, modify, skip, or reject the proposal</div>
+            </div>
+          </div>
+        </div>
+        <p style="margin-top:1.5rem;margin-bottom:0.5rem">
+          <strong style="color:var(--tb);font-family:'JetBrains Mono',monospace;font-size:0.65rem;letter-spacing:0.1rem">
+            CANDIDATE TYPES
+          </strong>
+        </p>
+        <ul style="margin-left:0.8rem">
+          <li>
+            <strong>ExistenceCandidate</strong> — concept not in graph. Agent proposes D1 (identity); D0 is auto-generated on acceptance.
+          </li>
+          <li>
+            <strong>DepthCandidate</strong> — concept exists but is too shallow. Proposes missing depths.
+          </li>
+          <li>
+            <strong>RelationalCandidate</strong> — relatum target is under-grounded. Proposes depths on target.
+          </li>
+          <li>
+            <strong>ReachabilityCandidate</strong> — concept is disconnected. Proposes edge placement.
+          </li>
+        </ul>
+        <p style="margin-top:1.5rem;margin-bottom:0.5rem">
+          <strong style="color:var(--tb);font-family:'JetBrains Mono',monospace;font-size:0.65rem;letter-spacing:0.1rem">
+            TWO-PHASE EDGE PLACEMENT
+          </strong>
+        </p>
+        <p>
+          When a reachability gap is resolved by placing an edge, the engine
+          checks whether the source and target have the required depths. If not,
+          it synthesizes <code>DepthGap</code>s and invokes the learning callback
+          for each missing depth <strong>before</strong> placing the edge. The
+          agent cannot connect concepts it does not yet understand.
+        </p>
+        <p style="margin-top:1.5rem;margin-bottom:0.5rem">
+          <strong style="color:var(--tb);font-family:'JetBrains Mono',monospace;font-size:0.65rem;letter-spacing:0.1rem">
+            PROVENANCE
+          </strong>
+        </p>
+        <p>
+          Every piece of learned knowledge carries structured provenance.
+          Accepted proposals are marked <code>learned</code>. Modified proposals
+          are marked <code>conversational</code>. The graph remembers not just
+          what it knows, but <strong>how it came to know it</strong>.
+        </p>
+      `
+    }
+  },
+  {
     id: 'roadmap',
     label: 'ROADMAP',
     ring: 3,
@@ -1056,17 +1166,12 @@ const NODES = [
         <div class="roadmap-item">
           <div class="roadmap-name">LEARNING THROUGH FAILURE</div>
           <p class="roadmap-desc">
-            When a mechanical failure reveals a constraint that was not modeled,
-            the agent proposes the missing relatum. Humans validate. The graph
-            grows through contact with reality.
-          </p>
-        </div>
-        <div class="roadmap-item">
-          <div class="roadmap-name">META-EPISTEMIC DISCUSSION</div>
-          <p class="roadmap-desc">
-            Structured conversation about the agent's epistemic state: asking
-            why a concept is unknown, providing domain knowledge, or refining
-            relata through dialogue.
+            Pre-execution learning is implemented. The next frontier is
+            <strong>post-execution</strong> learning: when a fully grounded
+            action fails mechanically (e.g. permission denied), the failure
+            reveals a constraint that was not modeled. The agent proposes the
+            missing relatum. Humans validate. The graph grows through contact
+            with reality.
           </p>
         </div>
         <div class="roadmap-item">
@@ -1370,13 +1475,15 @@ const outerGlowParticles = new THREE.Points(outerGlowGeo, outerGlowMat);
 voluteGroup.add(outerGlowParticles);
 
 // ─────────────── NAV NODE SPHERES ───────────────
+const navNodesGroup = new THREE.Group();
+scene.add(navNodesGroup);
 const nodeMeshes = [];
 const nodePositions = [];
 
 // Map nodes to positions on the spiral based on ring
 NODES.forEach((node, i) => {
   // Distribute along the spiral
-  const angles = [0.88, 0.72, 0.55, 0.4, 0.24, 0.08];
+  const angles = [0.93, 0.79, 0.65, 0.51, 0.24, 0.38, 0.08];
   const t = angles[i] || (i / NODES.length);
   const idx = Math.floor(t * (volutePoints.length - 1));
   const pt = volutePoints[idx];
@@ -1393,7 +1500,7 @@ NODES.forEach((node, i) => {
   });
   const glowMesh = new THREE.Mesh(glowGeo, glowMat);
   glowMesh.position.copy(pos);
-  voluteGroup.add(glowMesh);
+  navNodesGroup.add(glowMesh);
 
   // Inner glow — tighter, brighter halo
   const glow2Geo = new THREE.SphereGeometry(0.18, 32, 32);
@@ -1405,7 +1512,7 @@ NODES.forEach((node, i) => {
   });
   const glow2Mesh = new THREE.Mesh(glow2Geo, glow2Mat);
   glow2Mesh.position.copy(pos);
-  voluteGroup.add(glow2Mesh);
+  navNodesGroup.add(glow2Mesh);
 
   // Ring
   const ringGeo = new THREE.RingGeometry(0.15, 0.17, 32);
@@ -1417,7 +1524,7 @@ NODES.forEach((node, i) => {
   });
   const ringMesh = new THREE.Mesh(ringGeo, ringMat);
   ringMesh.position.copy(pos);
-  voluteGroup.add(ringMesh);
+  navNodesGroup.add(ringMesh);
 
   // Core sphere
   const geo = new THREE.SphereGeometry(0.09, 32, 32);
@@ -1429,7 +1536,7 @@ NODES.forEach((node, i) => {
   const mesh = new THREE.Mesh(geo, mat);
   mesh.position.copy(pos);
   mesh.userData = { nodeIndex: i, glowMesh, glow2Mesh, ringMesh };
-  voluteGroup.add(mesh);
+  navNodesGroup.add(mesh);
   nodeMeshes.push(mesh);
 
   // Inner bright dot
@@ -1437,7 +1544,7 @@ NODES.forEach((node, i) => {
   const dotMat = new THREE.MeshBasicMaterial({ color: 0xffffff, transparent: true, opacity: 0.5 });
   const dot = new THREE.Mesh(dotGeo, dotMat);
   dot.position.copy(pos);
-  voluteGroup.add(dot);
+  navNodesGroup.add(dot);
 });
 
 // ─────────────── 3D DETAIL VOLUTE ───────────────
@@ -1627,6 +1734,9 @@ function navigateToNode(index) {
   voluteGroup.children.forEach(child => {
     if (child.material) child.material._baseOpacityStored = child.material.opacity;
   });
+  navNodesGroup.children.forEach(child => {
+    if (child.material) child.material._baseOpacityStored = child.material.opacity;
+  });
 
   // Single continuous camera sweep: start → waypoint near node → final detail position
   const startPos = { x: camera.position.x, y: camera.position.y, z: camera.position.z };
@@ -1708,6 +1818,11 @@ function navigateToNode(index) {
           child.material.opacity = child.material._baseOpacityStored * (1 - cfEase);
         }
       });
+      navNodesGroup.children.forEach(child => {
+        if (child.material && child.material._baseOpacityStored !== undefined) {
+          child.material.opacity = child.material._baseOpacityStored * (1 - cfEase);
+        }
+      });
 
       detailVoluteGroup.children.forEach(child => {
         if (child.material && child.material._targetOpacity !== undefined) {
@@ -1743,7 +1858,14 @@ function navigateToNode(index) {
         });
       }
       voluteGroup.visible = false;
+      navNodesGroup.visible = false;
       voluteGroup.children.forEach(child => {
+        if (child.material && child.material._baseOpacityStored !== undefined) {
+          child.material.opacity = child.material._baseOpacityStored;
+          delete child.material._baseOpacityStored;
+        }
+      });
+      navNodesGroup.children.forEach(child => {
         if (child.material && child.material._baseOpacityStored !== undefined) {
           child.material.opacity = child.material._baseOpacityStored;
           delete child.material._baseOpacityStored;
@@ -1772,6 +1894,7 @@ function returnToOverview() {
   // Small delay for panel fade-out, then one smooth sweep back
   setTimeout(() => {
     voluteGroup.visible = true;
+    navNodesGroup.visible = true;
 
     // Store detail opacities for crossfade
     detailVoluteGroup.children.forEach(child => {
@@ -1779,6 +1902,14 @@ function returnToOverview() {
     });
     // Reset overview opacities to 0 for fade-in
     voluteGroup.children.forEach(child => {
+      if (child.material) {
+        if (child.material._baseOpacityStored === undefined) {
+          child.material._baseOpacityStored = child.material.opacity;
+        }
+        child.material.opacity = 0;
+      }
+    });
+    navNodesGroup.children.forEach(child => {
       if (child.material) {
         if (child.material._baseOpacityStored === undefined) {
           child.material._baseOpacityStored = child.material.opacity;
@@ -1835,6 +1966,11 @@ function returnToOverview() {
             child.material.opacity = child.material._baseOpacityStored * cfEase;
           }
         });
+        navNodesGroup.children.forEach(child => {
+          if (child.material && child.material._baseOpacityStored !== undefined) {
+            child.material.opacity = child.material._baseOpacityStored * cfEase;
+          }
+        });
       }
 
       // Gradually fade overview UI back in over the final stretch
@@ -1879,6 +2015,12 @@ function returnToOverview() {
 
         detailVoluteGroup.visible = false;
         voluteGroup.children.forEach(child => {
+          if (child.material && child.material._baseOpacityStored !== undefined) {
+            child.material.opacity = child.material._baseOpacityStored;
+            delete child.material._baseOpacityStored;
+          }
+        });
+        navNodesGroup.children.forEach(child => {
           if (child.material && child.material._baseOpacityStored !== undefined) {
             child.material.opacity = child.material._baseOpacityStored;
             delete child.material._baseOpacityStored;
@@ -1978,6 +2120,7 @@ function animate() {
   // Breathing scale
   const breathScale = 1 + Math.sin(elapsed * 0.8) * 0.012 + Math.sin(elapsed * 1.3) * 0.006;
   voluteGroup.scale.set(breathScale, breathScale, breathScale);
+  navNodesGroup.scale.set(breathScale, breathScale, breathScale);
 
   // Mouse parallax
   if (!cameraAnimating && state.mode === 'overview') {
@@ -2093,7 +2236,7 @@ function animate() {
   if (state.mode === 'overview' || (state.transitioning && voluteGroup.visible)) {
     nodeLabels.forEach((label, i) => {
       const pos = nodePositions[i].clone();
-      pos.applyMatrix4(voluteGroup.matrixWorld);
+      pos.applyMatrix4(navNodesGroup.matrixWorld);
       pos.project(camera);
 
       const x = (pos.x * 0.5 + 0.5) * window.innerWidth;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.2.0"
+version = "0.3.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}
@@ -18,6 +18,7 @@ demo = [
     "rich>=14.3.2",
     "langchain-core>=1.2.16",
     "langchain-ollama>=1.0.1",
+    "questionary (>=2.1.1,<3.0.0)"
 ]
 
 [tool.poetry]

--- a/scripts/seed_all.py
+++ b/scripts/seed_all.py
@@ -1141,7 +1141,7 @@ def main(repository: PrimitiveRepository) -> None:
             ),
         ])
         repo.save_primitive(filesystem)
-        print(f"Updated: filesystem with INCLUDES relata")
+        print("Updated: filesystem with INCLUDES relata")
 
         # Add APPLIES_TO relata to permission now that user, group, and action
         # primitives exist. Permission's D2 (CAPABILITIES) applies to actor types
@@ -1226,7 +1226,7 @@ def main(repository: PrimitiveRepository) -> None:
             ),
         ])
         repo.save_primitive(permission)
-        print(f"Updated: permission with APPLIES_TO relata")
+        print("Updated: permission with APPLIES_TO relata")
 
         # Add CONSTRAINED_BY relata to action primitives at D3 (CONSTRAINTS).
         # read, write, delete, and create all state permission constraints in
@@ -1245,7 +1245,7 @@ def main(repository: PrimitiveRepository) -> None:
                 )
             )
             repo.save_primitive(action_prim)
-        print(f"Updated: read, write, delete, create with CONSTRAINED_BY permission at D3")
+        print("Updated: read, write, delete, create with CONSTRAINED_BY permission at D3")
 
         list_constraints = next(d for d in list_prim.depths if d.level == DepthLevel.CONSTRAINTS)
         list_constraints.relata.append(
@@ -1260,7 +1260,7 @@ def main(repository: PrimitiveRepository) -> None:
             )
         )
         repo.save_primitive(list_prim)
-        print(f"Updated: list with CONSTRAINED_BY permission at D3")
+        print("Updated: list with CONSTRAINED_BY permission at D3")
 
         move_constraints = next(d for d in move.depths if d.level == DepthLevel.CONSTRAINTS)
         move_constraints.relata.append(
@@ -1277,7 +1277,7 @@ def main(repository: PrimitiveRepository) -> None:
             )
         )
         repo.save_primitive(move)
-        print(f"Updated: move with CONSTRAINED_BY permission at D3")
+        print("Updated: move with CONSTRAINED_BY permission at D3")
 
         copy_constraints = next(d for d in copy.depths if d.level == DepthLevel.CONSTRAINTS)
         copy_constraints.relata.append(
@@ -1294,7 +1294,7 @@ def main(repository: PrimitiveRepository) -> None:
             )
         )
         repo.save_primitive(copy)
-        print(f"Updated: copy with CONSTRAINED_BY permission at D3")
+        print("Updated: copy with CONSTRAINED_BY permission at D3")
 
         print("\nDone. Seeded 15 primitives.")
 

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -77,7 +77,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
         ],
     )
     repo.save_primitive(os_prim)
-    print(f"  operating_system  D0–D3  (substrate)")
+    print("  operating_system  D0–D3  (substrate)")
     return os_prim
 
 
@@ -144,7 +144,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(filesystem)
-    print(f"  filesystem        D0–D3  (substrate)")
+    print("  filesystem        D0–D3  (substrate)")
     return filesystem
 
 
@@ -208,7 +208,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(path)
-    print(f"  path              D0–D3  (structural)")
+    print("  path              D0–D3  (structural)")
     return path
 
 
@@ -276,7 +276,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(permission)
-    print(f"  permission        D0–D3  (structural)")
+    print("  permission        D0–D3  (structural)")
     return permission
 
 
@@ -370,7 +370,7 @@ def seed_directory(
         ],
     )
     repo.save_primitive(directory)
-    print(f"  directory         D0–D3  (entity, fully grounded)")
+    print("  directory         D0–D3  (entity, fully grounded)")
     return directory
 
 
@@ -409,7 +409,7 @@ def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(file)
-    print(f"  file              D0–D1  (shallow → RelationalGap when targeted at D2)")
+    print("  file              D0–D1  (shallow → RelationalGap when targeted at D2)")
     return file
 
 
@@ -462,7 +462,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(read)
-    print(f"  read              D0–D2  (safe action, APPLIES_TO@D2 → file)")
+    print("  read              D0–D2  (safe action, APPLIES_TO@D2 → file)")
     return read
 
 
@@ -514,7 +514,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
         ],
     )
     repo.save_primitive(list_prim)
-    print(f"  list              D0–D2  (safe action, APPLIES_TO@D2 → directory)")
+    print("  list              D0–D2  (safe action, APPLIES_TO@D2 → directory)")
     return list_prim
 
 
@@ -559,7 +559,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
         ],
     )
     repo.save_primitive(delete)
-    print(f"  delete            D0–D2  (destructive, APPLIES_TO@D3 omitted → ReachabilityGap)")
+    print("  delete            D0–D2  (destructive, APPLIES_TO@D3 omitted → ReachabilityGap)")
     return delete
 
 
@@ -619,7 +619,7 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
         ],
     )
     repo.save_primitive(create)
-    print(f"  create            D0–D1+D3  (destructive, APPLIES_TO@D3 gated — D2 missing)")
+    print("  create            D0–D1+D3  (destructive, APPLIES_TO@D3 gated — D2 missing)")
     return create
 
 
@@ -645,10 +645,10 @@ def main(repository: PrimitiveRepository) -> None:
         file = seed_file(repo, path)
 
         # Actions
-        read = seed_read(repo, file)
-        list_prim = seed_list(repo, directory)
-        delete = seed_delete(repo, file, directory)
-        create = seed_create(repo, file, directory)
+        seed_read(repo, file)
+        seed_list(repo, directory)
+        seed_delete(repo, file, directory)
+        seed_create(repo, file, directory)
 
         # Add INCLUDES relata to filesystem now that file and directory exist.
         fs_caps = next(d for d in filesystem.depths if d.level == DepthLevel.CAPABILITIES)
@@ -667,7 +667,7 @@ def main(repository: PrimitiveRepository) -> None:
             ),
         ])
         repo.save_primitive(filesystem)
-        print(f"\n  Updated: filesystem with INCLUDES → file, directory")
+        print("\n  Updated: filesystem with INCLUDES → file, directory")
 
         print("""
 Done. Seeded 10 primitives.

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -21,6 +21,13 @@ from vre.core.models import DepthLevel, Provenance, ProvenanceSource
 from vre.core.policy import Cardinality, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
+from vre.learning import (
+    CandidateDecision,
+    LearningCallback,
+    LearningCandidate,
+    LearningEngine,
+    LearningResult,
+)
 
 __all__ = [
     "VRE",
@@ -35,6 +42,11 @@ __all__ = [
     "PolicyResult",
     "PolicyCallContext",
     "PolicyGate",
+    "CandidateDecision",
+    "LearningCallback",
+    "LearningCandidate",
+    "LearningEngine",
+    "LearningResult",
 ]
 
 
@@ -51,8 +63,10 @@ class VRE:
         """
         Initialize VRE with the given primitive repository.
         """
+        self._repo = repository
         self._resolver = ConceptResolver(repository)
         self._engine = GroundingEngine(repository)
+        self._learning_engine = LearningEngine(repository)
 
     def resolve(self, concepts: list[str]) -> list[str]:
         """
@@ -78,6 +92,40 @@ class VRE:
             on all root primitives. Can only raise the floor, never lower it.
         """
         return self._engine.ground(concepts, self._resolver, min_depth=min_depth)
+
+    def learn_all(
+        self,
+        grounding: GroundingResult,
+        callback: LearningCallback,
+        concepts: list[str],
+        min_depth: DepthLevel | None = None,
+    ) -> GroundingResult:
+        """
+        Iteratively resolve all gaps via the learning loop.
+
+        Processes one gap at a time, re-grounding after each accepted/modified
+        candidate. Skipped gaps are excluded from subsequent rounds (the user
+        has acknowledged them). Rejected gaps stop the loop entirely.
+        Returns the final GroundingResult.
+        """
+        skipped: set[int] = set()
+        with callback:
+            while not grounding.grounded and grounding.gaps:
+                gap_index = next(
+                    (i for i, g in enumerate(grounding.gaps) if i not in skipped),
+                    None,
+                )
+                if gap_index is None:
+                    break
+                result = self._learning_engine.learn_at(grounding, gap_index, callback)
+                if result.decision == CandidateDecision.REJECTED:
+                    break
+                if result.decision == CandidateDecision.SKIPPED:
+                    skipped.add(gap_index)
+                    continue
+                grounding = self.check(concepts, min_depth=min_depth)
+                skipped.clear()
+        return grounding
 
     def check_policy(
         self,

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -204,8 +204,10 @@ class GroundingEngine:
                 continue
             curr = GroundingEngine._contiguous_max_depth(tgt_prim)
             gaps.append(RelationalGap(
-                source=src_prim, target=tgt_prim,
-                required_depth=max_req, current_depth=curr,
+                source=src_prim,
+                target=tgt_prim,
+                required_depth=max_req,
+                current_depth=curr,
             ))
 
         return gaps
@@ -292,17 +294,21 @@ class GroundingEngine:
         )
 
         # Undirected connectivity check across all non-transient roots
-        # using only visible edges
+        # using only visible edges. Anchor on the root with the largest
+        # reachable component so truly isolated nodes get reported.
         non_transient_roots = [r for r in roots if r.id not in transient_ids]
         if len(non_transient_roots) > 1:
             neighbors: dict[UUID, set[UUID]] = {}
             for edge in visible_edges:
                 neighbors.setdefault(edge.source_id, set()).add(edge.target_id)
                 neighbors.setdefault(edge.target_id, set()).add(edge.source_id)
-            anchor = non_transient_roots[0]
+            anchor = max(
+                non_transient_roots,
+                key=lambda r: len(self._reachable_undirected(r.id, neighbors)),
+            )
             reachable = self._reachable_undirected(anchor.id, neighbors)
-            for root in non_transient_roots[1:]:
-                if root.id not in reachable:
+            for root in non_transient_roots:
+                if root.id != anchor.id and root.id not in reachable:
                     gaps.append(ReachabilityGap(primitive=root))
 
         filtered = self._filter_depths(all_nodes)

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -37,6 +37,7 @@ from vre.core.policy.callback import PolicyCallContext
 if TYPE_CHECKING:
     from vre import VRE
     from vre.core.grounding import GroundingResult
+    from vre.learning.callback import LearningCallback
 
 # `concepts` and `cardinality` may be static values or callables that receive
 # the same (*args, **kwargs) as the decorated function and return the value
@@ -52,6 +53,7 @@ def vre_guard(
     min_depth: DepthLevel | None = None,
     on_trace: Callable[["GroundingResult"], None] | None = None,
     on_policy: Callable[[str], bool] | None = None,
+    on_learn: "LearningCallback | None" = None,
 ) -> Callable:
     """
     Decorator that gates a function behind VRE grounding and policy checks.
@@ -76,6 +78,12 @@ def vre_guard(
     on_policy:
         Optional callback called with the confirmation message when a policy
         requires confirmation. Should return True to proceed, False to block.
+    on_learn:
+        Optional learning callback invoked when grounding fails. Enters the
+        auto-learning loop: surfaces gap templates, collects agent/user
+        responses, persists accepted candidates, and re-grounds iteratively.
+        When absent, ungrounded results are returned immediately (existing
+        behaviour).
     """
     def decorator(fn: Callable) -> Callable:
         """
@@ -86,38 +94,49 @@ def vre_guard(
         @functools.wraps(fn)
         def wrapped(*args, **kwargs):
             """
-            Run grounding → policy → execution on each call.
+            Run grounding → learning [optional] → policy → execution on each call.
             """
             resolved_concepts = concepts(*args, **kwargs) if callable(concepts) else concepts
             grounding = vre.check(resolved_concepts, min_depth=min_depth)
             if on_trace:
                 on_trace(grounding)
 
+            if not grounding.grounded and on_learn:
+                grounding = vre.learn_all(grounding, on_learn, resolved_concepts, min_depth=min_depth)
+                if on_trace:
+                    on_trace(grounding)
+
             if not grounding.grounded:
-                return grounding
+                result = grounding
+            else:
+                # Policy evaluation
+                resolved_cardinality = (
+                    cardinality(*args, **kwargs) if callable(cardinality) else cardinality
+                )
+                context = PolicyCallContext(
+                    tool_name=tool_name,
+                    grounding=grounding,
+                    call_args=args,
+                    call_kwargs=kwargs,
+                )
 
-            resolved_cardinality = (
-                cardinality(*args, **kwargs) if callable(cardinality) else cardinality
-            )
-            context = PolicyCallContext(
-                tool_name=tool_name,
-                grounding=grounding,
-                call_args=args,
-                call_kwargs=kwargs,
-            )
+                policy = vre.check_policy(grounding, resolved_cardinality, context)
 
-            policy = vre.check_policy(grounding, resolved_cardinality, context)
-            if policy.action == "PENDING":
-                if on_policy:
-                    if not on_policy(policy.confirmation_message or ""):
-                        return PolicyResult(action="BLOCK", reason="User declined")
-                else:
-                    return PolicyResult(
-                        action="BLOCK", reason="Confirmation required, no handler"
-                    )
-            if policy.action == "BLOCK":
-                return policy
-            return fn(*args, **kwargs)
+                match policy.action:
+                    case "PENDING":
+                        if on_policy:
+                            if on_policy(policy.confirmation_message or ""):
+                                result = fn(*args, **kwargs)
+                            else:
+                                result = PolicyResult(action="BLOCK", reason="User declined")
+                        else:
+                            result = PolicyResult(action="BLOCK", reason="Confirmation required, no handler")
+                    case "BLOCK":
+                        result = policy
+                    case _:
+                        result = fn(*args, **kwargs)
+
+            return result
 
         wrapped._vre_concepts = concepts  # type: ignore[attr-defined]
         return wrapped

--- a/src/vre/learning/__init__.py
+++ b/src/vre/learning/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+from vre.learning.callback import LearningCallback
+from vre.learning.engine import LearningEngine
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    LearningCandidate,
+    LearningResult,
+    ProposedDepth,
+    ReachabilityCandidate,
+    RelationalCandidate,
+)
+
+__all__ = [
+    "CandidateDecision",
+    "DepthCandidate",
+    "ExistenceCandidate",
+    "LearningCallback",
+    "LearningCandidate",
+    "LearningEngine",
+    "LearningResult",
+    "ProposedDepth",
+    "ReachabilityCandidate",
+    "RelationalCandidate",
+]

--- a/src/vre/learning/callback.py
+++ b/src/vre/learning/callback.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+LearningCallback — the integrator-facing contract for the learning loop.
+
+The callback receives a structured candidate template, the full GroundingResult,
+and the specific gap being addressed. It returns the (possibly modified) candidate
+and a decision. Provenance is derived from the decision by the engine, not set by
+the callback.
+
+Integrators decide:
+- Whether to prompt "enter learning mode?" before invoking the callback
+- What UI to present for each gap type
+- Whether learning is available at all (organizational policy)
+
+Example::
+
+    from vre.learning.callback import LearningCallback
+    from vre.learning.models import LearningCandidate, CandidateDecision
+
+    class InteractiveLearner(LearningCallback):
+        def __call__(
+            self,
+            candidate: LearningCandidate,
+            grounding: GroundingResult,
+            gap: KnowledgeGap,
+        ) -> tuple[LearningCandidate | None, CandidateDecision]:
+            # Present candidate to user, collect decision
+            ...
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from vre.core.grounding.models import GroundingResult
+from vre.core.models import KnowledgeGap
+from vre.learning.models import CandidateDecision, LearningCandidate
+
+
+class LearningCallback(ABC):
+    """
+    Abstract base class for learning loop callbacks.
+
+    A callback receives a candidate template, the full GroundingResult for context,
+    and the specific gap being addressed.
+
+    Lifecycle:
+      - `__enter__` is called at the start of a learning session (one
+        `learn_all` invocation). Use it to acquire resources or set state.
+      - `__exit__` is called when the session ends. Use it to clean up.
+      - The callback is used as a context manager by `learn_all`::
+
+            with on_learn:
+                # engine invokes on_learn(...) for each gap
+
+      Default implementations are no-ops — override only if your callback
+      needs session lifecycle management.
+
+    Returns:
+      - (candidate, ACCEPTED) — persist as proposed, provenance: learned
+      - (modified_candidate, MODIFIED) — persist modified version, provenance: conversational
+      - (None, SKIPPED) — intentionally dismissed (e.g. edge absence is enforcement), loop continues
+      - (None, REJECTED) — discard, stops the learning loop entirely
+    """
+
+    @abstractmethod
+    def __call__(
+        self,
+        candidate: LearningCandidate,
+        grounding: GroundingResult,
+        gap: KnowledgeGap,
+    ) -> tuple[LearningCandidate | None, CandidateDecision]:
+        ...
+
+    def __enter__(self) -> LearningCallback:
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -1,0 +1,337 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+LearningEngine — orchestrates the auto-learning loop.
+
+Processes one gap at a time: template creation -> callback invocation ->
+validation -> persistence -> re-grounding.
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from vre.core.graph import PrimitiveRepository
+from vre.core.grounding.models import GroundingResult
+from vre.core.models import (
+    Depth,
+    DepthGap,
+    DepthLevel,
+    ExistenceGap,
+    KnowledgeGap,
+    Primitive,
+    Provenance,
+    ProvenanceSource,
+    ReachabilityGap,
+    Relatum,
+    RelationalGap,
+)
+from vre.learning.callback import LearningCallback
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    LearningCandidate,
+    LearningResult,
+    ProposedDepth,
+    ReachabilityCandidate,
+    RelationalCandidate,
+)
+from vre.learning.templates import TemplateFactory
+
+
+def _make_provenance(decision: CandidateDecision) -> Provenance:
+    """
+    Derive provenance from the candidate decision.
+    """
+    source = (
+        ProvenanceSource.LEARNED
+        if decision == CandidateDecision.ACCEPTED
+        else ProvenanceSource.CONVERSATIONAL
+    )
+    detail = (
+        "auto-learning: accepted as proposed"
+        if decision == CandidateDecision.ACCEPTED
+        else "auto-learning: modified by user"
+    )
+    now = datetime.now(timezone.utc)
+    return Provenance(source=source, created_at=now, updated_at=now, detail=detail)
+
+
+def _to_depth(proposed: ProposedDepth, provenance: Provenance) -> Depth:
+    """
+    Convert a ProposedDepth (agent-facing) to a Depth (graph-facing) with provenance.
+    """
+    return Depth(level=proposed.level, properties=proposed.properties, provenance=provenance)
+
+
+def _resolve_name_to_id(name: str, grounding: GroundingResult) -> UUID:
+    """
+    Resolve a primitive name to its UUID from the grounding trace.
+    """
+    if grounding.trace:
+        for p in grounding.trace.result.primitives:
+            if p.name.lower() == name.lower():
+                return p.id
+    raise ValueError(f"Cannot resolve '{name}' to a primitive ID from the grounding trace")
+
+
+class LearningEngine:
+    """
+    Processes knowledge gaps via the auto-learning loop.
+
+    The engine:
+    1. Creates a template from the gap
+    2. Invokes the callback (agent fills template, user reviews)
+    3. Validates and persists accepted/modified candidates using gap context
+    4. Returns the result with the decision
+    """
+
+    def __init__(self, repository: PrimitiveRepository) -> None:
+        self._repo = repository
+
+    def _persist_existence(
+        self, gap: ExistenceGap, candidate: ExistenceCandidate, provenance: Provenance,
+    ) -> None:
+        """
+        Persist a new primitive with D0 (auto-generated) and agent-provided D1.
+        """
+        if candidate.d1 is None:
+            raise ValueError(f"ExistenceCandidate '{candidate.name}' is missing D1 (identity)")
+
+        d0 = Depth(
+            level=DepthLevel.EXISTENCE,
+            properties={"exists": True},
+            provenance=provenance,
+        )
+        d1 = _to_depth(candidate.d1, provenance)
+
+        primitive = Primitive(
+            name=candidate.name,
+            depths=[d0, d1],
+            provenance=provenance,
+        )
+        self._repo.save_primitive(primitive)
+
+    def _merge_depths(
+        self, primitive: Primitive, new_depths: list[ProposedDepth], provenance: Provenance,
+    ) -> None:
+        """
+        Merge proposed depth levels into a primitive and persist.
+
+        Converts ProposedDepth → Depth, replaces existing depth levels when the
+        level already exists, appends otherwise. Sorts and saves.
+        """
+        existing_levels = {d.level for d in primitive.depths}
+        touched_levels: set[DepthLevel] = set()
+        for proposed in new_depths:
+            depth = _to_depth(proposed, provenance)
+            touched_levels.add(depth.level)
+            if depth.level in existing_levels:
+                # Carry forward relata from the old depth — edges and properties
+                # are independent concerns; replacing descriptive knowledge should
+                # not silently drop validated relationships.
+                old = next(d for d in primitive.depths if d.level == depth.level)
+                depth.relata = old.relata
+                primitive.depths = [
+                    d if d.level != depth.level else depth for d in primitive.depths
+                ]
+            else:
+                primitive.depths.append(depth)
+            existing_levels.add(depth.level)
+
+        # Stamp provenance on carried-forward relata that lack it
+        for depth in primitive.depths:
+            if depth.level not in touched_levels:
+                continue
+            for relatum in depth.relata:
+                if relatum.provenance is None:
+                    relatum.provenance = provenance
+
+        primitive.depths.sort(key=lambda d: int(d.level))
+        self._repo.save_primitive(primitive)
+
+    def _persist_depth(
+        self, gap: DepthGap, candidate: DepthCandidate, provenance: Provenance,
+    ) -> None:
+        """
+        Merge new depth levels into an existing primitive and persist.
+        """
+        if not candidate.new_depths:
+            raise ValueError(f"DepthCandidate for '{gap.primitive.name}' has no new depths")
+
+        existing = self._repo.find_by_id(gap.primitive.id)
+        if existing is None:
+            raise ValueError(f"Primitive '{gap.primitive.name}' ({gap.primitive.id}) not found")
+
+        self._merge_depths(existing, candidate.new_depths, provenance)
+
+    def _persist_relational(
+        self, gap: RelationalGap, candidate: RelationalCandidate, provenance: Provenance,
+    ) -> None:
+        """
+        Merge new depth levels into the target primitive and persist.
+        """
+        if not candidate.new_depths:
+            raise ValueError(f"RelationalCandidate for '{gap.target.name}' has no new depths")
+
+        target = self._repo.find_by_id(gap.target.id)
+        if target is None:
+            raise ValueError(f"Target '{gap.target.name}' ({gap.target.id}) not found")
+
+        self._merge_depths(target, candidate.new_depths, provenance)
+
+    def _learn_missing_depths(
+        self,
+        primitive: Primitive,
+        required_level: DepthLevel,
+        grounding: GroundingResult,
+        callback: LearningCallback,
+    ) -> CandidateDecision | None:
+        """
+        If the primitive lacks the required depth level, synthesize a DepthGap
+        and invoke the callback to learn the missing depths. Returns the
+        decision if learning was needed, or None if the depth already exists.
+        """
+        existing_levels = {d.level for d in primitive.depths}
+        if required_level in existing_levels:
+            return None
+
+        current_depth = max(existing_levels, key=lambda lv: lv.value) if existing_levels else None
+        gap = DepthGap(
+            primitive=primitive,
+            required_depth=required_level,
+            current_depth=current_depth,
+        )
+        template = TemplateFactory.from_gap(gap)
+        filled, decision = callback(template, grounding, gap)
+
+        if decision in (CandidateDecision.SKIPPED, CandidateDecision.REJECTED):
+            return decision
+        if filled is None:
+            return CandidateDecision.REJECTED
+
+        provenance = _make_provenance(decision)
+        self._persist_depth(gap, filled, provenance)
+        return decision
+
+    def _persist_reachability(
+        self,
+        gap: ReachabilityGap,
+        candidate: ReachabilityCandidate,
+        grounding: GroundingResult,
+        callback: LearningCallback,
+        provenance: Provenance,
+    ) -> CandidateDecision:
+        """
+        Two-phase edge placement:
+        1. Learn any missing depths on source and target via the callback
+        2. Place the edge once both sides have the required depths
+
+        If depth learning is rejected or skipped, edge placement is abandoned.
+        """
+        if candidate.target_name is None or candidate.relation_type is None:
+            raise ValueError(
+                f"ReachabilityCandidate for '{gap.primitive.name}' is missing "
+                f"target_name or relation_type"
+            )
+        if candidate.source_depth_level is None or candidate.target_depth_level is None:
+            raise ValueError(
+                f"ReachabilityCandidate for '{gap.primitive.name}' is missing "
+                f"source_depth_level or target_depth_level"
+            )
+
+        target_id = _resolve_name_to_id(candidate.target_name, grounding)
+
+        source = self._repo.find_by_id(gap.primitive.id)
+        if source is None:
+            raise ValueError(f"Source '{gap.primitive.name}' ({gap.primitive.id}) not found")
+
+        target = self._repo.find_by_id(target_id)
+        if target is None:
+            raise ValueError(f"Target '{candidate.target_name}' ({target_id}) not found")
+
+        # Phase 1: learn missing depths on source, then target
+        result = self._learn_missing_depths(source, candidate.source_depth_level, grounding, callback)
+        if result in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+            return result
+        if result is not None:
+            source = self._repo.find_by_id(source.id)
+
+        result = self._learn_missing_depths(target, candidate.target_depth_level, grounding, callback)
+        if result in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+            return result
+        if result is not None:
+            target = self._repo.find_by_id(target.id)
+
+        # Phase 2: place the edge
+        depth_obj = next(d for d in source.depths if d.level == candidate.source_depth_level)
+
+        new_relatum = Relatum(
+            relation_type=candidate.relation_type,
+            target_id=target_id,
+            target_depth=candidate.target_depth_level,
+            provenance=provenance,
+        )
+        depth_obj.relata.append(new_relatum)
+
+        source.depths.sort(key=lambda d: int(d.level))
+        self._repo.save_primitive(source)
+        return CandidateDecision.ACCEPTED
+
+    def _persist(
+        self,
+        gap: KnowledgeGap,
+        candidate: LearningCandidate,
+        grounding: GroundingResult,
+        callback: LearningCallback,
+        provenance: Provenance,
+    ) -> CandidateDecision | None:
+        """
+        Validate and persist a filled candidate to the graph.
+        Returns a decision override for reachability (two-phase), or None.
+        """
+        if isinstance(gap, ExistenceGap) and isinstance(candidate, ExistenceCandidate):
+            self._persist_existence(gap, candidate, provenance)
+        elif isinstance(gap, DepthGap) and isinstance(candidate, DepthCandidate):
+            self._persist_depth(gap, candidate, provenance)
+        elif isinstance(gap, RelationalGap) and isinstance(candidate, RelationalCandidate):
+            self._persist_relational(gap, candidate, provenance)
+        elif isinstance(gap, ReachabilityGap) and isinstance(candidate, ReachabilityCandidate):
+            return self._persist_reachability(gap, candidate, grounding, callback, provenance)
+        return None
+
+    def learn_at(
+        self,
+        grounding: GroundingResult,
+        gap_index: int,
+        callback: LearningCallback,
+    ) -> LearningResult:
+        """
+        Process the gap at the given index in the grounding result.
+        """
+        if not grounding.gaps:
+            raise ValueError("No gaps to learn from")
+        if gap_index < 0 or gap_index >= len(grounding.gaps):
+            raise ValueError(f"Gap index {gap_index} out of range (0..{len(grounding.gaps) - 1})")
+
+        gap = grounding.gaps[gap_index]
+        candidate = TemplateFactory.from_gap(gap)
+        filled, decision = callback(candidate, grounding, gap)
+
+        if decision == CandidateDecision.SKIPPED:
+            return LearningResult(decision=CandidateDecision.SKIPPED, candidate=candidate)
+
+        if decision == CandidateDecision.REJECTED or filled is None:
+            return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
+
+        provenance = _make_provenance(decision)
+        override = self._persist(gap, filled, grounding, callback, provenance)
+
+        # Reachability two-phase can override the decision if depth
+        # learning was rejected or skipped
+        if override in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+            return LearningResult(decision=override, candidate=filled)
+
+        return LearningResult(decision=decision, candidate=filled)
+

--- a/src/vre/learning/models.py
+++ b/src/vre/learning/models.py
@@ -1,0 +1,141 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Candidate models for the VRE auto-learning loop.
+
+Candidates carry only what's *new* — the agent's proposed knowledge. All
+context (primitive IDs, existing depths, required depths) lives on the gap
+itself, which the engine already has access to.
+
+This keeps the models lightweight and compatible with LLM structured output.
+"""
+
+from enum import Enum
+from typing import Annotated, Any, Literal
+
+from pydantic import BaseModel, Field
+
+from vre.core.models import DepthLevel, RelationType
+
+
+class CandidateDecision(str, Enum):
+    """
+    Outcome of a learning candidate review.
+
+    ACCEPTED — agent proposal persisted as-is (provenance: learned).
+    MODIFIED — user refined the proposal before persistence (provenance: conversational).
+    REJECTED — candidate discarded, nothing persisted. Stops the learning loop entirely.
+    SKIPPED — candidate intentionally dismissed (e.g. edge absence is deliberate
+              enforcement). The loop continues to the next gap.
+    """
+
+    ACCEPTED = "accepted"
+    MODIFIED = "modified"
+    REJECTED = "rejected"
+    SKIPPED = "skipped"
+
+
+class ProposedDepth(BaseModel):
+    """
+    A depth level proposed by the agent during learning.
+
+    Unlike the full Depth model, this carries only what the agent should
+    fill: the level and descriptive properties. Relata and provenance are
+    structural concerns handled by the engine during persistence.
+    """
+
+    level: DepthLevel
+    properties: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Descriptive attributes intrinsic to this concept at this depth level. "
+            "Each key names an attribute, each value describes it in natural language."
+        ),
+    )
+
+
+class ExistenceCandidate(BaseModel):
+    """
+    Proposal for an ExistenceGap — concept not found in the graph.
+
+    The agent fills in D1 (identity). On acceptance, D0 is generated
+    automatically — the act of accepting *is* the D0 confirmation.
+    """
+
+    kind: Literal["EXISTENCE"] = "EXISTENCE"
+    name: str
+    d1: ProposedDepth | None = None
+
+
+class DepthCandidate(BaseModel):
+    """
+    Proposal for a DepthGap — concept exists but lacks required depth.
+
+    The agent fills in the missing depth levels. The engine pulls
+    primitive ID and existing depths from the gap itself.
+    """
+
+    kind: Literal["DEPTH"] = "DEPTH"
+    new_depths: list[ProposedDepth] = Field(default_factory=list)
+
+
+class RelationalCandidate(BaseModel):
+    """
+    Proposal for a RelationalGap — edge target not grounded deeply enough.
+
+    The agent fills in the missing depth levels on the target. The engine
+    pulls target ID and existing depths from the gap itself.
+    """
+
+    kind: Literal["RELATIONAL"] = "RELATIONAL"
+    new_depths: list[ProposedDepth] = Field(default_factory=list)
+
+
+class ReachabilityCandidate(BaseModel):
+    """
+    Proposal for a ReachabilityGap — concept not connected to other concepts.
+
+    Focused solely on edge placement. The agent proposes which target to
+    connect to, the relation type, and the depth levels for the edge.
+    The engine resolves target_name to an ID from the grounding trace and
+    scaffolds any missing depths as stubs. If the scaffolded depths lack
+    required knowledge, re-grounding will surface them as depth or
+    relational gaps for the loop to handle naturally.
+
+    If the absence is intentional enforcement, the user skips instead of
+    filling this in.
+    """
+
+    kind: Literal["REACHABILITY"] = "REACHABILITY"
+    target_name: str | None = Field(
+        default=None,
+        description="Name of the target concept to connect to.",
+    )
+    relation_type: RelationType | None = Field(
+        default=None,
+        description="The type of relationship between source and target.",
+    )
+    source_depth_level: DepthLevel | None = Field(
+        default=None,
+        description="Depth level on the source where the edge is placed. Determines when the agent can reason about this relationship.",
+    )
+    target_depth_level: DepthLevel | None = Field(
+        default=None,
+        description="Minimum depth required on the target for the edge to resolve.",
+    )
+
+
+LearningCandidate = Annotated[
+    ExistenceCandidate | DepthCandidate | RelationalCandidate | ReachabilityCandidate,
+    Field(discriminator="kind"),
+]
+
+
+class LearningResult(BaseModel):
+    """
+    Outcome of a single learning round.
+    """
+
+    decision: CandidateDecision
+    candidate: LearningCandidate

--- a/src/vre/learning/templates.py
+++ b/src/vre/learning/templates.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+TemplateFactory — converts knowledge gaps into structured candidate templates.
+
+VRE presents the shape of what is needed; the agent fills in the content.
+Context (primitive IDs, existing depths) lives on the gap; the candidate
+carries only the new knowledge to be proposed.
+"""
+
+from vre.core.models import (
+    DepthGap,
+    ExistenceGap,
+    KnowledgeGap,
+    ReachabilityGap,
+    RelationalGap,
+)
+from vre.learning.models import (
+    DepthCandidate,
+    ExistenceCandidate,
+    LearningCandidate,
+    ReachabilityCandidate,
+    RelationalCandidate,
+)
+
+
+class TemplateFactory:
+    """
+    Converts typed knowledge gaps into candidate templates.
+
+    ExistenceGap pre-fills the concept name; all other candidates start
+    empty since context lives on the gap itself.
+    """
+
+    @staticmethod
+    def from_gap(gap: KnowledgeGap) -> LearningCandidate:
+        if isinstance(gap, ExistenceGap):
+            return ExistenceCandidate(name=gap.primitive.name)
+        if isinstance(gap, DepthGap):
+            return DepthCandidate()
+        if isinstance(gap, RelationalGap):
+            return RelationalCandidate()
+        if isinstance(gap, ReachabilityGap):
+            return ReachabilityCandidate()
+        raise ValueError(f"Unknown gap type: {type(gap)}")

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -634,3 +634,92 @@ class TestSourceDepthGating:
         resp = engine.query(["delete", "file"])
 
         assert len(resp.result.pathway) == 0
+
+
+# ---------------------------------------------------------------------------
+# Tests: empty concepts and utility methods
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyConcepts:
+    def test_query_empty_concepts_returns_empty_response(self) -> None:
+        """query([]) returns a valid but empty EpistemicResponse."""
+        engine = GroundingEngine(StubRepository([]))
+        resp = engine.query([])
+        assert len(resp.result.primitives) == 0
+        assert len(resp.result.gaps) == 0
+
+    def test_list_primitive_names(self) -> None:
+        """list_primitive_names returns all names in the repository."""
+        p = _make_primitive("file", [_depth(DepthLevel.EXISTENCE)])
+        engine = GroundingEngine(StubRepository([p]))
+        names = engine.list_primitive_names()
+        assert "file" in names
+
+
+class TestReachabilityAnchorSelection:
+    """Anchor selection uses the root with the largest reachable component."""
+
+    def test_isolated_node_reported_not_majority(self) -> None:
+        """
+        With 3 roots where 2 are connected and 1 is isolated, the isolated
+        one gets the ReachabilityGap regardless of submission order.
+        """
+        permission_p = _make_primitive("permission", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        file_p = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES, [
+                _relatum(permission_p.id, RelationType.REQUIRES, DepthLevel.CONSTRAINTS),
+            ]),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        orphan_p = _make_primitive("orphan", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        engine = GroundingEngine(StubRepository([file_p, permission_p, orphan_p]))
+
+        # Submit orphan first to test that anchor selection picks the larger component
+        resp = engine.query(["orphan", "file", "permission"])
+        reachability_gaps = [g for g in resp.result.gaps if g.kind == "REACHABILITY"]
+        assert len(reachability_gaps) == 1
+        assert reachability_gaps[0].primitive.name == "orphan"
+
+
+class TestMinDepthOnNonRootNodes:
+    """min_depth only applies to root (submitted) nodes, not discovered ones."""
+
+    def test_min_depth_skips_non_root_discovered_nodes(self) -> None:
+        """
+        Discovered node (via BFS) should not get a DepthGap from min_depth.
+        """
+        permission_p = _make_primitive("permission", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            # Only D0+D1, but it's not a root — min_depth should not apply
+        ])
+        file_p = _make_primitive("file", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS, [
+                _relatum(permission_p.id, RelationType.CONSTRAINED_BY, DepthLevel.IDENTITY),
+            ]),
+        ])
+        engine = GroundingEngine(StubRepository([file_p, permission_p]))
+
+        # Only "file" is the root; "permission" is discovered via BFS
+        resp = engine.query(["file"], min_depth=DepthLevel.CONSTRAINTS)
+
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        # No DepthGap on permission — it's not a root
+        for gap in depth_gaps:
+            assert gap.primitive.name != "permission"

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -1,11 +1,13 @@
 """
-Unit tests for vre.core.guard — lemmatize and vre_guard.
+Unit tests for vre.guard — vre_guard decorator.
 """
 
 from unittest.mock import MagicMock
 
 from vre.core.grounding import GroundingResult
 from vre.core.policy import PolicyResult
+from vre.learning.callback import LearningCallback
+from vre.learning.models import CandidateDecision
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -348,3 +350,91 @@ def test_vre_guard_no_min_depth_passes_none():
 
     my_fn()
     mock_vre.check.assert_called_once_with(["file"], min_depth=None)
+
+
+# ── on_learn path ────────────────────────────────────────────────────────────
+
+class _StubLearner(LearningCallback):
+    """Minimal LearningCallback for guard tests."""
+    def __call__(self, candidate, grounding, gap):
+        return None, CandidateDecision.REJECTED
+
+
+def test_vre_guard_on_learn_invokes_learn_all_when_not_grounded():
+    """When grounding fails and on_learn is provided, learn_all is called."""
+    from vre.guard import vre_guard
+
+    grounded_result = _grounding(grounded=True)
+    mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
+    mock_vre.learn_all.return_value = grounded_result
+    mock_vre.check_policy.return_value = PolicyResult(action="PASS")
+
+    learner = _StubLearner()
+
+    @vre_guard(mock_vre, concepts=["file"], on_learn=learner)
+    def my_fn():
+        return "executed"
+
+    result = my_fn()
+    assert result == "executed"
+    mock_vre.learn_all.assert_called_once()
+
+
+def test_vre_guard_on_learn_fires_on_trace_after_learning():
+    """on_trace fires twice: once after initial grounding, once after learning."""
+    from vre.guard import vre_guard
+
+    traces = []
+    grounded_result = _grounding(grounded=True)
+    mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
+    mock_vre.learn_all.return_value = grounded_result
+    mock_vre.check_policy.return_value = PolicyResult(action="PASS")
+
+    learner = _StubLearner()
+
+    @vre_guard(mock_vre, concepts=["file"], on_trace=traces.append, on_learn=learner)
+    def my_fn():
+        return "executed"
+
+    my_fn()
+    assert len(traces) == 2
+    assert traces[0].grounded is False
+    assert traces[1].grounded is True
+
+
+def test_vre_guard_on_learn_returns_grounding_when_still_not_grounded():
+    """When learn_all doesn't fully resolve gaps, returns the GroundingResult."""
+    from vre.guard import vre_guard
+
+    still_ungrounded = _grounding(grounded=False, gaps=[MagicMock()])
+    mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
+    mock_vre.learn_all.return_value = still_ungrounded
+
+    learner = _StubLearner()
+
+    @vre_guard(mock_vre, concepts=["file"], on_learn=learner)
+    def my_fn():
+        return "executed"
+
+    result = my_fn()
+    assert isinstance(result, GroundingResult)
+    assert result.grounded is False
+
+
+def test_vre_guard_on_policy_decline_returns_block():
+    """When on_policy returns False, returns PolicyResult(BLOCK, 'User declined')."""
+    from vre.guard import vre_guard
+
+    mock_vre = _mock_vre(
+        _grounding(),
+        PolicyResult(action="PENDING", confirmation_message="Are you sure?"),
+    )
+
+    @vre_guard(mock_vre, concepts=["file"], on_policy=lambda msg: False)
+    def my_fn():
+        return "executed"
+
+    result = my_fn()
+    assert isinstance(result, PolicyResult)
+    assert result.action == "BLOCK"
+    assert result.reason == "User declined"

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -1,0 +1,1028 @@
+"""
+Unit tests for the VRE auto-learning loop.
+
+Tests cover template generation, engine persistence, and the iterative
+learning loop.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+
+from vre.core.grounding.models import GroundingResult
+from vre.core.models import (
+    Depth,
+    DepthGap,
+    DepthLevel,
+    EpistemicQuery,
+    EpistemicResponse,
+    EpistemicResult,
+    ExistenceGap,
+    Primitive,
+    Provenance,
+    ProvenanceSource,
+    ReachabilityGap,
+    Relatum,
+    RelationalGap,
+    RelationType,
+)
+from vre.learning.callback import LearningCallback
+from vre.learning.engine import LearningEngine, _make_provenance
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    ProposedDepth,
+    ReachabilityCandidate,
+    RelationalCandidate,
+)
+from vre.learning.templates import TemplateFactory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _prov(source: ProvenanceSource = ProvenanceSource.AUTHORED) -> Provenance:
+    return Provenance(source=source)
+
+
+def _primitive(
+    name: str,
+    depths: list[Depth] | None = None,
+    id: UUID | None = None,
+) -> Primitive:
+    return Primitive(
+        id=id or uuid4(),
+        name=name,
+        depths=depths or [],
+        provenance=_prov(),
+    )
+
+
+def _depth(
+    level: DepthLevel,
+    properties: dict | None = None,
+) -> Depth:
+    return Depth(
+        level=level,
+        properties=properties or {},
+        provenance=_prov(),
+    )
+
+
+def _grounding_result(
+    grounded: bool,
+    gaps: list | None = None,
+    primitives: list[Primitive] | None = None,
+) -> GroundingResult:
+    prims = primitives or []
+    trace = EpistemicResponse(
+        query=EpistemicQuery(concept_ids=[]),
+        result=EpistemicResult(primitives=prims, gaps=[], pathway=[]),
+    ) if prims else None
+    return GroundingResult(
+        grounded=grounded,
+        resolved=[],
+        gaps=gaps or [],
+        trace=trace,
+    )
+
+
+class StubRepository:
+    """
+    In-memory repository for learning engine tests.
+    """
+
+    def __init__(self, primitives: list[Primitive] | None = None) -> None:
+        self._by_id: dict[UUID, Primitive] = {}
+        for p in primitives or []:
+            self._by_id[p.id] = p
+        self.saved: list[Primitive] = []
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        return self._by_id.get(id)
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        self._by_id[primitive.id] = primitive
+        self.saved.append(primitive)
+
+
+# ---------------------------------------------------------------------------
+# Template tests
+# ---------------------------------------------------------------------------
+
+class TestTemplateFactory:
+    def test_existence_has_name(self):
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        template = TemplateFactory.from_gap(gap)
+        assert isinstance(template, ExistenceCandidate)
+        assert template.name == "Copy"
+        assert template.d1 is None
+        assert template.kind == "EXISTENCE"
+
+    def test_depth_is_empty(self):
+        prim = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE)
+        template = TemplateFactory.from_gap(gap)
+        assert isinstance(template, DepthCandidate)
+        assert template.new_depths == []
+        assert template.kind == "DEPTH"
+
+    def test_relational_is_empty(self):
+        gap = RelationalGap(
+            source=_primitive("Create"),
+            target=_primitive("File"),
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=None,
+        )
+        template = TemplateFactory.from_gap(gap)
+        assert isinstance(template, RelationalCandidate)
+        assert template.new_depths == []
+        assert template.kind == "RELATIONAL"
+
+    def test_reachability_is_empty(self):
+        prim = _primitive("Delete", depths=[_depth(DepthLevel.EXISTENCE)])
+        gap = ReachabilityGap(primitive=prim)
+        template = TemplateFactory.from_gap(gap)
+        assert isinstance(template, ReachabilityCandidate)
+        assert template.target_name is None
+        assert template.relation_type is None
+        assert template.source_depth_level is None
+        assert template.target_depth_level is None
+        assert template.kind == "REACHABILITY"
+
+
+# ---------------------------------------------------------------------------
+# Provenance derivation tests
+# ---------------------------------------------------------------------------
+
+class TestMakeProvenance:
+    def test_accepted_is_learned(self):
+        prov = _make_provenance(CandidateDecision.ACCEPTED)
+        assert prov.source == ProvenanceSource.LEARNED
+        assert "accepted" in prov.detail
+
+    def test_modified_is_conversational(self):
+        prov = _make_provenance(CandidateDecision.MODIFIED)
+        assert prov.source == ProvenanceSource.CONVERSATIONAL
+        assert "modified" in prov.detail
+
+
+# ---------------------------------------------------------------------------
+# Engine persistence tests
+# ---------------------------------------------------------------------------
+
+class TestPersistExistence:
+    def test_saves_primitive_with_d0_and_d1(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = ExistenceCandidate(
+            name="Copy",
+            d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"description": "Duplicates content"}),
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.ACCEPTED
+        assert len(repo.saved) == 1
+        saved = repo.saved[0]
+        assert saved.name == "Copy"
+        assert len(saved.depths) == 2
+        levels = {d.level for d in saved.depths}
+        assert levels == {DepthLevel.EXISTENCE, DepthLevel.IDENTITY}
+        assert saved.provenance.source == ProvenanceSource.LEARNED
+
+    def test_rejects_missing_d1(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = ExistenceCandidate(name="Copy", d1=None)
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="missing D1"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_modified_gets_conversational_provenance(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = ExistenceCandidate(
+            name="Copy",
+            d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"description": "Duplicates"}),
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.MODIFIED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.MODIFIED
+        saved = repo.saved[0]
+        assert saved.provenance.source == ProvenanceSource.CONVERSATIONAL
+
+
+class TestPersistDepth:
+    def test_merges_new_depth_into_existing(self):
+        prim = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+        ])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+
+        gap = DepthGap(
+            primitive=prim,
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=DepthLevel.IDENTITY,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = DepthCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"can_read": "true"})],
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        levels = [d.level for d in saved.depths]
+        assert DepthLevel.CAPABILITIES in levels
+        assert levels == sorted(levels, key=int)
+
+    def test_rejects_empty_new_depths(self):
+        prim = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+        gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE)
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = DepthCandidate(new_depths=[])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="no new depths"):
+            engine.learn_at(grounding, 0, callback)
+
+
+class TestPersistRelational:
+    def test_merges_depth_into_target(self):
+        source = _primitive("Create")
+        target = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+
+        gap = RelationalGap(
+            source=source,
+            target=target,
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=DepthLevel.EXISTENCE,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"writable": "true"})],
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        assert saved.id == target.id
+        levels = {d.level for d in saved.depths}
+        assert DepthLevel.CAPABILITIES in levels
+
+
+class TestPersistReachability:
+    def test_attaches_relatum_to_source(self):
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        source = _primitive("Delete", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(
+            grounded=False, gaps=[gap], primitives=[source, target],
+        )
+
+        filled = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        assert saved.id == source.id
+        d2 = next(d for d in saved.depths if d.level == DepthLevel.CAPABILITIES)
+        assert len(d2.relata) == 1
+        assert d2.relata[0].target_id == target.id
+        assert d2.relata[0].relation_type == RelationType.APPLIES_TO
+        assert d2.relata[0].provenance.source == ProvenanceSource.LEARNED
+
+    def test_rejects_missing_target_name(self):
+        source = _primitive("Delete", depths=[_depth(DepthLevel.CAPABILITIES)])
+        repo = StubRepository([source])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source])
+
+        filled = ReachabilityCandidate()
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="missing"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_learns_missing_source_depth_before_placing_edge(self):
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        source = _primitive("Delete", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CONSTRAINTS,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        call_count = 0
+
+        def callback(candidate, gr, gap):
+            nonlocal call_count
+            call_count += 1
+            if isinstance(candidate, DepthCandidate):
+                # Agent fills in the missing depths
+                filled = DepthCandidate(new_depths=[
+                    ProposedDepth(level=DepthLevel.IDENTITY, properties={"description": "Remove"}),
+                    ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"can_delete": "true"}),
+                    ProposedDepth(level=DepthLevel.CONSTRAINTS, properties={"requires_perm": "true"}),
+                ])
+                return filled, CandidateDecision.ACCEPTED
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        # Callback invoked twice: once for edge, once for source depths
+        assert call_count == 2
+        # Source should have depths + relatum
+        saved_source = next(s for s in repo.saved if s.id == source.id and any(
+            r for d in s.depths for r in d.relata
+        ))
+        d3 = next(d for d in saved_source.depths if d.level == DepthLevel.CONSTRAINTS)
+        assert d3.properties == {"requires_perm": "true"}
+        assert len(d3.relata) == 1
+        assert d3.relata[0].target_id == target.id
+
+    def test_abandons_edge_if_depth_learning_rejected(self):
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        source = _primitive("Delete", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CONSTRAINTS,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            if isinstance(candidate, DepthCandidate):
+                return None, CandidateDecision.REJECTED
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.REJECTED
+        # No relata should have been placed
+        for saved in repo.saved:
+            for d in saved.depths:
+                assert len(d.relata) == 0
+
+    def test_skips_depth_learning_when_already_present(self):
+        target = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        source = _primitive("Delete", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY, {"description": "Removes content"}),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.EXISTENCE,
+        )
+
+        call_count = 0
+
+        def callback(candidate, gr, gap):
+            nonlocal call_count
+            call_count += 1
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        # Only called once — no depth learning needed
+        assert call_count == 1
+        # D1 retains original properties
+        saved = next(s for s in repo.saved if s.id == source.id)
+        d1 = next(d for d in saved.depths if d.level == DepthLevel.IDENTITY)
+        assert d1.properties == {"description": "Removes content"}
+
+    def test_rejects_unresolvable_target_name(self):
+        source = _primitive("Delete", depths=[_depth(DepthLevel.CAPABILITIES)])
+        repo = StubRepository([source])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source])
+
+        filled = ReachabilityCandidate(
+            target_name="Nonexistent",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="Cannot resolve"):
+            engine.learn_at(grounding, 0, callback)
+
+
+# ---------------------------------------------------------------------------
+# Decision flow tests
+# ---------------------------------------------------------------------------
+
+class TestDecisionFlow:
+    def test_rejected_does_not_persist(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        def callback(candidate, gr, gap):
+            return None, CandidateDecision.REJECTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.REJECTED
+        assert len(repo.saved) == 0
+
+    def test_skipped_does_not_persist(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        def callback(candidate, gr, gap):
+            return None, CandidateDecision.SKIPPED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.SKIPPED
+        assert len(repo.saved) == 0
+
+    def test_no_gaps_raises(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        grounding = _grounding_result(grounded=True, gaps=[])
+
+        with pytest.raises(ValueError, match="No gaps"):
+            engine.learn_at(grounding, 0, lambda c, g, gap: (None, CandidateDecision.REJECTED))
+
+
+# ---------------------------------------------------------------------------
+# learn_at tests
+# ---------------------------------------------------------------------------
+
+class TestLearnAt:
+    def test_processes_gap_at_index(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap0 = ExistenceGap(primitive=_primitive("Copy"))
+        gap1 = ExistenceGap(primitive=_primitive("Move"))
+        grounding = _grounding_result(grounded=False, gaps=[gap0, gap1])
+
+        received_names = []
+
+        def callback(candidate, gr, gap):
+            received_names.append(candidate.name)
+            return None, CandidateDecision.SKIPPED
+
+        engine.learn_at(grounding, 1, callback)
+        assert received_names == ["Move"]
+
+    def test_out_of_range_raises(self):
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        with pytest.raises(ValueError, match="out of range"):
+            engine.learn_at(grounding, 5, lambda c, g, gap: (None, CandidateDecision.REJECTED))
+
+
+# ---------------------------------------------------------------------------
+# Callback lifecycle tests
+# ---------------------------------------------------------------------------
+
+class TestLearningCallbackLifecycle:
+    def test_default_enter_returns_self(self):
+        class SimpleLearner(LearningCallback):
+            def __call__(self, candidate, grounding, gap):
+                return None, CandidateDecision.REJECTED
+
+        cb = SimpleLearner()
+        assert cb.__enter__() is cb
+
+    def test_default_exit_is_noop(self):
+        class SimpleLearner(LearningCallback):
+            def __call__(self, candidate, grounding, gap):
+                return None, CandidateDecision.REJECTED
+
+        cb = SimpleLearner()
+        cb.__exit__(None, None, None)  # should not raise
+
+    def test_usable_as_context_manager(self):
+        class SimpleLearner(LearningCallback):
+            def __call__(self, candidate, grounding, gap):
+                return None, CandidateDecision.REJECTED
+
+        cb = SimpleLearner()
+        with cb as entered:
+            assert entered is cb
+
+
+# ---------------------------------------------------------------------------
+# Template edge cases
+# ---------------------------------------------------------------------------
+
+class TestTemplateFactoryEdgeCases:
+    def test_unknown_gap_type_raises(self):
+        class UnknownGap:
+            pass
+
+        with pytest.raises(ValueError, match="Unknown gap type"):
+            TemplateFactory.from_gap(UnknownGap())
+
+
+# ---------------------------------------------------------------------------
+# Engine persistence edge cases
+# ---------------------------------------------------------------------------
+
+class TestPersistDepthEdgeCases:
+    def test_primitive_not_found_raises(self):
+        prim = _primitive("Ghost")
+        repo = StubRepository()  # empty — primitive not in repo
+        engine = LearningEngine(repo)
+        gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE)
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = DepthCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"a": "true"})],
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="not found"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_replaces_existing_depth_level(self):
+        """When a candidate proposes a depth that already exists, it should replace it."""
+        prim = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY, {"old": True}),
+        ])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+        gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.IDENTITY)
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = DepthCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.IDENTITY, properties={"updated": "true"}),
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"cap": "true"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        d1 = next(d for d in saved.depths if d.level == DepthLevel.IDENTITY)
+        assert d1.properties == {"updated": "true"}
+
+    def test_preserves_relata_and_stamps_provenance_on_replaced_depth(self):
+        """Replacing a depth carries forward its relata and stamps None provenance."""
+        target_id = uuid4()
+        prim = _primitive("File", depths=[
+            Depth(
+                level=DepthLevel.EXISTENCE,
+                properties={},
+                relata=[Relatum(
+                    relation_type=RelationType.APPLIES_TO,
+                    target_id=target_id,
+                    target_depth=DepthLevel.CAPABILITIES,
+                    provenance=None,
+                )],
+            ),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                properties={"old": "val"},
+                relata=[Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=target_id,
+                    target_depth=DepthLevel.IDENTITY,
+                    provenance=None,
+                )],
+            ),
+        ])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+        gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.IDENTITY)
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = DepthCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "a file"}),
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"cap": "read"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        # D0 was NOT touched — its relatum should remain unstamped
+        d0 = next(d for d in saved.depths if d.level == DepthLevel.EXISTENCE)
+        assert d0.relata[0].provenance is None
+        # D1 WAS replaced — relata carried forward and provenance stamped
+        d1 = next(d for d in saved.depths if d.level == DepthLevel.IDENTITY)
+        assert len(d1.relata) == 1
+        assert d1.relata[0].target_id == target_id
+        assert d1.relata[0].provenance is not None
+        assert d1.relata[0].provenance.source == ProvenanceSource.LEARNED
+        # D1 properties updated
+        assert d1.properties == {"desc": "a file"}
+
+
+class TestPersistRelationalEdgeCases:
+    def test_empty_new_depths_raises(self):
+        source = _primitive("Create")
+        target = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = RelationalGap(
+            source=source, target=target,
+            required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(new_depths=[])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="no new depths"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_target_not_found_raises(self):
+        source = _primitive("Create")
+        target = _primitive("File")
+        repo = StubRepository([source])  # target not in repo
+        engine = LearningEngine(repo)
+        gap = RelationalGap(
+            source=source, target=target,
+            required_depth=DepthLevel.CAPABILITIES, current_depth=None,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"writable": "true"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="not found"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_replaces_existing_depth_on_target(self):
+        source = _primitive("Create")
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.CAPABILITIES, {"old": True}),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = RelationalGap(
+            source=source, target=target,
+            required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"updated": "true"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        d2 = next(d for d in saved.depths if d.level == DepthLevel.CAPABILITIES)
+        assert d2.properties == {"updated": "true"}
+
+    def test_does_not_stamp_provenance_on_untouched_depths(self):
+        """Relata on depths not being replaced should remain untouched."""
+        source = _primitive("Create")
+        target = _primitive("File", depths=[
+            Depth(
+                level=DepthLevel.EXISTENCE,
+                properties={},
+                relata=[Relatum(
+                    relation_type=RelationType.APPLIES_TO,
+                    target_id=uuid4(),
+                    target_depth=DepthLevel.IDENTITY,
+                    provenance=None,
+                )],
+            ),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = RelationalGap(
+            source=source, target=target,
+            required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"cap": "true"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        # D0 was not touched — its relatum provenance should remain None
+        d0 = next(d for d in saved.depths if d.level == DepthLevel.EXISTENCE)
+        assert d0.relata[0].provenance is None
+
+    def test_preserves_relata_on_replaced_target_depth(self):
+        """Replacing a depth on the target carries forward its relata."""
+        source = _primitive("Create")
+        rel_target_id = uuid4()
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            Depth(
+                level=DepthLevel.CAPABILITIES,
+                properties={"old": "val"},
+                relata=[Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=rel_target_id,
+                    target_depth=DepthLevel.IDENTITY,
+                    provenance=None,
+                )],
+            ),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = RelationalGap(
+            source=source, target=target,
+            required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE,
+        )
+        grounding = _grounding_result(grounded=False, gaps=[gap])
+
+        filled = RelationalCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"updated": "true"}),
+        ])
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        engine.learn_at(grounding, 0, callback)
+        saved = repo.saved[0]
+        d2 = next(d for d in saved.depths if d.level == DepthLevel.CAPABILITIES)
+        assert d2.properties == {"updated": "true"}
+        assert len(d2.relata) == 1
+        assert d2.relata[0].target_id == rel_target_id
+        assert d2.relata[0].provenance is not None
+        assert d2.relata[0].provenance.source == ProvenanceSource.LEARNED
+
+
+class TestPersistReachabilityEdgeCases:
+    def test_missing_depth_levels_raises(self):
+        source = _primitive("Delete", depths=[_depth(DepthLevel.CAPABILITIES)])
+        repo = StubRepository([source])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source])
+
+        filled = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=None,
+            target_depth_level=None,
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="missing"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_source_not_found_raises(self):
+        source = _primitive("Ghost")
+        target = _primitive("File", depths=[_depth(DepthLevel.CAPABILITIES)])
+        repo = StubRepository([target])  # source not in repo
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        filled = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="not found"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_target_not_found_raises(self):
+        source = _primitive("Delete", depths=[_depth(DepthLevel.CAPABILITIES)])
+        target = _primitive("File", depths=[_depth(DepthLevel.CAPABILITIES)])
+        repo = StubRepository([source])  # target not in repo
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        filled = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            return filled, CandidateDecision.ACCEPTED
+
+        with pytest.raises(ValueError, match="not found"):
+            engine.learn_at(grounding, 0, callback)
+
+    def test_learns_missing_target_depth_and_refreshes(self):
+        """When only the target needs depth learning, verifies the target is refreshed."""
+        source = _primitive("Delete", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        target = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            if isinstance(candidate, DepthCandidate):
+                filled = DepthCandidate(new_depths=[
+                    ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "a file"}),
+                    ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"readable": "true"}),
+                ])
+                return filled, CandidateDecision.ACCEPTED
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.ACCEPTED
+        # Edge should be placed on source
+        saved_source = next(s for s in repo.saved if s.id == source.id and any(
+            r for d in s.depths for r in d.relata
+        ))
+        d2 = next(d for d in saved_source.depths if d.level == DepthLevel.CAPABILITIES)
+        assert len(d2.relata) == 1
+        assert d2.relata[0].target_id == target.id
+
+    def test_rejects_target_depth_learning_abandons_edge(self):
+        """When target depth learning is rejected, edge placement is abandoned."""
+        source = _primitive("Delete", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        target = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            if isinstance(candidate, DepthCandidate):
+                return None, CandidateDecision.REJECTED
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.REJECTED
+
+    def test_skips_source_depth_learning_abandons_edge(self):
+        """When source depth learning is skipped, edge placement is abandoned."""
+        source = _primitive("Delete", depths=[_depth(DepthLevel.EXISTENCE)])
+        target = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        repo = StubRepository([source, target])
+        engine = LearningEngine(repo)
+        gap = ReachabilityGap(primitive=source)
+        grounding = _grounding_result(grounded=False, gaps=[gap], primitives=[source, target])
+
+        edge_candidate = ReachabilityCandidate(
+            target_name="File",
+            relation_type=RelationType.APPLIES_TO,
+            source_depth_level=DepthLevel.CAPABILITIES,
+            target_depth_level=DepthLevel.CAPABILITIES,
+        )
+
+        def callback(candidate, gr, gap):
+            if isinstance(candidate, DepthCandidate):
+                return None, CandidateDecision.SKIPPED
+            return edge_candidate, CandidateDecision.ACCEPTED
+
+        result = engine.learn_at(grounding, 0, callback)
+        assert result.decision == CandidateDecision.SKIPPED
+
+
+class TestLearnMissingDepthsEdgeCases:
+    def test_filled_none_treated_as_rejected(self):
+        """If callback returns filled=None with ACCEPTED, treat as REJECTED."""
+        prim = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+
+        # Call _learn_missing_depths directly
+        grounding = _grounding_result(grounded=False)
+
+        def callback(candidate, gr, gap):
+            return None, CandidateDecision.ACCEPTED
+
+        result = engine._learn_missing_depths(
+            prim, DepthLevel.CAPABILITIES, grounding, callback,
+        )
+        assert result == CandidateDecision.REJECTED

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -20,6 +20,13 @@ from vre.core.models import (
 from vre.core.policy import Cardinality, Policy
 from vre.core.grounding import GroundingResult
 from vre.core.policy import PolicyResult
+from vre.learning.callback import LearningCallback
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    ProposedDepth,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -39,6 +46,13 @@ class StubRepository:
 
     def list_names(self) -> list[str]:
         return list(self._by_name.keys())
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        return self._by_id.get(id)
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        self._by_id[primitive.id] = primitive
+        self._by_name[primitive.name.lower()] = primitive
 
     def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
         roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
@@ -195,3 +209,144 @@ class TestVRECheck:
         result = vre.check_policy(["file"])
         assert isinstance(result, PolicyResult)
         assert result.action in ("PASS", "PENDING", "BLOCK")
+
+    def test_check_empty_concepts_returns_not_grounded(self):
+        """check([]) returns grounded=False with no gaps."""
+        vre = _make_vre_with_stub([])
+        result = vre.check([])
+        assert isinstance(result, GroundingResult)
+        assert result.grounded is False
+        assert result.gaps == []
+
+    def test_check_policy_with_grounding_result(self):
+        """check_policy accepts a pre-computed GroundingResult."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+        grounding = vre.check(["file"])
+        result = vre.check_policy(grounding)
+        assert isinstance(result, PolicyResult)
+        assert result.action == "PASS"
+
+    def test_check_policy_returns_pass_when_no_trace(self):
+        """check_policy returns PASS when GroundingResult has no trace."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+        grounding = GroundingResult(grounded=True, resolved=["file"], gaps=[], trace=None)
+        result = vre.check_policy(grounding)
+        assert result.action == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# VRE.learn_all tests
+# ---------------------------------------------------------------------------
+
+
+class _AcceptLearner(LearningCallback):
+    """Callback that accepts proposals with appropriate candidates."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, candidate, grounding, gap):
+        self.calls.append((candidate, gap))
+        if isinstance(candidate, ExistenceCandidate):
+            filled = ExistenceCandidate(
+                name=candidate.name,
+                d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "test"}),
+            )
+            return filled, CandidateDecision.ACCEPTED
+        if isinstance(candidate, DepthCandidate):
+            filled = DepthCandidate(new_depths=[
+                ProposedDepth(level=gap.required_depth, properties={"test": True}),
+            ])
+            return filled, CandidateDecision.ACCEPTED
+        return None, CandidateDecision.SKIPPED
+
+
+class _RejectLearner(LearningCallback):
+    """Callback that rejects all proposals."""
+
+    def __call__(self, candidate, grounding, gap):
+        return None, CandidateDecision.REJECTED
+
+
+class TestVRELearnAll:
+    def test_learn_all_resolves_existence_gap(self):
+        """learn_all creates the missing primitive and returns grounded."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+
+        grounding = vre.check(["file", "copy"])
+        assert grounding.grounded is False
+
+        learner = _AcceptLearner()
+        result = vre.learn_all(grounding, learner, ["file", "copy"])
+        # After learning "copy", re-grounding should find it (now in the repo)
+        assert isinstance(result, GroundingResult)
+
+    def test_learn_all_stops_on_rejection(self):
+        """learn_all stops the loop when callback rejects."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+
+        grounding = vre.check(["file", "copy"])
+        result = vre.learn_all(grounding, _RejectLearner(), ["file", "copy"])
+        assert isinstance(result, GroundingResult)
+        assert result.grounded is False
+
+    def test_learn_all_skips_gaps_and_continues(self):
+        """learn_all skips a gap and continues to the next."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+
+        grounding = vre.check(["file", "alpha", "beta"])
+        assert len([g for g in grounding.gaps if g.kind == "EXISTENCE"]) == 2
+
+        call_count = 0
+
+        class SkipThenAccept(LearningCallback):
+            def __call__(self, candidate, grounding, gap):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return None, CandidateDecision.SKIPPED
+                if isinstance(candidate, ExistenceCandidate):
+                    filled = ExistenceCandidate(
+                        name=candidate.name,
+                        d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "test"}),
+                    )
+                    return filled, CandidateDecision.ACCEPTED
+                # Skip any non-existence gaps (e.g. ReachabilityGap)
+                return None, CandidateDecision.SKIPPED
+
+        result = vre.learn_all(grounding, SkipThenAccept(), ["file", "alpha", "beta"])
+        assert isinstance(result, GroundingResult)
+        # At least 2 calls: one skip, one accept
+        assert call_count >= 2
+
+    def test_learn_all_uses_context_manager(self):
+        """learn_all wraps the callback in a context manager."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+
+        grounding = vre.check(["file", "unknown"])
+
+        entered = False
+        exited = False
+
+        class LifecycleLearner(LearningCallback):
+            def __enter__(self):
+                nonlocal entered
+                entered = True
+                return self
+
+            def __exit__(self, *args):
+                nonlocal exited
+                exited = True
+
+            def __call__(self, candidate, grounding, gap):
+                return None, CandidateDecision.REJECTED
+
+        vre.learn_all(grounding, LifecycleLearner(), ["file", "unknown"])
+        assert entered
+        assert exited


### PR DESCRIPTION
## Summary

Implements the auto-learning system (Issue #4) that transforms knowledge gaps into graph growth through structured agent/user dialogue. When grounding fails and an `on_learn` callback is present, VRE surfaces typed candidate templates, invokes the callback to fill them, persists accepted knowledge with provenance, and re-grounds iteratively until the action is epistemically justified.

- **`src/vre/learning/`** — New learning subsystem: `LearningCallback` ABC, `ProposedDepth` agent-facing model, four candidate types with discriminated union, `LearningEngine` with two-phase edge placement and relata-preserving depth replacement, `TemplateFactory` (engine-internal)
- **`src/vre/__init__.py`** — `VRE.learn()` and `VRE.learn_all()` public API with cached `LearningEngine`
- **`src/vre/guard.py`** — `on_learn` parameter on `vre_guard` with post-learning `on_trace` fire
- **`demo/learner.py`** — `DemoLearner` using ChatOllama structured output, questionary arrow-key selection, Rich panels, multi-round message history
- **`README.md`** / **`docs/index.html`** — Full documentation of learning API, `ProposedDepth`, guard execution sequence, candidate types
- **`scripts/`** — Fixes pre-existing ruff lint errors (f-strings, unused vars)

## Key design decisions

- `ProposedDepth` has `properties: dict[str, Any]` — deliberately unrestricted so integrators can use lists, nested dicts, etc. for their domain. Relata/provenance leakage is addressed at the prompt layer, not the model layer.
- Depth replacement preserves relata — replacing descriptive properties at a depth does not silently drop validated edges. Provenance stamping is scoped to only touched depths.
- Two-phase edge placement for reachability — learns missing depths on source/target before placing the edge, with explicit sequential calls (no fragile loop-and-rebind).
- `TemplateFactory` removed from public API — engine-internal concern.
- `LearningEngine` typed against `PrimitiveRepository` (not `object`).

## Test plan

- [x] 198 tests passing
- [x] 100% coverage on all `src/vre/learning/` files
- [x] 100% coverage on `src/vre/guard.py` and `src/vre/__init__.py`
- [x] Ruff lint clean (`poetry run ruff check .`)
- [ ] Manual demo run: `poetry run python -m demo.main` — verify learning flow with existence, depth, and reachability gaps

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)