### PR TITLE
Implement structured logging across VRE

### DIFF
--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -15,6 +15,7 @@ Usage::
     print(result.grounded, result.resolved)
 """
 
+import logging
 from typing import Callable
 
 from vre.core.graph import PrimitiveRepository
@@ -40,6 +41,8 @@ from vre.learning import (
     LearningEngine,
     LearningResult,
 )
+
+logging.getLogger("vre").addHandler(logging.NullHandler())
 
 __all__ = [
     "VRE",

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -10,6 +10,7 @@ with embedded depth JSON; relata are stored as typed Neo4j relationships.
 """
 
 import json
+import logging
 from typing import Any, LiteralString, cast
 from uuid import UUID
 
@@ -37,6 +38,8 @@ from vre.core.policy.models import parse_policy
 
 
 _TRANSITIVE_RELS = [rt.value for rt in TRANSITIVE_RELATION_TYPES]
+
+logger = logging.getLogger(__name__)
 
 
 class PrimitiveRepository:
@@ -83,6 +86,7 @@ class PrimitiveRepository:
         """
         Create uniqueness constraint on Primitive.id.
         """
+        logger.debug("Ensuring uniqueness constraint on Primitive.id")
         try:
             with self._driver.session(database=self._database) as session:
                 session.run(
@@ -93,6 +97,7 @@ class PrimitiveRepository:
                     )
                 )
         except Neo4jError as exc:
+            logger.error("Failed to ensure Neo4j constraints: %s", exc)
             raise GraphError(f"Failed to ensure constraints: {exc}") from exc
 
     @staticmethod
@@ -174,6 +179,7 @@ class PrimitiveRepository:
                 provenance=node_prov,
             )
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            logger.error("Hydration failed for primitive %r: %s", node_data.get("name", "?"), exc)
             raise HydrationError(
                 f"Failed to hydrate primitive '{node_data.get('name', '?')}': {exc}"
             ) from exc
@@ -200,6 +206,7 @@ class PrimitiveRepository:
                 continue
 
             if rp["target_id"] == source_id:
+                logger.warning("Self-referential %s detected on primitive %s", rp["relation_type"], source_id)
                 raise CyclicRelationshipError(
                     f"Self-referential {rp['relation_type']} on {source_id}"
                 )
@@ -218,6 +225,10 @@ class PrimitiveRepository:
             ).single()
 
             if record and record["would_cycle"]:
+                logger.warning(
+                    "Cycle detected: %s from %s to %s would create a cycle",
+                    rp["relation_type"], source_id, rp["target_id"],
+                )
                 raise CyclicRelationshipError(
                     f"{rp['relation_type']} from {source_id} to "
                     f"{rp['target_id']} would create a cycle"
@@ -244,6 +255,11 @@ class PrimitiveRepository:
                         "provenance": json.dumps(relatum.provenance.model_dump(mode="json")) if relatum.provenance else None,
                     }
                 )
+
+        logger.debug(
+            "Saving primitive %r (id=%s, depths=%d, relata=%d)",
+            primitive.name, primitive.id, len(primitive.depths), len(relata_params),
+        )
 
         rel_types = [rt.value for rt in RelationType]
 
@@ -304,6 +320,7 @@ class PrimitiveRepository:
         except CyclicRelationshipError:
             raise
         except Neo4jError as exc:
+            logger.error("Neo4j error saving primitive %r: %s", primitive.name, exc)
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
 
     def list_names(self) -> list[str]:
@@ -349,6 +366,7 @@ class PrimitiveRepository:
             with self._driver.session(database=self._database) as session:
                 record = session.run(cypher, id=str(id)).single()
                 if record is None or record["id"] is None:
