### PR TITLE
Address Copilot review feedback on logging

### DIFF
--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -358,7 +358,8 @@ class GroundingEngine:
             (resolver.lookup(c, name_map) or c)
             for c in concepts
         ]
-        logger.info("Grounding %d concept(s): %s -> canonical: %s", len(concepts), concepts, canonical)
+        logger.info("Grounding %d concept(s)", len(concepts))
+        logger.debug("Grounding concepts: %s -> canonical: %s", concepts, canonical)
 
         response = self.query(canonical, min_depth=min_depth)
         grounded = len(response.result.gaps) == 0

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -101,7 +101,8 @@ def vre_guard(
             Run grounding → learning [optional] → policy → execution on each call.
             """
             resolved_concepts = concepts(*args, **kwargs) if callable(concepts) else concepts
-            logger.info("Guard %r: grounding %d concept(s) %s", tool_name, len(resolved_concepts), resolved_concepts)
+            logger.info("Guard %r: grounding %d concept(s)", tool_name, len(resolved_concepts))
+            logger.debug("Guard %r: concepts %s", tool_name, resolved_concepts)
             grounding = vre.check(resolved_concepts, min_depth=min_depth)
             if on_trace:
                 on_trace(grounding)

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -316,11 +316,14 @@ class LearningEngine:
 
         try:
             self._repo.save_primitive(source)
-        except CyclicRelationshipError as exc:
-            logger.error(
-                "Cyclic relationship error placing %s edge from %r (%s) to %s: %s",
-                candidate.relation_type.value, gap.primitive.name,
-                gap.primitive.id, target_id, exc,
+        except CyclicRelationshipError:
+            logger.exception(
+                "Cyclic relationship error placing %s edge from %r (%s) to %r (%s)",
+                candidate.relation_type.value,
+                source.name,
+                source.id,
+                target.name,
+                target.id,
             )
             depth_obj.relata.remove(new_relatum)
             raise
@@ -372,8 +375,16 @@ class LearningEngine:
             logger.info("Gap %d skipped by callback", gap_index)
             return LearningResult(decision=CandidateDecision.SKIPPED, candidate=candidate)
 
-        if decision == CandidateDecision.REJECTED or filled is None:
+        if decision == CandidateDecision.REJECTED:
             logger.info("Gap %d rejected by callback", gap_index)
+            return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
+
+        if filled is None:
+            logger.warning(
+                "Callback for gap %d returned no candidate (decision=%s); treating as REJECTED",
+                gap_index,
+                decision.value,
+            )
             return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
 
         logger.debug(


### PR DESCRIPTION
Follow-up to #44 — addresses all 4 Copilot review comments.

## Summary

- Split `learn_at` REJECTED/`filled is None` into distinct branches with separate log messages (WARNING for the None case)
- Use `source`/`target` variables instead of `gap.primitive` in the cycle detection error log for accuracy
- Switch to `logger.exception` for cycle detection to include traceback
- Move concept lists from INFO to DEBUG in `guard.py` and `grounding/engine.py` (INFO now logs only counts)

## Test plan

- [x] All 194 tests pass
- [x] Coverage at 75%

🤖 Generated with [Claude Code](https://claude.com/claude-code)