### PR TITLE
Make policy action values a PolicyAction enum

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ def on_policy(message: str) -> bool:
     return Confirm.ask(f"[yellow]⚠  Policy gate:[/] {message}")
 ```
 
-If `on_policy` is not provided and a policy requires confirmation, the guard returns `PolicyResult(action="BLOCK", reason="Confirmation required, no handler")` and the function does not execute.
+If `on_policy` is not provided and a policy requires confirmation, the guard returns `PolicyResult(action=PolicyAction.BLOCK, reason="Confirmation required, no handler")` and the function does not execute.
 
 <img width="1968" height="1592" alt="image" src="https://github.com/user-attachments/assets/81257f0f-4273-4235-85ca-dcb50c21439b" />
 

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -18,7 +18,7 @@ Usage::
 from vre.core.graph import PrimitiveRepository
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
 from vre.core.models import DepthLevel, Provenance, ProvenanceSource
-from vre.core.policy import Cardinality, PolicyResult
+from vre.core.policy import Cardinality, PolicyAction, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
 from vre.learning import (
@@ -39,6 +39,7 @@ __all__ = [
     "Provenance",
     "ProvenanceSource",
     "Cardinality",
+    "PolicyAction",
     "PolicyResult",
     "PolicyCallContext",
     "PolicyGate",
@@ -151,7 +152,7 @@ class VRE:
             grounding = self._engine.ground(concepts, self._resolver)
 
         if grounding.trace is None:
-            return PolicyResult(action="PASS")
+            return PolicyResult(action=PolicyAction.PASS)
 
         card_enum = Cardinality.SINGLE
         if cardinality is not None:

--- a/src/vre/core/policy/__init__.py
+++ b/src/vre/core/policy/__init__.py
@@ -1,11 +1,19 @@
 # Copyright 2026 Andrew Greene
 # Licensed under the Apache License, Version 2.0
 
-from vre.core.policy.models import Cardinality, Policy, PolicyResult, PolicyViolation, parse_policy
+from vre.core.policy.models import (
+    Cardinality,
+    Policy,
+    PolicyAction,
+    PolicyResult,
+    PolicyViolation,
+    parse_policy,
+)
 
 __all__ = [
     "Cardinality",
     "Policy",
+    "PolicyAction",
     "PolicyResult",
     "PolicyViolation",
     "parse_policy",

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -7,7 +7,7 @@ PolicyGate — evaluates policy violations against an epistemic trace.
 
 from vre.core.models import EpistemicResponse, RelationType
 from vre.core.policy.callback import PolicyCallContext
-from vre.core.policy.models import Cardinality, Policy, PolicyResult, PolicyViolation
+from vre.core.policy.models import Cardinality, Policy, PolicyAction, PolicyResult, PolicyViolation
 
 
 class PolicyGate:
@@ -26,14 +26,14 @@ class PolicyGate:
         """
         violations = self._collect_violations(response, cardinality, call_context)
         if not violations:
-            return PolicyResult(action="PASS")
+            return PolicyResult(action=PolicyAction.PASS)
         pending = [v for v in violations if v.requires_confirmation]
         if pending:
             return PolicyResult(
-                action="PENDING",
+                action=PolicyAction.PENDING,
                 confirmation_message=pending[0].message,
             )
-        return PolicyResult(action="PASS")  # informational-only violations don't block
+        return PolicyResult(action=PolicyAction.PASS)  # informational-only violations don't block
 
     def _collect_violations(
         self,

--- a/src/vre/core/policy/models.py
+++ b/src/vre/core/policy/models.py
@@ -17,6 +17,16 @@ if TYPE_CHECKING:
     from vre.core.policy.callback import PolicyCallback
 
 
+class PolicyAction(str, Enum):
+    """
+    Outcome of a policy evaluation — PASS, PENDING, or BLOCK.
+    """
+
+    PASS = "PASS"
+    PENDING = "PENDING"
+    BLOCK = "BLOCK"
+
+
 class Cardinality(str, Enum):
     """
     Cardinality hint passed to policy evaluation — "single" or "multiple" target.
@@ -69,11 +79,9 @@ class PolicyViolation(BaseModel):
 class PolicyResult(BaseModel):
     """
     Result of a VRE policy evaluation.
-
-    `action` is one of "PASS", "PENDING", or "BLOCK".
     """
 
-    action: str
+    action: PolicyAction
     reason: str | None = None
     confirmation_message: str | None = None
 
@@ -81,10 +89,10 @@ class PolicyResult(BaseModel):
         """
         Render the policy result as a human-readable status string.
         """
-        if self.action == "PASS":
+        if self.action == PolicyAction.PASS:
             return "[VRE Policy] PASSED"
-        if self.action == "PENDING":
+        if self.action == PolicyAction.PENDING:
             return f"[VRE Policy] PENDING — {self.confirmation_message}"
-        if self.action == "BLOCK":
+        if self.action == PolicyAction.BLOCK:
             return f"[VRE Policy] BLOCKED — {self.reason}"
         return f"[VRE Policy] {self.action}"

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -31,7 +31,7 @@ import functools
 from typing import TYPE_CHECKING, Callable
 
 from vre.core.models import DepthLevel
-from vre.core.policy import PolicyResult
+from vre.core.policy import PolicyAction, PolicyResult
 from vre.core.policy.callback import PolicyCallContext
 
 if TYPE_CHECKING:
@@ -123,15 +123,15 @@ def vre_guard(
                 policy = vre.check_policy(grounding, resolved_cardinality, context)
 
                 match policy.action:
-                    case "PENDING":
+                    case PolicyAction.PENDING:
                         if on_policy:
                             if on_policy(policy.confirmation_message or ""):
                                 result = fn(*args, **kwargs)
                             else:
-                                result = PolicyResult(action="BLOCK", reason="User declined")
+                                result = PolicyResult(action=PolicyAction.BLOCK, reason="User declined")
                         else:
-                            result = PolicyResult(action="BLOCK", reason="Confirmation required, no handler")
-                    case "BLOCK":
+                            result = PolicyResult(action=PolicyAction.BLOCK, reason="Confirmation required, no handler")
+                    case PolicyAction.BLOCK:
                         result = policy
                     case _:
                         result = fn(*args, **kwargs)

--- a/src/vre/integrations/claude_code.py
+++ b/src/vre/integrations/claude_code.py
@@ -189,7 +189,7 @@ def _run_hook() -> None:
 
         config = json.loads(_VRE_CONFIG_PATH.read_text())
 
-        from vre import VRE
+        from vre import VRE, PolicyAction
         from vre.core.graph import PrimitiveRepository
 
         with PrimitiveRepository(
@@ -203,10 +203,10 @@ def _run_hook() -> None:
 
             policy = vre.check_policy(grounding)
 
-        if policy.action == "PENDING":
+        if policy.action == PolicyAction.PENDING:
             _ask(policy.confirmation_message or "This action requires confirmation.")
 
-        if policy.action == "BLOCK":
+        if policy.action == PolicyAction.BLOCK:
             _block(str(policy))
 
         _allow()

--- a/tests/vre/test_claude_code.py
+++ b/tests/vre/test_claude_code.py
@@ -12,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from vre.core.grounding import GroundingResult
-from vre.core.policy import PolicyResult
+from vre.core.policy import PolicyAction, PolicyResult
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -212,7 +212,7 @@ class TestRunHook:
 
         grounding = GroundingResult(grounded=True, resolved=["Read"], gaps=[])
         policy = PolicyResult(
-            action="PENDING",
+            action=PolicyAction.PENDING,
             confirmation_message="Read access requires confirmation.",
         )
 

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -5,7 +5,7 @@ Unit tests for vre.guard — vre_guard decorator.
 from unittest.mock import MagicMock
 
 from vre.core.grounding import GroundingResult
-from vre.core.policy import PolicyResult
+from vre.core.policy import PolicyAction, PolicyResult
 from vre.learning.callback import LearningCallback
 from vre.learning.models import CandidateDecision
 
@@ -24,7 +24,7 @@ def _mock_vre(grounding: GroundingResult, policy: PolicyResult | None = None):
     """Return a MagicMock VRE wired with the given grounding and policy."""
     mock = MagicMock()
     mock.check.return_value = grounding
-    mock.check_policy.return_value = policy or PolicyResult(action="PASS")
+    mock.check_policy.return_value = policy or PolicyResult(action=PolicyAction.PASS)
     return mock
 
 
@@ -136,7 +136,7 @@ def test_vre_guard_blocks_when_pending_and_no_handler():
 
     mock_vre = _mock_vre(
         _grounding(),
-        PolicyResult(action="PENDING", confirmation_message="Confirm this action?"),
+        PolicyResult(action=PolicyAction.PENDING, confirmation_message="Confirm this action?"),
     )
 
     @vre_guard(mock_vre, concepts=["file"])
@@ -145,7 +145,7 @@ def test_vre_guard_blocks_when_pending_and_no_handler():
 
     result = my_fn()
     assert isinstance(result, PolicyResult)
-    assert result.action == "BLOCK"
+    assert result.action == PolicyAction.BLOCK
 
 
 def test_vre_guard_calls_fn_when_policy_confirmed():
@@ -154,7 +154,7 @@ def test_vre_guard_calls_fn_when_policy_confirmed():
 
     mock_vre = _mock_vre(
         _grounding(),
-        PolicyResult(action="PENDING", confirmation_message="Confirm?"),
+        PolicyResult(action=PolicyAction.PENDING, confirmation_message="Confirm?"),
     )
 
     @vre_guard(mock_vre, concepts=["file"], on_policy=lambda msg: True)
@@ -171,7 +171,7 @@ def test_vre_guard_blocks_on_block_policy():
 
     mock_vre = _mock_vre(
         _grounding(),
-        PolicyResult(action="BLOCK", reason="Forbidden"),
+        PolicyResult(action=PolicyAction.BLOCK, reason="Forbidden"),
     )
 
     @vre_guard(mock_vre, concepts=["file"])
@@ -180,7 +180,7 @@ def test_vre_guard_blocks_on_block_policy():
 
     result = my_fn()
     assert isinstance(result, PolicyResult)
-    assert result.action == "BLOCK"
+    assert result.action == PolicyAction.BLOCK
     assert result.reason == "Forbidden"
 
 
@@ -367,7 +367,7 @@ def test_vre_guard_on_learn_invokes_learn_all_when_not_grounded():
     grounded_result = _grounding(grounded=True)
     mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
     mock_vre.learn_all.return_value = grounded_result
-    mock_vre.check_policy.return_value = PolicyResult(action="PASS")
+    mock_vre.check_policy.return_value = PolicyResult(action=PolicyAction.PASS)
 
     learner = _StubLearner()
 
@@ -388,7 +388,7 @@ def test_vre_guard_on_learn_fires_on_trace_after_learning():
     grounded_result = _grounding(grounded=True)
     mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
     mock_vre.learn_all.return_value = grounded_result
-    mock_vre.check_policy.return_value = PolicyResult(action="PASS")
+    mock_vre.check_policy.return_value = PolicyResult(action=PolicyAction.PASS)
 
     learner = _StubLearner()
 
@@ -427,7 +427,7 @@ def test_vre_guard_on_policy_decline_returns_block():
 
     mock_vre = _mock_vre(
         _grounding(),
-        PolicyResult(action="PENDING", confirmation_message="Are you sure?"),
+        PolicyResult(action=PolicyAction.PENDING, confirmation_message="Are you sure?"),
     )
 
     @vre_guard(mock_vre, concepts=["file"], on_policy=lambda msg: False)
@@ -436,5 +436,5 @@ def test_vre_guard_on_policy_decline_returns_block():
 
     result = my_fn()
     assert isinstance(result, PolicyResult)
-    assert result.action == "BLOCK"
+    assert result.action == PolicyAction.BLOCK
     assert result.reason == "User declined"

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -15,7 +15,7 @@ from vre.core.models import (
     Relatum,
     RelationType,
 )
-from vre.core.policy import Cardinality, Policy, parse_policy
+from vre.core.policy import Cardinality, Policy, PolicyAction, parse_policy
 from vre.core.policy.gate import PolicyGate
 
 
@@ -85,7 +85,7 @@ def test_no_policies_proceed():
     primitive = _make_primitive_with_applies_to("create", [])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert result.action == "PASS"
+    assert result.action == PolicyAction.PASS
 
 
 def test_step_cardinality_single_no_trigger():
@@ -98,7 +98,7 @@ def test_step_cardinality_single_no_trigger():
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert result.action == "PASS"
+    assert result.action == PolicyAction.PASS
 
 
 def test_step_cardinality_multiple_triggers():
@@ -111,7 +111,7 @@ def test_step_cardinality_multiple_triggers():
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.MULTIPLE)
-    assert result.action == "PENDING"
+    assert result.action == PolicyAction.PENDING
     assert result.confirmation_message is not None
     assert "BulkDelete" in result.confirmation_message or "delete" in result.confirmation_message
 
@@ -126,8 +126,8 @@ def test_policy_trigger_cardinality_none_always_fires():
     primitive = _make_primitive_with_applies_to("write", [policy])
     response = _make_step_result(primitive)
 
-    assert PolicyGate().evaluate(response, Cardinality.SINGLE).action == "PENDING"
-    assert PolicyGate().evaluate(response, Cardinality.MULTIPLE).action == "PENDING"
+    assert PolicyGate().evaluate(response, Cardinality.SINGLE).action == PolicyAction.PENDING
+    assert PolicyGate().evaluate(response, Cardinality.MULTIPLE).action == PolicyAction.PENDING
 
 
 def test_no_callback_fires_violation():
@@ -140,7 +140,7 @@ def test_no_callback_fires_violation():
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert result.action == "PENDING"
+    assert result.action == PolicyAction.PENDING
     assert result.confirmation_message is not None
 
 
@@ -170,7 +170,7 @@ def test_non_applies_to_relata_ignored():
     primitive = Primitive(name="create", depths=[depth])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert result.action == "PASS"
+    assert result.action == PolicyAction.PASS
 
 
 def test_requires_confirmation_false_never_triggers():
@@ -184,4 +184,4 @@ def test_requires_confirmation_false_never_triggers():
     primitive = _make_primitive_with_applies_to("list", [policy])
     response = _make_step_result(primitive)
     result = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert result.action == "PASS"
+    assert result.action == PolicyAction.PASS

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -19,7 +19,7 @@ from vre.core.models import (
     RelationType,
 )
 from vre.core.grounding import GroundingResult
-from vre.core.policy import PolicyResult
+from vre.core.policy import PolicyAction, PolicyResult
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -244,15 +244,15 @@ def test_grounding_str_primitive_with_no_depths():
 # ── PolicyResult.__str__ ──────────────────────────────────────────────────────
 
 def test_policy_str_pass():
-    result = PolicyResult(action="PASS")
+    result = PolicyResult(action=PolicyAction.PASS)
     assert str(result) == "[VRE Policy] PASSED"
 
 
 def test_policy_str_pending():
-    result = PolicyResult(action="PENDING", confirmation_message="Confirm this action?")
+    result = PolicyResult(action=PolicyAction.PENDING, confirmation_message="Confirm this action?")
     assert str(result) == "[VRE Policy] PENDING — Confirm this action?"
 
 
 def test_policy_str_block():
-    result = PolicyResult(action="BLOCK", reason="Forbidden operation")
+    result = PolicyResult(action=PolicyAction.BLOCK, reason="Forbidden operation")
     assert str(result) == "[VRE Policy] BLOCKED — Forbidden operation"

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -17,7 +17,7 @@ from vre.core.models import (
     RelationType,
     ResolvedSubgraph,
 )
-from vre.core.policy import Cardinality, Policy
+from vre.core.policy import Cardinality, Policy, PolicyAction
 from vre.core.grounding import GroundingResult
 from vre.core.policy import PolicyResult
 from vre.learning.callback import LearningCallback
@@ -145,25 +145,25 @@ class TestCheckPolicyCardinality:
         """Passing cardinality="multiple" triggers a MULTIPLE-scoped policy."""
         vre = self._setup(Cardinality.MULTIPLE)
         result = vre.check_policy(["write", "file"], cardinality="multiple")
-        assert result.action == "PENDING"
+        assert result.action == PolicyAction.PENDING
 
     def test_cardinality_single_does_not_trigger_multiple_scoped_policy(self):
         """Passing cardinality="single" skips a MULTIPLE-scoped policy → PASS."""
         vre = self._setup(Cardinality.MULTIPLE)
         result = vre.check_policy(["write", "file"], cardinality="single")
-        assert result.action == "PASS"
+        assert result.action == PolicyAction.PASS
 
     def test_cardinality_none_triggers_always_on_policy(self):
         """trigger_cardinality=None means the policy always fires regardless of cardinality."""
         vre = self._setup(trigger_cardinality=None)
-        assert vre.check_policy(["write", "file"], cardinality="single").action == "PENDING"
-        assert vre.check_policy(["write", "file"], cardinality="multiple").action == "PENDING"
+        assert vre.check_policy(["write", "file"], cardinality="single").action == PolicyAction.PENDING
+        assert vre.check_policy(["write", "file"], cardinality="multiple").action == PolicyAction.PENDING
 
     def test_unknown_cardinality_string_falls_back_to_single(self):
         """Unrecognised cardinality string → treated as SINGLE, not an error."""
         vre = self._setup(Cardinality.MULTIPLE)
         result = vre.check_policy(["write", "file"], cardinality="bulk_delete_everything")
-        assert result.action == "PASS"  # falls back to SINGLE, MULTIPLE policy skipped
+        assert result.action == PolicyAction.PASS  # falls back to SINGLE, MULTIPLE policy skipped
 
 
 class TestVRECheck:
@@ -208,7 +208,7 @@ class TestVRECheck:
         vre = _make_vre_with_stub([file_p])
         result = vre.check_policy(["file"])
         assert isinstance(result, PolicyResult)
-        assert result.action in ("PASS", "PENDING", "BLOCK")
+        assert result.action in (PolicyAction.PASS, PolicyAction.PENDING, PolicyAction.BLOCK)
 
     def test_check_empty_concepts_returns_not_grounded(self):
         """check([]) returns grounded=False with no gaps."""
@@ -225,7 +225,7 @@ class TestVRECheck:
         grounding = vre.check(["file"])
         result = vre.check_policy(grounding)
         assert isinstance(result, PolicyResult)
-        assert result.action == "PASS"
+        assert result.action == PolicyAction.PASS
 
     def test_check_policy_returns_pass_when_no_trace(self):
         """check_policy returns PASS when GroundingResult has no trace."""
@@ -233,7 +233,7 @@ class TestVRECheck:
         vre = _make_vre_with_stub([file_p])
         grounding = GroundingResult(grounded=True, resolved=["file"], gaps=[], trace=None)
         result = vre.check_policy(grounding)
-        assert result.action == "PASS"
+        assert result.action == PolicyAction.PASS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `PolicyAction(str, Enum)` with `PASS`, `PENDING`, `BLOCK` members
- Changes `PolicyResult.action` type from `str` to `PolicyAction`
- Replaces all hardcoded string literals and comparisons across source and tests
- Exports `PolicyAction` from `vre.core.policy` and `vre` top-level

Closes #20

## Test plan
- [x] All 76 existing tests pass with no assertion changes needed (`str, Enum` remains `==`-comparable to strings)
- [ ] Verify CI passes (linting + pytest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)