+                    logger.debug("Primitive not found by id=%s", id)
                     return None
 
                 node_data = {
@@ -376,6 +394,7 @@ class PrimitiveRepository:
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
+            logger.error("Neo4j error finding primitive by id=%s: %s", id, exc)
             raise GraphError(f"Failed to find primitive by id '{id}': {exc}") from exc
 
     def find_by_name(self, name: str) -> Primitive | None:
@@ -409,6 +428,7 @@ class PrimitiveRepository:
             with self._driver.session(database=self._database) as session:
                 record = session.run(cypher, name=name).single()
                 if record is None or record["id"] is None:
+                    logger.debug("Primitive not found by name=%r", name)
                     return None
 
                 node_data = {
@@ -436,6 +456,7 @@ class PrimitiveRepository:
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
+            logger.error("Neo4j error finding primitive by name=%r: %s", name, exc)
             raise GraphError(f"Failed to find primitive by name '{name}': {exc}") from exc
 
     def delete_primitive(self, id: UUID) -> bool:
@@ -462,6 +483,7 @@ class PrimitiveRepository:
         """
         Single-query Cypher traversal that resolves a subgraph for the given names.
         """
+        logger.debug("Resolving subgraph for names=%s", names)
         lowered = [n.lower() for n in names]
 
         cypher = cast(
@@ -551,8 +573,13 @@ class PrimitiveRepository:
                     for e in raw_edges
                 ]
 
+                logger.debug(
+                    "Subgraph resolved: %d roots, %d nodes, %d edges",
+                    len(roots), len(nodes), len(edges),
+                )
                 return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
+            logger.error("Neo4j error resolving subgraph for %s: %s", names, exc)
             raise GraphError(f"Failed to resolve subgraph for {names}: {exc}") from exc

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -16,6 +16,7 @@ lever to enforce a stricter floor than the graph alone would require.
 
 from __future__ import annotations
 
+import logging
 from uuid import UUID
 
 from vre.core.graph import PrimitiveRepository
@@ -44,6 +45,9 @@ def _empty_response() -> EpistemicResponse:
         query=EpistemicQuery(concept_ids=[]),
         result=EpistemicResult(primitives=[]),
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 class GroundingEngine:
@@ -124,6 +128,7 @@ class GroundingEngine:
                 visible.append(edge)
             else:
                 gated.append(edge)
+        logger.debug("Edge partition: %d visible, %d gated", len(visible), len(gated))
         return visible, gated
 
     @staticmethod
@@ -210,6 +215,10 @@ class GroundingEngine:
                 current_depth=curr,
             ))
 
+        if gaps:
+            logger.info("Detected %d gap(s): %s", len(gaps), [g.kind for g in gaps])
+        else:
+            logger.debug("No gaps detected")
         return gaps
 
     @staticmethod
@@ -274,6 +283,7 @@ class GroundingEngine:
             it below what the graph structure requires.
         """
         if not concepts:
+            logger.debug("Empty concept list, returning empty response")
             return _empty_response()
 
         subgraph = self._repo.resolve_subgraph(concepts)
@@ -282,6 +292,10 @@ class GroundingEngine:
         transient_ids = {t.id for t in transients}
         root_ids = {r.id for r in roots}
         all_nodes = list(subgraph.nodes) + transients
+        logger.debug(
+            "Query for %s: resolved %d roots (%d transient), %d nodes, %d edges",
+            concepts, len(roots), len(transients), len(all_nodes), len(subgraph.edges),
+        )
 
         id_to_prim = {n.id: n for n in all_nodes}
         visible_edges, gated_edges = self._partition_edges_by_source_depth(
@@ -309,6 +323,7 @@ class GroundingEngine:
             reachable = self._reachable_undirected(anchor.id, neighbors)
             for root in non_transient_roots:
                 if root.id != anchor.id and root.id not in reachable:
+                    logger.warning("Reachability gap: %r is isolated from other query roots", root.name)
                     gaps.append(ReachabilityGap(primitive=root))
 
         filtered = self._filter_depths(all_nodes)
@@ -333,6 +348,7 @@ class GroundingEngine:
         all concepts are grounded with no gaps.
         """
         if not concepts:
+            logger.debug("Ground called with empty concepts")
             return GroundingResult(grounded=False, resolved=[], gaps=[], trace=None)
 
         # Resolve to canonical names where possible; unknown names pass through
