### PR TITLE
Add agent identity to trace entries via persisted registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,24 @@ repo = PrimitiveRepository(
 vre = VRE(repo)
 ```
 
+An optional `agent_key` associates the VRE instance with a stable agent identity. The key is resolved via a file-based registry (`~/.vre/agents.json`) so that the same key always maps to the same UUID, even across restarts. When configured, every `GroundingResult` produced by this instance carries the agent's `agent_id`.
+
+```python
+vre = VRE(repo, agent_key="my-agent", agent_name="My Agent")
+
+vre.identity.agent_id    # stable UUID, persisted across restarts
+vre.identity.name        # "My Agent"
+```
+
+`agent_name` is a human-readable label used only on first registration — subsequent calls with the same key return the existing identity. Both parameters are optional; without `agent_key`, traces are anonymous and `vre.identity` is `None`.
+
+You may also pass an optional `registry_path` to customize the location of the agent registry file.
+By default, it is `~/.vre/agents.json`.
+
+```python
+vre = VRE(repo, agent_key="my-agent", agent_name="My Agent", registry_path="/path/to/registry.json")
+```
+
 ### Checking Grounding Directly
 
 ```python
@@ -382,6 +400,7 @@ def on_trace(grounding: GroundingResult) -> None:
 - `resolved: list[str]` — canonical primitive names (or original if unresolvable)
 - `gaps: list[KnowledgeGap]` — structured gap descriptions (`ExistenceGap`, `DepthGap`, `RelationalGap`, `ReachabilityGap`)
 - `trace: EpistemicResponse | None` — the full subgraph with all primitives, depths, relata, and pathway
+- `agent_id: UUID | None` — the stable agent identifier, when the VRE instance was created with an `agent_key`
 
 The demo renders `on_trace` as a Rich tree showing each primitive with a dot-per-depth progress indicator and its relata:
 
@@ -733,6 +752,9 @@ related concepts.
 src/vre/
   __init__.py              # VRE public interface (check, learn, learn_all, check_policy)
   guard.py                 # vre_guard decorator (grounding → learning → policy → execution)
+  identity/
+    models.py              # AgentIdentity — stable UUID bound to a registration key
+    registry.py            # AgentRegistry — file-based, append-only identity persistence
   core/
     models.py              # Primitive, Depth, Relatum, RelationType, DepthLevel, gaps, Provenance
     graph.py               # PrimitiveRepository (Neo4j)

--- a/examples/langchain_ollama/main.py
+++ b/examples/langchain_ollama/main.py
@@ -34,7 +34,7 @@ def main() -> None:
     os.makedirs(args.sandbox, exist_ok=True)
 
     repo = PrimitiveRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
-    vre = VRE(repo)
+    vre = VRE(repo, agent_key="langchain-ollama-demo-agent", agent_name="Langchain Ollama Demo Agent")
 
     concepts = ConceptExtractor(model=args.concepts_model)
     on_learn = make_on_learn(model=args.model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.3.4"
+version = "0.4.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -16,6 +16,7 @@ Usage::
 """
 
 import logging
+from pathlib import Path
 from typing import Callable
 
 from vre.core.graph import PrimitiveRepository
@@ -27,6 +28,7 @@ from vre.core.errors import (
     GraphIntegrityError,
     HydrationError,
     PersistenceError,
+    RegistryError,
     ResolutionError,
     VREError,
 )
@@ -34,6 +36,7 @@ from vre.core.models import DepthLevel, Provenance, ProvenanceSource
 from vre.core.policy import Cardinality, PolicyAction, PolicyCallbackResult, PolicyResult, PolicyViolation
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
+from vre.identity import AgentIdentity, AgentRegistry
 from vre.learning import (
     CandidateDecision,
     LearningCallback,
@@ -46,12 +49,15 @@ logging.getLogger("vre").addHandler(logging.NullHandler())
 
 __all__ = [
     "VRE",
+    "AgentIdentity",
+    "AgentRegistry",
     "CandidateValidationError",
     "CyclicRelationshipError",
     "GraphError",
     "GraphIntegrityError",
     "HydrationError",
     "PersistenceError",
+    "RegistryError",
     "ResolutionError",
     "VREError",
     "PrimitiveRepository",
@@ -85,14 +91,57 @@ class VRE:
     integrators enforce a stricter floor.
     """
 
-    def __init__(self, repository: PrimitiveRepository) -> None:
+    def __init__(
+        self,
+        repository: PrimitiveRepository,
+        agent_key: str | None = None,
+        agent_name: str | None = None,
+        registry_path: str | Path | None = None,
+    ) -> None:
         """
         Initialize VRE with the given primitive repository.
+
+        Parameters
+        ----------
+        repository:
+            The Neo4j primitive repository for graph operations.
+        agent_key:
+            Optional registration key for agent identity. When provided,
+            the key is resolved via the persisted registry to a stable
+            AgentIdentity whose `agent_id` is stamped on every
+            GroundingResult produced by this instance.
+        agent_name:
+            Optional human-readable name for the agent. Only used on
+            first registration; ignored on subsequent calls with the
+            same `agent_key`.
+        registry_path:
+            Path to the agent registry JSON file. Defaults to
+            `AgentRegistry`'s built-in default when None.
         """
         self._repo = repository
         self._resolver = ConceptResolver(repository)
         self._engine = GroundingEngine(repository)
         self._learning_engine = LearningEngine(repository)
+
+        if agent_key is not None:
+            self._identity: AgentIdentity | None = AgentRegistry(registry_path).get_or_create(agent_key, name=agent_name)
+        else:
+            self._identity = None
+
+    @property
+    def identity(self) -> AgentIdentity | None:
+        """
+        The agent identity associated with this VRE instance, if any.
+        """
+        return self._identity
+
+    def _stamp_identity(self, result: GroundingResult) -> GroundingResult:
+        """
+        Set `agent_id` on the result if this instance has an identity and the result doesn't already have one.
+        """
+        if self._identity is not None and result.agent_id is None:
+            result.agent_id = self._identity.agent_id
+        return result
 
     def resolve(self, concepts: list[str]) -> list[str]:
         """
@@ -119,7 +168,7 @@ class VRE:
             Optional integrator override — enforces a minimum depth floor
             on all root primitives. Can only raise the floor, never lower it.
         """
-        return self._engine.ground(concepts, self._resolver, min_depth=min_depth)
+        return self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
 
     def learn_all(
         self,
@@ -182,7 +231,7 @@ class VRE:
         if isinstance(concepts, GroundingResult):
             grounding = concepts
         else:
-            grounding = self._engine.ground(concepts, self._resolver)
+            grounding = self._stamp_identity(self._engine.ground(concepts, self._resolver))
 
         if grounding.trace is None:
             return PolicyResult(action=PolicyAction.PASS)

--- a/src/vre/core/errors.py
+++ b/src/vre/core/errors.py
@@ -43,3 +43,7 @@ class ResolutionError(VREError):
 
 class CandidateValidationError(VREError):
     """A learning candidate is missing required fields or references invalid data."""
+
+
+class RegistryError(VREError):
+    """A file-based registry operation failed (read, write, or corruption)."""

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -6,6 +6,7 @@ GroundingResult — the public result type returned by VRE grounding checks.
 """
 
 from typing import Any
+from uuid import UUID
 
 from pydantic import BaseModel
 
@@ -127,6 +128,7 @@ class GroundingResult(BaseModel):
     resolved: list[str]
     gaps: list[Any]
     trace: EpistemicResponse | None = None
+    agent_id: UUID | None = None
 
     def __str__(self) -> str:
         """
@@ -135,7 +137,8 @@ class GroundingResult(BaseModel):
         lines: list[str] = []
         resolved_str = ", ".join(self.resolved)
         prefix = "Grounded" if self.grounded else "Not grounded"
-        lines.append(f"[VRE] {prefix} — {resolved_str}")
+        agent_tag = f"  (agent: {self.agent_id})" if self.agent_id else ""
+        lines.append(f"[VRE] {prefix} — {resolved_str}{agent_tag}")
 
         if self.grounded:
             lines.append("")

--- a/src/vre/identity/__init__.py
+++ b/src/vre/identity/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+from vre.identity.models import AgentIdentity
+from vre.identity.registry import AgentRegistry
+
+__all__ = [
+    "AgentIdentity",
+    "AgentRegistry",
+]

--- a/src/vre/identity/models.py
+++ b/src/vre/identity/models.py
@@ -1,0 +1,25 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Agent identity model for trace attribution.
+
+An AgentIdentity binds a stable UUID to a registration key so that
+traces from the same agent are attributable across restarts and sessions.
+"""
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from pydantic import BaseModel, Field
+
+
+class AgentIdentity(BaseModel):
+    """
+    A registered agent identity with a stable, unique identifier.
+    """
+
+    agent_id: UUID = Field(default_factory=uuid4)
+    registration_key: str
+    name: str | None = None
+    created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))

--- a/src/vre/identity/registry.py
+++ b/src/vre/identity/registry.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+File-based agent registry.
+
+Persists agent identities to a JSON file so that the same registration key
+always resolves to the same stable UUID across process restarts.
+"""
+
+import json
+import logging
+import os
+import tempfile
+from pathlib import Path
+from uuid import UUID
+
+from vre.core.errors import RegistryError
+from vre.identity.models import AgentIdentity
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATH = Path.home() / ".vre" / "agents.json"
+
+
+class AgentRegistry:
+    """
+    Append-only, file-based agent identity registry.
+
+    Usage::
+
+        registry = AgentRegistry()
+        identity = registry.get_or_create("my-agent")
+        # Same key → same UUID on every call, even across restarts.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self._path = Path(path) if path is not None else _DEFAULT_PATH
+
+    # ── Private helpers ──────────────────────────────────────────────────
+
+    def _load(self) -> dict[str, AgentIdentity]:
+        """
+        Load registry from disk. Returns empty dict if file doesn't exist.
+        """
+        if not self._path.exists():
+            return {}
+
+        try:
+            raw = self._path.read_text(encoding="utf-8")
+            if not raw.strip():
+                return {}
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise RegistryError(
+                    f"Corrupt registry at {self._path}: expected JSON object at top level"
+                )
+            registry = {
+                key: AgentIdentity.model_validate(value) for key, value in data.items()
+            }
+            return registry
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise RegistryError(f"Corrupt registry at {self._path}: {exc}") from exc
+        except OSError as exc:
+            raise RegistryError(f"Cannot read registry at {self._path}: {exc}") from exc
+
+    def _save(self, registry: dict[str, AgentIdentity]) -> None:
+        """
+        Atomically write registry to disk. Creates parent dirs if needed.
+        """
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+        serialized = {
+            key: identity.model_dump(mode="json") for key, identity in registry.items()
+        }
+        payload = json.dumps(serialized, indent=2)
+
+        # Write to a temp file, fsync, then atomic rename. This ensures
+        # agents.json is never left in a partial state: a crash during
+        # write or fsync leaves the original file intact (the rename
+        # hasn't happened yet), and a crash after fsync is safe because
+        # the new data is already durable on disk before the swap.
+        try:
+            fd, tmp_path = tempfile.mkstemp(dir=self._path.parent, suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(payload)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(tmp_path, self._path)
+        except OSError as exc:
+            raise RegistryError(f"Cannot write registry to {self._path}: {exc}") from exc
+
+    def get_or_create(self, registration_key: str, name: str | None = None) -> AgentIdentity:
+        """
+        Return the identity for *registration_key*, creating it if absent.
+
+        Idempotent: repeated calls with the same key return the same identity
+        (same `agent_id`). The *name* parameter is only used on first creation.
+        """
+        registry = self._load()
+
+        if registration_key in registry:
+            logger.debug("Registry hit for key '%s'", registration_key)
+            agent_identity = registry[registration_key]
+        else:
+            agent_identity = AgentIdentity(registration_key=registration_key, name=name)
+            registry[registration_key] = agent_identity
+            self._save(registry)
+            logger.info("Registered new agent '%s' → %s", registration_key, agent_identity.agent_id)
+
+        return agent_identity
+
+    def get_by_id(self, agent_id: UUID) -> AgentIdentity | None:
+        """
+        Look up an agent identity by its UUID.
+
+        Returns None if no identity with the given `agent_id` exists.
+        """
+        registry = self._load()
+        return next(
+            (identity for identity in registry.values() if identity.agent_id == agent_id),
+            None,
+        )

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -3,21 +3,24 @@ Unit tests for vre.guard — vre_guard decorator.
 """
 
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 from vre.core.grounding import GroundingResult
 from vre.core.policy import PolicyAction, PolicyResult
 from vre.core.policy.models import PolicyViolation, Policy
+from vre.guard import vre_guard
 from vre.learning.callback import LearningCallback
 from vre.learning.models import CandidateDecision
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
 
-def _grounding(grounded=True, resolved=None, gaps=None):
+def _grounding(grounded=True, resolved=None, gaps=None, agent_id=None):
     return GroundingResult(
         grounded=grounded,
         resolved=resolved or ["file"],
         gaps=gaps or [],
+        agent_id=agent_id,
     )
 
 
@@ -120,6 +123,19 @@ def test_vre_guard_fires_on_trace_when_grounded():
     assert len(traces) == 1
     assert isinstance(traces[0], GroundingResult)
 
+
+def test_vre_guard_on_trace_receives_agent_id():
+    """on_trace receives GroundingResult with agent_id when VRE stamps it."""
+    agent_id = uuid4()
+    traces = []
+    mock_vre = _mock_vre(_grounding(agent_id=agent_id))
+
+    @vre_guard(mock_vre, concepts=["file"], on_trace=traces.append)
+    def my_fn():
+        return "executed"
+
+    my_fn()
+    assert traces[0].agent_id == agent_id
 
 
 def test_vre_guard_grounding_called_once():

--- a/tests/vre/test_identity.py
+++ b/tests/vre/test_identity.py
@@ -1,0 +1,146 @@
+"""
+Unit tests for vre.identity — AgentIdentity model and AgentRegistry.
+"""
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from vre.core.errors import RegistryError
+from vre.identity.models import AgentIdentity
+from vre.identity.registry import AgentRegistry
+
+
+# ── AgentIdentity model ─────────────────────────────────────────────────────
+
+
+class TestAgentIdentity:
+
+    def test_auto_generates_uuid(self):
+        identity = AgentIdentity(registration_key="test-agent")
+        assert isinstance(identity.agent_id, UUID)
+
+    def test_registration_key_required(self):
+        with pytest.raises(ValidationError):
+            AgentIdentity()
+
+    def test_name_defaults_to_none(self):
+        identity = AgentIdentity(registration_key="test-agent")
+        assert identity.name is None
+
+    def test_name_can_be_set(self):
+        identity = AgentIdentity(registration_key="test-agent", name="My Agent")
+        assert identity.name == "My Agent"
+
+    def test_created_at_auto_set(self):
+        identity = AgentIdentity(registration_key="test-agent")
+        assert identity.created_at is not None
+
+    def test_serialization_roundtrip(self):
+        identity = AgentIdentity(registration_key="test-agent", name="Agent A")
+        dumped = identity.model_dump(mode="json")
+        restored = AgentIdentity.model_validate(dumped)
+        assert restored.agent_id == identity.agent_id
+        assert restored.registration_key == identity.registration_key
+        assert restored.name == identity.name
+
+    def test_two_identities_have_different_uuids(self):
+        a = AgentIdentity(registration_key="a")
+        b = AgentIdentity(registration_key="b")
+        assert a.agent_id != b.agent_id
+
+
+# ── AgentRegistry ────────────────────────────────────────────────────────────
+
+
+class TestAgentRegistry:
+
+    def test_creates_new_identity(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        identity = registry.get_or_create("my-agent")
+        assert isinstance(identity.agent_id, UUID)
+        assert identity.registration_key == "my-agent"
+
+    def test_idempotent_same_uuid(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        first = registry.get_or_create("my-agent")
+        second = registry.get_or_create("my-agent")
+        assert first.agent_id == second.agent_id
+
+    def test_different_keys_different_uuids(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        a = registry.get_or_create("agent-a")
+        b = registry.get_or_create("agent-b")
+        assert a.agent_id != b.agent_id
+
+    def test_persists_across_instances(self, tmp_path):
+        path = tmp_path / "agents.json"
+        first_id = AgentRegistry(path=path).get_or_create("my-agent").agent_id
+        second_id = AgentRegistry(path=path).get_or_create("my-agent").agent_id
+        assert first_id == second_id
+
+    def test_creates_parent_directory(self, tmp_path):
+        path = tmp_path / "nested" / "dir" / "agents.json"
+        registry = AgentRegistry(path=path)
+        registry.get_or_create("my-agent")
+        assert path.exists()
+
+    def test_name_stored_on_creation(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        identity = registry.get_or_create("my-agent", name="My Agent")
+        assert identity.name == "My Agent"
+
+    def test_name_not_overwritten_on_subsequent_calls(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        registry.get_or_create("my-agent", name="First Name")
+        second = registry.get_or_create("my-agent", name="Second Name")
+        assert second.name == "First Name"
+
+    def test_corrupt_json_raises_registry_error(self, tmp_path):
+        path = tmp_path / "agents.json"
+        path.write_text("not valid json", encoding="utf-8")
+        registry = AgentRegistry(path=path)
+        with pytest.raises(RegistryError, match="Corrupt registry"):
+            registry.get_or_create("my-agent")
+
+    def test_non_dict_json_raises_registry_error(self, tmp_path):
+        path = tmp_path / "agents.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        registry = AgentRegistry(path=path)
+        with pytest.raises(RegistryError, match="expected JSON object"):
+            registry.get_or_create("my-agent")
+
+    def test_empty_file_treated_as_empty_registry(self, tmp_path):
+        path = tmp_path / "agents.json"
+        path.write_text("", encoding="utf-8")
+        registry = AgentRegistry(path=path)
+        identity = registry.get_or_create("my-agent")
+        assert isinstance(identity.agent_id, UUID)
+
+    def test_get_by_id_returns_matching_identity(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        created = registry.get_or_create("my-agent")
+        found = registry.get_by_id(created.agent_id)
+        assert found is not None
+        assert found.agent_id == created.agent_id
+        assert found.registration_key == "my-agent"
+
+    def test_get_by_id_returns_none_for_unknown_uuid(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        registry.get_or_create("my-agent")
+        assert registry.get_by_id(uuid4()) is None
+
+    def test_get_by_id_returns_none_on_empty_registry(self, tmp_path):
+        registry = AgentRegistry(path=tmp_path / "agents.json")
+        assert registry.get_by_id(uuid4()) is None
+
+    def test_registry_file_is_valid_json(self, tmp_path):
+        path = tmp_path / "agents.json"
+        registry = AgentRegistry(path=path)
+        registry.get_or_create("agent-a")
+        registry.get_or_create("agent-b")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert "agent-a" in data
+        assert "agent-b" in data

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -436,3 +436,54 @@ class TestVRELearnAll:
         vre.learn_all(grounding, LifecycleLearner(), ["file", "unknown"])
         assert entered
         assert exited
+
+
+# ---------------------------------------------------------------------------
+# Agent identity integration
+# ---------------------------------------------------------------------------
+
+
+class TestAgentIdentityIntegration:
+    """Integration tests: agent_key stamps agent_id on GroundingResult."""
+
+    def test_check_stamps_agent_id(self, tmp_path):
+        """VRE with agent_key stamps agent_id on check() result."""
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo, agent_key="test-agent", registry_path=tmp_path / "agents.json")
+        result = vre.check(["file"])
+        assert result.agent_id is not None
+        assert result.agent_id == vre.identity.agent_id
+
+    def test_no_identity_leaves_agent_id_none(self):
+        """VRE without agent_key leaves agent_id as None."""
+        file_p = _make_fully_grounded("file")
+        vre = _make_vre_with_stub([file_p])
+        result = vre.check(["file"])
+        assert result.agent_id is None
+        assert vre.identity is None
+
+    def test_same_key_same_uuid_across_instances(self, tmp_path):
+        """Two VRE instances with the same agent_key share the same agent_id."""
+        file_p = _make_fully_grounded("file")
+        path = tmp_path / "agents.json"
+        repo = StubRepository([file_p])
+        vre1 = VRE(repo, agent_key="shared-agent", registry_path=path)
+        vre2 = VRE(repo, agent_key="shared-agent", registry_path=path)
+        assert vre1.identity.agent_id == vre2.identity.agent_id
+
+    def test_agent_name_stored_on_identity(self, tmp_path):
+        """VRE with agent_name passes it through to the registered identity."""
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo, agent_key="named-agent", agent_name="My Agent", registry_path=tmp_path / "agents.json")
+        assert vre.identity.name == "My Agent"
+
+    def test_check_policy_with_agent_key_passes(self, tmp_path):
+        """check_policy runs without error when VRE has an agent identity."""
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo, agent_key="policy-agent", registry_path=tmp_path / "agents.json")
+        # Pass concepts as list to trigger internal grounding path
+        policy_result = vre.check_policy(["file"])
+        assert policy_result.action == PolicyAction.PASS


### PR DESCRIPTION
## Summary
- Introduces `AgentIdentity` model and file-based `AgentRegistry` (`~/.vre/agents.json`) with atomic writes and idempotent `get_or_create` + `get_by_id` lookups
- VRE accepts an optional `agent_key` at construction; the registry resolves it to a persisted identity whose `agent_id` is stamped on every `GroundingResult`
- Adds `RegistryError` to the VRE error hierarchy and `agent_id: UUID | None` field to `GroundingResult` (including display in `__str__`)
- Updates langchain_ollama example to use agent identity

Closes #41

## Test plan
- [x] 219 tests pass, 76% coverage (above 70% threshold)
- [x] `TestAgentIdentity` — model field defaults, serialization roundtrip, UUID uniqueness
- [x] `TestAgentRegistry` — idempotency, cross-instance persistence, corrupt/empty file handling, `get_by_id` lookup
- [x] `TestAgentIdentityIntegration` — `check()` stamps `agent_id`, no-identity leaves None, same key across VRE instances, `check_policy` with identity
- [x] `test_vre_guard_on_trace_receives_agent_id` — guard decorator passes `agent_id` through to `on_trace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)