@@ -342,9 +358,11 @@ class GroundingEngine:
             (resolver.lookup(c, name_map) or c)
             for c in concepts
         ]
+        logger.info("Grounding %d concept(s): %s -> canonical: %s", len(concepts), concepts, canonical)
 
         response = self.query(canonical, min_depth=min_depth)
         grounded = len(response.result.gaps) == 0
+        logger.info("Grounding result: grounded=%s, gaps=%d", grounded, len(response.result.gaps))
         return GroundingResult(
             grounded=grounded,
             resolved=canonical,

--- a/src/vre/core/grounding/resolver.py
+++ b/src/vre/core/grounding/resolver.py
@@ -11,10 +11,14 @@ similarity scoring.
 
 from __future__ import annotations
 
+import logging
 from functools import lru_cache
 
 from vre.core.errors import ResolutionError
 from vre.core.graph import PrimitiveRepository
+
+
+logger = logging.getLogger(__name__)
 
 
 @lru_cache(maxsize=1)
@@ -26,6 +30,7 @@ def _nlp():
         import spacy
         return spacy.load("en_core_web_sm")
     except OSError as exc:
+        logger.error("spaCy model 'en_core_web_sm' not found: %s", exc)
         raise ResolutionError(
             "spaCy model not found. Run: python -m spacy download en_core_web_sm"
         ) from exc
@@ -75,11 +80,14 @@ class ConceptResolver:
         """
         # Try direct lowercase match first
         if concept.lower() in name_map:
+            logger.debug("Concept %r matched directly to %r", concept, name_map[concept.lower()])
             return name_map[concept.lower()]
         # Try each lemma
         for lemma in lemmatize(concept):
             if lemma in name_map:
+                logger.debug("Concept %r matched via lemma %r to %r", concept, lemma, name_map[lemma])
                 return name_map[lemma]
+        logger.debug("Concept %r: no match found in name map", concept)
         return None
 
     def resolve(self, concepts: list[str]) -> list[str]:

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -5,9 +5,13 @@
 PolicyGate — evaluates policy violations against an epistemic trace.
 """
 
+import logging
+
 from vre.core.models import EpistemicResponse, RelationType
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.models import Cardinality, PolicyCallbackResult, PolicyViolation
+
+logger = logging.getLogger(__name__)
 
 
 class PolicyGate:
@@ -36,12 +40,17 @@ class PolicyGate:
                         if (cardinality is not None
                                 and policy.trigger_cardinality is not None
                                 and policy.trigger_cardinality != cardinality):
+                            logger.debug(
+                                "Policy %r skipped: trigger_cardinality=%s does not match %s",
+                                policy.name, policy.trigger_cardinality, cardinality,
+                            )
                             continue
                         cb = policy.resolve_callback()
                         cb_result: PolicyCallbackResult | None = None
                         if cb is not None and call_context is not None:
                             cb_result = cb(call_context)
                             if cb_result.passed:
+                                logger.debug("Policy %r passed by callback", policy.name)
                                 continue  # action passed the policy — no violation
 
                         try:
@@ -51,6 +60,10 @@ class PolicyGate:
                         except (KeyError, ValueError):
                             message = policy.confirmation_message
 
+                        logger.info(
+                            "Policy violation: %r — %s (requires_confirmation=%s)",
+                            policy.name, message, policy.requires_confirmation,
+                        )
                         violations.append(PolicyViolation(
                             policy=policy,
                             message=message,
@@ -68,4 +81,10 @@ class PolicyGate:
         """
         Evaluate all policies in the trace and return triggered violations.
         """
-        return self._collect_violations(response, cardinality, call_context)
+        logger.debug("Evaluating policies (cardinality=%s, has_context=%s)", cardinality, call_context is not None)
+        violations = self._collect_violations(response, cardinality, call_context)
+        if violations:
+            logger.info("Policy evaluation: %d violation(s)", len(violations))
+        else:
+            logger.debug("Policy evaluation: no violations")
+        return violations

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -27,6 +27,7 @@ Each call runs grounding → policy → execution in a single pass:
 from __future__ import annotations
 
 import functools
+import logging
 from typing import TYPE_CHECKING, Callable
 
 from vre.core.models import DepthLevel
@@ -44,6 +45,8 @@ if TYPE_CHECKING:
 # dynamically at call time.
 ConceptsInput = list[str] | Callable[..., list[str]]
 CardinalityInput = str | None | Callable[..., str | None]
+
+logger = logging.getLogger(__name__)
 
 
 def vre_guard(
@@ -98,16 +101,19 @@ def vre_guard(
             Run grounding → learning [optional] → policy → execution on each call.
             """
             resolved_concepts = concepts(*args, **kwargs) if callable(concepts) else concepts
+            logger.info("Guard %r: grounding %d concept(s) %s", tool_name, len(resolved_concepts), resolved_concepts)
             grounding = vre.check(resolved_concepts, min_depth=min_depth)
             if on_trace:
                 on_trace(grounding)
 
             if not grounding.grounded and on_learn:
+                logger.info("Guard %r: entering learning loop (%d gaps)", tool_name, len(grounding.gaps))
                 grounding = vre.learn_all(grounding, on_learn, resolved_concepts, min_depth=min_depth)
                 if on_trace:
                     on_trace(grounding)
 
             if not grounding.grounded:
+                logger.info("Guard %r: not grounded, returning GroundingResult (%d gaps)", tool_name, len(grounding.gaps))
                 result = grounding
             else:
                 # Policy evaluation
@@ -126,8 +132,10 @@ def vre_guard(
                 )
 
                 if policy.action == PolicyAction.BLOCK:
+                    logger.info("Guard %r: policy BLOCKED — %s", tool_name, policy.reason)
                     result = policy
                 else:
+                    logger.debug("Guard %r: grounded and policy passed, executing function", tool_name)
                     result = fn(*args, **kwargs)
 
             return result

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -8,6 +8,7 @@ Processes one gap at a time: template creation -> callback invocation ->
 validation -> persistence -> re-grounding.
 """
 
+import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -77,6 +78,9 @@ def _resolve_name_to_id(name: str, grounding: GroundingResult) -> UUID:
     raise CandidateValidationError(f"Cannot resolve '{name}' to a primitive ID from the grounding trace")
 
 
+logger = logging.getLogger(__name__)
+
+
 class LearningEngine:
     """
     Processes knowledge gaps via the auto-learning loop.
@@ -98,6 +102,7 @@ class LearningEngine:
         Persist a new primitive with D0 (auto-generated) and agent-provided D1.
         """
         if candidate.d1 is None:
+            logger.warning("ExistenceCandidate %r missing D1 (identity)", candidate.name)
             raise CandidateValidationError(f"ExistenceCandidate '{candidate.name}' is missing D1 (identity)")
 
         d0 = Depth(
@@ -113,6 +118,7 @@ class LearningEngine:
             provenance=provenance,
         )
         self._repo.save_primitive(primitive)
+        logger.info("Persisted new primitive %r with D0+D1", candidate.name)
 
     def _merge_depths(
         self, primitive: Primitive, new_depths: list[ProposedDepth], provenance: Provenance,
@@ -123,6 +129,11 @@ class LearningEngine:
         Converts ProposedDepth → Depth, replaces existing depth levels when the
         level already exists, appends otherwise. Sorts and saves.
         """
+        logger.debug(
+            "Merging %d proposed depth(s) into %r (existing levels: %s)",
+            len(new_depths), primitive.name,
+            sorted(int(d.level) for d in primitive.depths),
+        )
         existing_levels = {d.level for d in primitive.depths}
         touched_levels: set[DepthLevel] = set()
         for proposed in new_depths:
@@ -159,6 +170,7 @@ class LearningEngine:
         Merge new depth levels into an existing primitive and persist.
         """
         if not candidate.new_depths:
+            logger.warning("DepthCandidate for %r has no new depths", gap.primitive.name)
             raise CandidateValidationError(f"DepthCandidate for '{gap.primitive.name}' has no new depths")
 
         existing = self._repo.find_by_id(gap.primitive.id)
@@ -166,6 +178,10 @@ class LearningEngine:
             raise CandidateValidationError(f"Primitive '{gap.primitive.name}' ({gap.primitive.id}) not found")
 
         self._merge_depths(existing, candidate.new_depths, provenance)
+        logger.debug(
+            "Merged depths into %r: levels=%s",
+            existing.name, [int(d.level) for d in candidate.new_depths],
+        )
 
     def _persist_relational(
         self, gap: RelationalGap, candidate: RelationalCandidate, provenance: Provenance,
@@ -174,6 +190,7 @@ class LearningEngine:
         Merge new depth levels into the target primitive and persist.
         """
         if not candidate.new_depths:
+            logger.warning("RelationalCandidate for %r has no new depths", gap.target.name)
             raise CandidateValidationError(f"RelationalCandidate for '{gap.target.name}' has no new depths")
 
         target = self._repo.find_by_id(gap.target.id)
@@ -181,6 +198,7 @@ class LearningEngine:
             raise CandidateValidationError(f"Target '{gap.target.name}' ({gap.target.id}) not found")
 
         self._merge_depths(target, candidate.new_depths, provenance)
+        logger.debug("Merged relational depths into target %r", target.name)
 
     def _learn_missing_depths(
         self,
@@ -196,9 +214,15 @@ class LearningEngine:
         """
         existing_levels = {d.level for d in primitive.depths}
         if required_level in existing_levels:
+            logger.debug("Depth D%d already present on %r, skipping sub-learning", int(required_level), primitive.name)
             return None
 
         current_depth = max(existing_levels, key=lambda lv: lv.value) if existing_levels else None
+        logger.debug(
+            "Synthesized DepthGap for %r: requires D%d, current=%s",
+            primitive.name, int(required_level),
+            ("D" + str(int(current_depth))) if current_depth is not None else "None",
+        )
         gap = DepthGap(
             primitive=primitive,
             required_depth=required_level,
@@ -210,6 +234,7 @@ class LearningEngine:
         if decision in (CandidateDecision.SKIPPED, CandidateDecision.REJECTED):
             return decision
         if filled is None:
+            logger.warning("Callback returned None for synthesized depth gap on %r, treating as REJECTED", primitive.name)
             return CandidateDecision.REJECTED
 
         provenance = _make_provenance(decision)
@@ -232,6 +257,10 @@ class LearningEngine:
         If depth learning is rejected or skipped, edge placement is abandoned.
         """
         if candidate.target_name is None or candidate.relation_type is None:
+            logger.warning(
+                "ReachabilityCandidate for %r missing target_name or relation_type",
+                gap.primitive.name,
+            )
             raise CandidateValidationError(
                 f"ReachabilityCandidate for '{gap.primitive.name}' is missing "
                 f"target_name or relation_type"
@@ -253,6 +282,10 @@ class LearningEngine:
             raise CandidateValidationError(f"Target '{candidate.target_name}' ({target_id}) not found")
 
         # Phase 1: learn missing depths on source, then target
+        logger.debug(
+            "Reachability two-phase: learning missing depths on source=%r, target=%r",
+            source.name, target.name,
+        )
         result = self._learn_missing_depths(source, candidate.source_depth_level, grounding, callback)
         if result in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
             return result
@@ -264,6 +297,11 @@ class LearningEngine:
             return result
 
         # Phase 2: place the edge
+        logger.debug(
+            "Reachability two-phase: placing %s edge from %r (D%d) to %r (D%d)",
+            candidate.relation_type.value, source.name, int(candidate.source_depth_level),
+            candidate.target_name, int(candidate.target_depth_level),
+        )
         depth_obj = next(d for d in source.depths if d.level == candidate.source_depth_level)
 
         new_relatum = Relatum(
@@ -278,7 +316,12 @@ class LearningEngine:
 
         try:
             self._repo.save_primitive(source)
-        except CyclicRelationshipError:
+        except CyclicRelationshipError as exc:
+            logger.error(
+                "Cyclic relationship error placing %s edge from %r (%s) to %s: %s",
+                candidate.relation_type.value, gap.primitive.name,
+                gap.primitive.id, target_id, exc,
+            )
             depth_obj.relata.remove(new_relatum)
             raise
 
@@ -321,21 +364,29 @@ class LearningEngine:
             raise CandidateValidationError(f"Gap index {gap_index} out of range (0..{len(grounding.gaps) - 1})")
 
         gap = grounding.gaps[gap_index]
+        logger.info("Learning at gap_index=%d, gap_kind=%s", gap_index, gap.kind)
         candidate = TemplateFactory.from_gap(gap)
         filled, decision = callback(candidate, grounding, gap)
 
         if decision == CandidateDecision.SKIPPED:
+            logger.info("Gap %d skipped by callback", gap_index)
             return LearningResult(decision=CandidateDecision.SKIPPED, candidate=candidate)
 
         if decision == CandidateDecision.REJECTED or filled is None:
+            logger.info("Gap %d rejected by callback", gap_index)
             return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
 
+        logger.debug(
+            "Persisting %s candidate for gap %d (decision=%s)",
+            type(filled).__name__, gap_index, decision.value,
+        )
         provenance = _make_provenance(decision)
         override = self._persist(gap, filled, grounding, callback, provenance)
 
         # Reachability two-phase can override the decision if depth
         # learning was rejected or skipped
         if override in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+            logger.info("Reachability two-phase override: %s", override.value)
             return LearningResult(decision=override, candidate=filled)
 
         return LearningResult(decision=decision, candidate=filled)


### PR DESCRIPTION
Closes #39

## Summary

- Adds Python stdlib `logging` across 7 modules as a secondary diagnostic channel behind the existing callback hooks
- `NullHandler` on the root `"vre"` logger ensures silent defaults — integrators opt in by configuring their own handlers
- Module-level loggers via `getLogger(__name__)` produce a natural hierarchy (`vre.core.graph`, `vre.learning.engine`, etc.)
- Uses `%s`/`%r` lazy formatting throughout (no f-strings in log calls)
- **No public interface changes** — logging is a pure side effect

## Key log points

| Module | Level | What |
|--------|-------|------|
| `learning/engine.py` | **ERROR** | `CyclicRelationshipError` during reachability edge placement (the issue trigger) |
| `core/graph.py` | WARNING | Cycle detection in `_check_transitive_cycles()` |
| `grounding/engine.py` | WARNING | Reachability gaps (isolated roots) |
| `grounding/engine.py` | INFO | Grounding results, gap detection summaries |
| `policy/gate.py` | INFO | Policy violations |
| `guard.py` | INFO | Guard lifecycle (grounding, learning loop, policy block) |
| `resolver.py` | ERROR | spaCy model not found |

## Test plan

- [x] All 194 existing tests pass
- [x] Coverage remains at 75% (above 70% threshold)
- [ ] Manual: configure a handler on `logging.getLogger("vre")` and trigger a grounding check to verify output

<details>
<summary>Implementation plan</summary>

# Plan: Implement Structured Logging Across VRE (#39)

## Context

VRE has zero logging today. All observability is through callback hooks (`on_trace`, `on_policy`, `LearningCallback`) and exceptions. The immediate trigger: when `CyclicRelationshipError` is caught in `learning/engine.py:281`, the descriptive error message is swallowed — there's no logged context about what happened.

This plan adds Python stdlib `logging` as a secondary diagnostic channel without changing any public interfaces.

## Design Decisions

1. **NullHandler on `"vre"` root logger** — Yes. Standard library best practice for libraries. Prevents "No handler found" warnings for integrators who don't configure logging.

2. **Logger naming** — `logging.getLogger(__name__)` per module. Produces natural hierarchy: `vre.core.graph`, `vre.core.grounding.engine`, `vre.learning.engine`, `vre.core.policy.gate`.

3. **Message format** — Human-readable sentences with key identifiers embedded via `%s`/`%r` formatting (lazy evaluation). No `extra={}` structured fields — keeps it simple, no custom Formatters required.

4. **Callbacks remain primary** — Logging is secondary. `on_trace`, `on_policy`, and `LearningCallback` are the integrator contract. Logging serves operators and debuggers with fine-grained detail callbacks don't carry.

5. **`%` formatting, not f-strings** — `logging` defers `%`-style interpolation until the handler emits. f-strings would eagerly evaluate at DEBUG level in hot paths.

## Files Modified

### 1. `src/vre/__init__.py` — NullHandler (2 lines)

```python
import logging

logging.getLogger("vre").addHandler(logging.NullHandler())
```

### 2. `src/vre/learning/engine.py` — LearningEngine (PRIMARY)

Add `import logging` to stdlib imports, `logger = logging.getLogger(__name__)` at module level.

Key log calls:
| Method | Level | What |
|--------|-------|------|
| `learn_at()` entry | INFO | gap index + gap kind |
| `learn_at()` SKIPPED/REJECTED | INFO | decision |
| `_persist_existence()` | INFO | new primitive name |
| `_persist_depth()` / `_persist_relational()` | DEBUG | merge details |
| `_persist_reachability()` phases | DEBUG | two-phase progress |
| **`_persist_reachability()` CyclicRelationshipError catch (line 281)** | ERROR | relation type, source/target names, error message — **the issue trigger** (ERROR because the exception re-raises and will likely halt the learning attempt) |
| `_merge_depths()` | DEBUG | depth levels being merged |
| `_learn_missing_depths()` | DEBUG | synthesized gap details |

Critical fix at line 281: change `except CyclicRelationshipError:` to `except CyclicRelationshipError as exc:` and add `logger.error(...)` before the rollback+re-raise.

### 3. `src/vre/core/graph.py` — PrimitiveRepository

Key log calls:
| Method | Level | What |
|--------|-------|------|
| `save_primitive()` | DEBUG | primitive name, id, depth/relata counts |
| `_check_transitive_cycles()` | WARNING | self-referential or cycle detection |
| `save_primitive()` error catches | ERROR | CyclicRelationshipError, Neo4jError |
| `find_by_id()` / `find_by_name()` not found | DEBUG | lookup miss |
| `find_by_id()` / `find_by_name()` Neo4jError | ERROR | error detail |
| `resolve_subgraph()` | DEBUG | entry (names) + exit (root/node/edge counts) |
| `_hydrate_primitive()` failure | ERROR | hydration error detail |
| `ensure_constraints()` | DEBUG/ERROR | entry + Neo4j error |

### 4. `src/vre/core/grounding/engine.py` — GroundingEngine

Key log calls:
| Method | Level | What |
|--------|-------|------|
| `ground()` | INFO | concept list + canonical names + result (grounded/gap count) |
| `query()` | DEBUG | resolved subgraph stats |
| `_detect_gaps()` | DEBUG per gap, INFO summary | gap type + details |
| `_partition_edges_by_source_depth()` | DEBUG | visible/gated edge counts |
| Reachability gaps | WARNING | isolated root names |

### 5. `src/vre/core/policy/gate.py` — PolicyGate

Key log calls:
| Method | Level | What |
|--------|-------|------|
| `evaluate()` | DEBUG entry, INFO/DEBUG exit | cardinality + violation count |
| `_collect_violations()` | DEBUG | policy checks, cardinality skips, callback results |
| Violation appended | INFO | policy name, message, requires_confirmation |

### 6. `src/vre/guard.py` — vre_guard decorator

Key log calls:
| Location | Level | What |
|----------|-------|------|
| After concept resolution | INFO | tool name, concept count |
| Entering learning loop | INFO | gap count |
| Not grounded, returning | INFO | gap count |
| Policy BLOCK | INFO | reason |
| Executing function | DEBUG | tool name |

### 7. `src/vre/core/grounding/resolver.py` — ConceptResolver

Key log calls:
| Location | Level | What |
|----------|-------|------|
| spaCy model not found | ERROR | OSError detail |
| Concept match (direct/lemma/miss) | DEBUG | concept + match result |

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)