### PR TITLE
Add aggregate usage metrics to Primitive nodes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.4.0"
+version = "0.4.1"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -16,8 +16,10 @@ Usage::
 """
 
 import logging
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
+from uuid import UUID
 
 from vre.core.graph import PrimitiveRepository
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
@@ -32,7 +34,16 @@ from vre.core.errors import (
     ResolutionError,
     VREError,
 )
-from vre.core.models import DepthLevel, Provenance, ProvenanceSource
+from vre.core.models import (
+    DepthGap,
+    DepthLevel,
+    ExistenceGap,
+    PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
+    ReachabilityGap,
+    RelationalGap,
+)
 from vre.core.policy import Cardinality, PolicyAction, PolicyCallbackResult, PolicyResult, PolicyViolation
 from vre.core.policy.callback import PolicyCallContext
 from vre.core.policy.gate import PolicyGate
@@ -46,6 +57,8 @@ from vre.learning import (
 )
 
 logging.getLogger("vre").addHandler(logging.NullHandler())
+
+logger = logging.getLogger(__name__)
 
 __all__ = [
     "VRE",
@@ -65,6 +78,7 @@ __all__ = [
     "GroundingEngine",
     "GroundingResult",
     "DepthLevel",
+    "PrimitiveMetrics",
     "Provenance",
     "ProvenanceSource",
     "Cardinality",
@@ -143,6 +157,104 @@ class VRE:
             result.agent_id = self._identity.agent_id
         return result
 
+    @staticmethod
+    def _gap_primitive_ids(gaps: list) -> set[UUID]:
+        """
+        Collect the set of primitive UUIDs that are epistemically deficient.
+
+        RelationalGaps contribute only the target ID — the relationship
+        is a pure structural declaration and the source is epistemically
+        sound if the edge is visible. The failure belongs to the target
+        that lacks the required depth.
+        """
+        ids: set[UUID] = set()
+        for gap in gaps:
+            if gap.kind == "RELATIONAL":
+                ids.add(gap.target.id)
+            else:
+                ids.add(gap.primitive.id)
+        return ids
+
+    def _update_grounding_metrics(self, result: GroundingResult) -> None:
+        """
+        Update per-primitive grounding metrics after a `check` call.
+
+        For each root concept in the trace, reads current metrics from the
+        repository, increments `grounding_count` or `failure_count` based
+        on gap membership, and persists the updated metrics. Updates are
+        best-effort — failures are logged but never block the caller.
+        """
+        if not result.trace:
+            return
+
+        now = datetime.now(timezone.utc)
+        gap_ids = self._gap_primitive_ids(result.gaps)
+        resolved_lower = {r.lower() for r in result.resolved}
+
+        for prim in result.trace.result.primitives:
+            if prim.name.lower() not in resolved_lower:
+                continue
+
+            # Read current metrics from the repo — trace primitives are
+            # copies created by _filter_depths and may be stale.
+            current = self._repo.find_by_id(prim.id)
+            if current is None:
+                continue
+            metrics = current.metrics or PrimitiveMetrics()
+
+            if prim.id in gap_ids:
+                metrics.failure_count += 1
+                metrics.last_failed = now
+            else:
+                metrics.grounding_count += 1
+                metrics.last_grounded = now
+
+            try:
+                self._repo.update_metrics(current.id, metrics)
+            except Exception:
+                logger.warning("Failed to update metrics for %r", prim.name, exc_info=True)
+
+    def _update_learning_metric(
+        self,
+        gap: DepthGap | ExistenceGap | RelationalGap | ReachabilityGap,
+        decision: CandidateDecision,
+    ) -> None:
+        """
+        Update learning metrics on the primitive targeted by a gap.
+
+        Increments `learning_count` for accepted/modified decisions and
+        `rejection_count` for rejected decisions. Skipped decisions are
+        ignored. Looks up the primitive by ID first, falling back to name
+        for ExistenceGaps where the gap carries a transient ID.
+        """
+        if decision == CandidateDecision.SKIPPED:
+            return
+
+        if isinstance(gap, RelationalGap):
+            prim_id, prim_name = gap.target.id, gap.target.name
+        elif isinstance(gap, (DepthGap, ExistenceGap, ReachabilityGap)):
+            prim_id, prim_name = gap.primitive.id, gap.primitive.name
+        else:
+            return
+
+        found = self._repo.find_by_id(prim_id)
+        if found is None:
+            found = self._repo.find_by_name(prim_name)
+        if found is None:
+            return
+
+        metrics = found.metrics or PrimitiveMetrics()
+
+        if decision in (CandidateDecision.ACCEPTED, CandidateDecision.MODIFIED):
+            metrics.learning_count += 1
+        elif decision == CandidateDecision.REJECTED:
+            metrics.rejection_count += 1
+
+        try:
+            self._repo.update_metrics(found.id, metrics)
+        except Exception:
+            logger.warning("Failed to update learning metrics for %r", prim_name, exc_info=True)
+
     def resolve(self, concepts: list[str]) -> list[str]:
         """
         Resolve free-form concept names to canonical primitive names.
@@ -168,7 +280,9 @@ class VRE:
             Optional integrator override — enforces a minimum depth floor
             on all root primitives. Can only raise the floor, never lower it.
         """
-        return self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
+        result = self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
+        self._update_grounding_metrics(result)
+        return result
 
     def learn_all(
         self,
@@ -195,6 +309,7 @@ class VRE:
                 if gap_index is None:
                     break
                 result = self._learning_engine.learn_at(grounding, gap_index, callback)
+                self._update_learning_metric(grounding.gaps[gap_index], result.decision)
                 if result.decision == CandidateDecision.REJECTED:
                     break
                 if result.decision == CandidateDecision.SKIPPED:

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -28,6 +28,7 @@ from vre.core.models import (
     DepthLevel,
     EpistemicStep,
     Primitive,
+    PrimitiveMetrics,
     Provenance,
     Relatum,
     RelationType,
@@ -117,6 +118,49 @@ class PrimitiveRepository:
         return json.dumps(stripped)
 
     @staticmethod
+    def _parse_json_field(value: Any) -> Any:
+        """
+        Parse a Neo4j property that may be a JSON string or already-decoded dict/list.
+        """
+        if isinstance(value, str):
+            return json.loads(value)
+        return value
+
+    @staticmethod
+    def _record_to_node_data(record: Any) -> dict[str, Any]:
+        """
+        Extract the node property dict from a Cypher record row.
+        """
+        return {
+            "id": record["id"],
+            "name": record["name"],
+            "depths_json": record["depths_json"],
+            "provenance": record["provenance"],
+            "metrics_json": record["metrics_json"],
+        }
+
+    @staticmethod
+    def _record_to_relationships(record: Any) -> list[dict[str, Any]]:
+        """
+        Extract the relationship list from a Cypher record row.
+        """
+        return [
+            {
+                "rel_type": r["rel_type"],
+                "target_id": r["target_id"],
+                "rel_props": {
+                    "source_depth": r["source_depth"],
+                    "target_depth": r["target_depth"],
+                    "metadata_json": r.get("metadata_json") or "{}",
+                    "policies": r.get("policies") or "[]",
+                    "provenance": r.get("provenance"),
+                },
+            }
+            for r in record["rels"]
+            if r.get("rel_type") is not None
+        ]
+
+    @staticmethod
     def _hydrate_primitive(
         node_data: dict[str, Any],
         relationships: list[dict[str, Any]],
@@ -149,8 +193,7 @@ class PrimitiveRepository:
                 rel_prov_json = rel_props.get("provenance")
                 rel_prov = None
                 if rel_prov_json:
-                    rel_prov_data = json.loads(rel_prov_json) if isinstance(rel_prov_json, str) else rel_prov_json
-                    rel_prov = Provenance(**rel_prov_data)
+                    rel_prov = Provenance(**PrimitiveRepository._parse_json_field(rel_prov_json))
 
                 relatum = Relatum(
                     relation_type=RelationType(rel["rel_type"]),
@@ -169,14 +212,19 @@ class PrimitiveRepository:
             node_prov_json = node_data.get("provenance")
             node_prov = None
             if node_prov_json:
-                node_prov_data = json.loads(node_prov_json) if isinstance(node_prov_json, str) else node_prov_json
-                node_prov = Provenance(**node_prov_data)
+                node_prov = Provenance(**PrimitiveRepository._parse_json_field(node_prov_json))
+
+            node_metrics_json = node_data.get("metrics_json")
+            node_metrics = None
+            if node_metrics_json:
+                node_metrics = PrimitiveMetrics(**PrimitiveRepository._parse_json_field(node_metrics_json))
 
             return Primitive(
                 id=UUID(node_data["id"]),
                 name=node_data["name"],
                 depths=sorted_depths,
                 provenance=node_prov,
+                metrics=node_metrics,
             )
         except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
             logger.error("Hydration failed for primitive %r: %s", node_data.get("name", "?"), exc)
@@ -264,18 +312,21 @@ class PrimitiveRepository:
         rel_types = [rt.value for rt in RelationType]
 
         node_provenance = json.dumps(primitive.provenance.model_dump(mode="json")) if primitive.provenance else None
+        node_metrics = json.dumps(primitive.metrics.model_dump(mode="json")) if primitive.metrics else None
 
         def _tx(tx: Any) -> None:
             tx.run(
                 cast(
                     LiteralString,
                     "MERGE (p:Primitive {id: $id}) "
-                    "SET p.name = $name, p.depths_json = $depths_json, p.provenance = $provenance",
+                    "SET p.name = $name, p.depths_json = $depths_json, "
+                    "p.provenance = $provenance, p.metrics_json = $metrics_json",
                 ),
                 id=str(primitive.id),
                 name=primitive.name,
                 depths_json=depths_json,
                 provenance=node_provenance,
+                metrics_json=node_metrics,
             )
 
             for rt in rel_types:
@@ -323,6 +374,26 @@ class PrimitiveRepository:
             logger.error("Neo4j error saving primitive %r: %s", primitive.name, exc)
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
 
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        """
+        Update only the metrics JSON on an existing primitive node.
+        """
+        metrics_json = json.dumps(metrics.model_dump(mode="json"))
+        try:
+            with self._driver.session(database=self._database) as session:
+                session.run(
+                    cast(
+                        LiteralString,
+                        "MATCH (p:Primitive {id: $id}) "
+                        "SET p.metrics_json = $metrics_json",
+                    ),
+                    id=str(primitive_id),
+                    metrics_json=metrics_json,
+                )
+        except Neo4jError as exc:
+            logger.error("Failed to update metrics for primitive %s: %s", primitive_id, exc)
+            raise PersistenceError(f"Failed to update metrics for '{primitive_id}': {exc}") from exc
+
     def list_names(self) -> list[str]:
         """
         Return the names of all primitives in the graph, sorted alphabetically.
@@ -350,6 +421,7 @@ class PrimitiveRepository:
               p.name AS name,
               p.depths_json AS depths_json,
               p.provenance AS provenance,
+              p.metrics_json AS metrics_json,
               collect({
                 rel_type: type(r),
                 target_id: t.id,
@@ -369,28 +441,10 @@ class PrimitiveRepository:
                     logger.debug("Primitive not found by id=%s", id)
                     return None
 
-                node_data = {
-                    "id": record["id"],
-                    "name": record["name"],
-                    "depths_json": record["depths_json"],
-                    "provenance": record["provenance"],
-                }
-                relationships = [
-                    {
-                        "rel_type": r["rel_type"],
-                        "target_id": r["target_id"],
-                        "rel_props": {
-                            "source_depth": r["source_depth"],
-                            "target_depth": r["target_depth"],
-                            "metadata_json": r.get("metadata_json") or "{}",
-                            "policies": r.get("policies") or "[]",
-                            "provenance": r.get("provenance"),
-                        },
-                    }
-                    for r in record["rels"]
-                    if r.get("rel_type") is not None
-                ]
-                return self._hydrate_primitive(node_data, relationships)
+                return self._hydrate_primitive(
+                    self._record_to_node_data(record),
+                    self._record_to_relationships(record),
+                )
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
@@ -412,6 +466,7 @@ class PrimitiveRepository:
               p.name AS name,
               p.depths_json AS depths_json,
               p.provenance AS provenance,
+              p.metrics_json AS metrics_json,
               collect({
                 rel_type: type(r),
                 target_id: t.id,
@@ -431,28 +486,10 @@ class PrimitiveRepository:
                     logger.debug("Primitive not found by name=%r", name)
                     return None
 
-                node_data = {
-                    "id": record["id"],
-                    "name": record["name"],
-                    "depths_json": record["depths_json"],
-                    "provenance": record["provenance"],
-                }
-                relationships = [
-                    {
-                        "rel_type": r["rel_type"],
-                        "target_id": r["target_id"],
-                        "rel_props": {
-                            "source_depth": r["source_depth"],
-                            "target_depth": r["target_depth"],
-                            "metadata_json": r.get("metadata_json") or "{}",
-                            "policies": r.get("policies") or "[]",
-                            "provenance": r.get("provenance"),
-                        },
-                    }
-                    for r in record["rels"]
-                    if r.get("rel_type") is not None
-                ]
-                return self._hydrate_primitive(node_data, relationships)
+                return self._hydrate_primitive(
+                    self._record_to_node_data(record),
+                    self._record_to_relationships(record),
+                )
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
@@ -511,8 +548,8 @@ class PrimitiveRepository:
             OPTIONAL MATCH (src)-[r]->(tgt:Primitive)
             WHERE tgt IN nodes
             RETURN
-              [r IN roots | {id: r.id, name: r.name, depths_json: r.depths_json, provenance: r.provenance}] AS roots,
-              [n IN nodes | {id: n.id, name: n.name, depths_json: n.depths_json, provenance: n.provenance}] AS nodes,
+              [r IN roots | {id: r.id, name: r.name, depths_json: r.depths_json, provenance: r.provenance, metrics_json: r.metrics_json}] AS roots,
+              [n IN nodes | {id: n.id, name: n.name, depths_json: n.depths_json, provenance: n.provenance, metrics_json: n.metrics_json}] AS nodes,
               [e IN collect({
                   source_id: src.id, target_id: tgt.id, rel_type: type(r),
                   source_depth: r.source_depth, target_depth: r.target_depth,

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -247,6 +247,7 @@ class GroundingEngine:
                 id=p.id,
                 name=p.name,
                 provenance=p.provenance,
+                metrics=p.metrics,
                 depths=[
                     Depth(
                         level=d.level,
@@ -302,8 +303,12 @@ class GroundingEngine:
             subgraph.edges, id_to_prim,
         )
 
-        gaps: list = self._detect_gaps(
-            all_nodes, visible_edges, gated_edges, root_ids, transient_ids,
+        gaps: list[DepthGap | ExistenceGap | RelationalGap | ReachabilityGap] = self._detect_gaps(
+            all_nodes,
+            visible_edges,
+            gated_edges,
+            root_ids,
+            transient_ids,
             min_depth=min_depth,
         )
 

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -48,7 +48,6 @@ TRANSITIVE_RELATION_TYPES: frozenset[RelationType] = frozenset(
 )
 
 
-
 class ProvenanceSource(str, Enum):
     """
     Origin category for knowledge in the epistemic graph.
@@ -68,6 +67,28 @@ class Provenance(BaseModel):
     created_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     updated_at: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
     detail: str | None = None
+
+
+class PrimitiveMetrics(BaseModel):
+    """
+    Aggregate usage counters for a primitive node.
+    """
+
+    last_grounded: datetime | None = None
+    last_failed: datetime | None = None
+    grounding_count: int = 0
+    failure_count: int = 0
+    learning_count: int = 0
+    rejection_count: int = 0
+
+    @property
+    def last_exercised(self) -> datetime | None:
+        """
+        The most recent time this primitive was exercised in any way.
+        """
+        if self.last_grounded and self.last_failed:
+            return max(self.last_grounded, self.last_failed)
+        return self.last_grounded or self.last_failed
 
 
 class Relatum(BaseModel):
@@ -127,6 +148,7 @@ class Primitive(BaseModel):
     name: str
     depths: list[Depth] = Field(default_factory=list)
     provenance: Provenance | None = None
+    metrics: PrimitiveMetrics | None = None
 
     def validate_provenance(self) -> None:
         """

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -1,0 +1,334 @@
+"""
+Unit tests for aggregate usage metrics on Primitive nodes.
+
+Uses a stub repository to avoid Neo4j dependency.
+"""
+
+from collections import deque
+from datetime import datetime, timezone
+from uuid import UUID
+
+from vre import VRE
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    EpistemicStep,
+    Primitive,
+    PrimitiveMetrics,
+    Relatum,
+    RelationType,
+    ResolvedSubgraph,
+)
+from vre.core.grounding import GroundingResult
+from vre.learning.callback import LearningCallback
+from vre.learning.models import (
+    CandidateDecision,
+    DepthCandidate,
+    ExistenceCandidate,
+    ProposedDepth,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stub repository
+# ---------------------------------------------------------------------------
+
+_TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
+
+
+class StubRepository:
+    def __init__(self, primitives: list[Primitive] | None = None) -> None:
+        self._by_id: dict[UUID, Primitive] = {}
+        self._by_name: dict[str, Primitive] = {}
+        for p in primitives or []:
+            self._by_id[p.id] = p
+            self._by_name[p.name.lower()] = p
+
+    def list_names(self) -> list[str]:
+        return list(self._by_name.keys())
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        return self._by_id.get(id)
+
+    def find_by_name(self, name: str) -> Primitive | None:
+        return self._by_name.get(name.lower())
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        self._by_id[primitive.id] = primitive
+        self._by_name[primitive.name.lower()] = primitive
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        prim = self._by_id.get(primitive_id)
+        if prim is not None:
+            prim.metrics = metrics
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
+
+        visited: set[UUID] = {r.id for r in roots}
+        queue: deque[UUID] = deque(r.id for r in roots)
+        while queue:
+            uid = queue.popleft()
+            prim = self._by_id.get(uid)
+            if not prim:
+                continue
+            for depth in prim.depths:
+                for rel in depth.relata:
+                    if rel.relation_type not in _TRANSITIVE_RELS:
+                        continue
+                    if rel.target_id not in visited:
+                        visited.add(rel.target_id)
+                        queue.append(rel.target_id)
+
+        nodes = [self._by_id[uid] for uid in visited if uid in self._by_id]
+        node_ids = {n.id for n in nodes}
+        edges: list[EpistemicStep] = []
+        for n in nodes:
+            for depth in n.depths:
+                for rel in depth.relata:
+                    if rel.target_id not in node_ids:
+                        continue
+                    edges.append(EpistemicStep(
+                        source_id=n.id,
+                        target_id=rel.target_id,
+                        relation_type=rel.relation_type,
+                        source_depth=depth.level,
+                        target_depth=rel.target_depth,
+                    ))
+        return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_fully_grounded(name: str) -> Primitive:
+    return Primitive(name=name, depths=[
+        Depth(level=DepthLevel.EXISTENCE),
+        Depth(level=DepthLevel.IDENTITY),
+        Depth(level=DepthLevel.CAPABILITIES),
+        Depth(level=DepthLevel.CONSTRAINTS),
+    ])
+
+
+def _make_vre(primitives: list[Primitive]) -> tuple[VRE, StubRepository]:
+    repo = StubRepository(primitives)
+    return VRE(repo), repo
+
+
+class _AcceptLearner(LearningCallback):
+    def __call__(self, candidate, grounding, gap):
+        if isinstance(candidate, ExistenceCandidate):
+            filled = ExistenceCandidate(
+                name=candidate.name,
+                d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "test"}),
+            )
+            return filled, CandidateDecision.ACCEPTED
+        if isinstance(candidate, DepthCandidate):
+            filled = DepthCandidate(new_depths=[
+                ProposedDepth(level=gap.required_depth, properties={"test": True}),
+            ])
+            return filled, CandidateDecision.ACCEPTED
+        return None, CandidateDecision.SKIPPED
+
+
+class _RejectLearner(LearningCallback):
+    def __call__(self, candidate, grounding, gap):
+        return None, CandidateDecision.REJECTED
+
+
+# ---------------------------------------------------------------------------
+# PrimitiveMetrics model tests
+# ---------------------------------------------------------------------------
+
+class TestPrimitiveMetricsModel:
+    def test_defaults(self):
+        m = PrimitiveMetrics()
+        assert m.grounding_count == 0
+        assert m.failure_count == 0
+        assert m.learning_count == 0
+        assert m.rejection_count == 0
+        assert m.last_grounded is None
+        assert m.last_failed is None
+
+    def test_last_exercised_both_none(self):
+        m = PrimitiveMetrics()
+        assert m.last_exercised is None
+
+    def test_last_exercised_only_grounded(self):
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        m = PrimitiveMetrics(last_grounded=t)
+        assert m.last_exercised == t
+
+    def test_last_exercised_only_failed(self):
+        t = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        m = PrimitiveMetrics(last_failed=t)
+        assert m.last_exercised == t
+
+    def test_last_exercised_returns_max(self):
+        early = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        late = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        m = PrimitiveMetrics(last_grounded=late, last_failed=early)
+        assert m.last_exercised == late
+        m = PrimitiveMetrics(last_grounded=early, last_failed=late)
+        assert m.last_exercised == late
+
+    def test_metrics_none_backward_compatible(self):
+        p = Primitive(name="legacy")
+        assert p.metrics is None
+
+
+# ---------------------------------------------------------------------------
+# Grounding metrics tests
+# ---------------------------------------------------------------------------
+
+class TestGroundingMetrics:
+    def test_check_grounded_increments_grounding_count(self):
+        file_p = _make_fully_grounded("file")
+        vre, repo = _make_vre([file_p])
+        vre.check(["file"])
+
+        updated = repo.find_by_name("file")
+        assert updated.metrics is not None
+        assert updated.metrics.grounding_count == 1
+        assert updated.metrics.failure_count == 0
+        assert updated.metrics.last_grounded is not None
+        assert updated.metrics.last_failed is None
+
+    def test_check_ungrounded_increments_failure_count(self):
+        """min_depth forces a DepthGap when the primitive lacks that depth."""
+        file_p = Primitive(name="file", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+        ])
+        vre, repo = _make_vre([file_p])
+        vre.check(["file"], min_depth=DepthLevel.CONSTRAINTS)
+
+        updated = repo.find_by_name("file")
+        assert updated.metrics is not None
+        assert updated.metrics.failure_count == 1
+        assert updated.metrics.grounding_count == 0
+        assert updated.metrics.last_failed is not None
+
+    def test_metrics_accumulate_across_calls(self):
+        file_p = _make_fully_grounded("file")
+        vre, repo = _make_vre([file_p])
+        vre.check(["file"])
+        vre.check(["file"])
+        vre.check(["file"])
+
+        updated = repo.find_by_name("file")
+        assert updated.metrics.grounding_count == 3
+
+    def test_check_empty_concepts_no_crash(self):
+        vre, repo = _make_vre([])
+        result = vre.check([])
+        # Empty concepts returns grounded=False with no trace — no crash
+        assert isinstance(result, GroundingResult)
+
+    def test_multiple_concepts_per_concept_metrics(self):
+        file_p = _make_fully_grounded("file")
+        create_p = Primitive(name="create", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY),
+            Depth(level=DepthLevel.CAPABILITIES, relata=[
+                Relatum(
+                    relation_type=RelationType.APPLIES_TO,
+                    target_id=file_p.id,
+                    target_depth=DepthLevel.CAPABILITIES,
+                ),
+            ]),
+            Depth(level=DepthLevel.CONSTRAINTS),
+        ])
+        vre, repo = _make_vre([file_p, create_p])
+        vre.check(["file", "create"])
+
+        file_m = repo.find_by_name("file").metrics
+        create_m = repo.find_by_name("create").metrics
+        assert file_m.grounding_count == 1
+        assert create_m.grounding_count == 1
+
+    def test_timestamps_are_utc(self):
+        file_p = _make_fully_grounded("file")
+        vre, repo = _make_vre([file_p])
+        vre.check(["file"])
+
+        metrics = repo.find_by_name("file").metrics
+        assert metrics.last_grounded.tzinfo is not None
+
+    def test_nonexistent_concept_does_not_crash(self):
+        vre, repo = _make_vre([])
+        result = vre.check(["nonexistent"])
+        assert result.grounded is False
+
+
+# ---------------------------------------------------------------------------
+# Learning metrics tests
+# ---------------------------------------------------------------------------
+
+class TestLearningMetrics:
+    def test_learn_all_accepted_increments_learning_count(self):
+        file_p = _make_fully_grounded("file")
+        vre, repo = _make_vre([file_p])
+
+        grounding = vre.check(["file", "copy"])
+        assert grounding.grounded is False
+
+        vre.learn_all(grounding, _AcceptLearner(), ["file", "copy"])
+
+        created = repo.find_by_name("copy")
+        assert created is not None
+        assert created.metrics is not None
+        # learning_count tracks accepted learning events on this primitive
+        assert created.metrics.learning_count >= 1
+        # Re-grounding after learning also updates grounding metrics
+        assert created.metrics.last_exercised is not None
+
+    def test_learn_all_rejected_increments_rejection_count(self):
+        file_p = _make_fully_grounded("file")
+        vre, repo = _make_vre([file_p])
+
+        grounding = vre.check(["file", "copy"])
+        vre.learn_all(grounding, _RejectLearner(), ["file", "copy"])
+
+        # "copy" was never created (rejected), so we can't track metrics on it.
+        # This verifies the code handles the case gracefully without crashing.
+        assert repo.find_by_name("copy") is None
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip tests
+# ---------------------------------------------------------------------------
+
+class TestMetricsSerialization:
+    def test_roundtrip_via_model_dump(self):
+        m = PrimitiveMetrics(
+            last_grounded=datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc),
+            last_failed=datetime(2026, 3, 10, 8, 0, 0, tzinfo=timezone.utc),
+            grounding_count=42,
+            failure_count=3,
+            learning_count=5,
+            rejection_count=1,
+        )
+        data = m.model_dump(mode="json")
+        restored = PrimitiveMetrics(**data)
+        assert restored.grounding_count == 42
+        assert restored.failure_count == 3
+        assert restored.learning_count == 5
+        assert restored.rejection_count == 1
+        assert restored.last_grounded == m.last_grounded
+        assert restored.last_failed == m.last_failed
+
+    def test_roundtrip_none_metrics_on_primitive(self):
+        p = Primitive(name="test")
+        data = p.model_dump(mode="json")
+        restored = Primitive(**data)
+        assert restored.metrics is None
+
+    def test_roundtrip_with_metrics_on_primitive(self):
+        m = PrimitiveMetrics(grounding_count=10)
+        p = Primitive(name="test", metrics=m)
+        data = p.model_dump(mode="json")
+        restored = Primitive(**data)
+        assert restored.metrics is not None
+        assert restored.metrics.grounding_count == 10

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -13,6 +13,7 @@ from vre.core.models import (
     DepthLevel,
     EpistemicStep,
     Primitive,
+    PrimitiveMetrics,
     Relatum,
     RelationType,
     ResolvedSubgraph,
@@ -49,9 +50,17 @@ class StubRepository:
     def find_by_id(self, id: UUID) -> Primitive | None:
         return self._by_id.get(id)
 
+    def find_by_name(self, name: str) -> Primitive | None:
+        return self._by_name.get(name.lower())
+
     def save_primitive(self, primitive: Primitive) -> None:
         self._by_id[primitive.id] = primitive
         self._by_name[primitive.name.lower()] = primitive
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        prim = self._by_id.get(primitive_id)
+        if prim is not None:
+            prim.metrics = metrics
 
     def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
         roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]


### PR DESCRIPTION
## Summary

- Add `PrimitiveMetrics` model tracking per-primitive grounding counts, failure counts, learning counts, rejection counts, and timestamps
- `VRE.check()` and `VRE.learn_all()` automatically update metrics as side effects — metrics are observability-only and do not alter grounding or policy evaluation
- Lightweight `update_metrics()` repository method avoids the overhead of full `save_primitive()` for counter updates
- `last_exercised` is a computed property derived from `max(last_grounded, last_failed)` rather than a persisted field

### Design notes

- **RelationalGap attribution**: only the target primitive receives a failure count — the relationship is a pure structural declaration, and the source is epistemically sound if the edge is visible
- **Best-effort updates**: metrics failures are logged but never block grounding from returning
- **Backward compatible**: `Primitive.metrics` defaults to `None`; existing graphs are unaffected
- **GroundingEngine stays read-only**: all metric writes happen at the VRE orchestration layer

Closes #35

## Test plan

- [x] 18 new tests in `test_metrics.py` covering grounding success/failure, accumulation, learning acceptance/rejection, `last_exercised` property, backward compatibility, and serialization round-trips
- [x] All 239 existing + new tests pass
- [x] Coverage at 76% (above 70% threshold)
- [x] Ruff lint passes clean

<details>
<summary>Implementation plan</summary>

# Plan: Add Aggregate Usage Metrics to Primitive Nodes (Issue #35)

## Context

Primitives currently carry no record of how they've been used. A node grounded thousands of times looks identical to one never exercised. This blocks the Workstation from showing usage signals and prevents future epistemic memory from reasoning about concept reliability.

## Design Decisions

### 1. Separate `PrimitiveMetrics` model (not fields on `Primitive`)

Follow the Provenance pattern: a dedicated model attached as `Primitive.metrics: PrimitiveMetrics | None = None`. Groups related fields together, keeps the core model clean, backward-compatible via `None` default.

### 2. Always-on — metrics updated at the VRE class level

`GroundingEngine` is currently read-only — it never writes to the repository. Breaking that invariant would be a significant architectural change. Instead, `VRE.check()` and `VRE.learn_all()` update metrics after engine calls automatically (no opt-in flag). The VRE class already orchestrates both paths and has repo access.

### 3. Lightweight `update_metrics()` repository method

`save_primitive()` is heavy — validates provenance, rebuilds all relationships, checks cycles. A targeted `update_metrics(id, metrics)` runs a single `MATCH ... SET p.metrics_json = $json` avoiding all that overhead.

### 4. Per-concept success/failure from gap analysis

When `grounded == True`: all resolved concepts succeeded. When `False`: extract primitive IDs from gaps. Root concepts whose IDs appear in gaps are failures; root concepts not in gaps are successes. ExistenceGap primitives are transient (not in repo), so they're naturally skipped.

### 5. Best-effort updates

Metrics failures are swallowed with a warning log. A counter update should never block a grounding check from returning.

### 6. Include `learning_count`

Track total accepted/modified learning events alongside `rejection_count`. Provides the denominator for rejection rate analysis.

## Model

```python
class PrimitiveMetrics(BaseModel):
    last_grounded: datetime | None = None
    last_failed: datetime | None = None
    grounding_count: int = 0
    failure_count: int = 0
    learning_count: int = 0
    rejection_count: int = 0

    @property
    def last_exercised(self) -> datetime | None:
        if self.last_grounded and self.last_failed:
            return max(self.last_grounded, self.last_failed)
        return self.last_grounded or self.last_failed
```

## Files Modified

- `src/vre/core/models.py` — `PrimitiveMetrics` class + `metrics` field on `Primitive`
- `src/vre/core/graph.py` — serialization, deserialization, `update_metrics()`, DRY extraction of `_parse_json_field`, `_record_to_node_data`, `_record_to_relationships`
- `src/vre/__init__.py` — `_gap_primitive_ids`, `_update_grounding_metrics`, `_update_learning_metric`; wired into `check()` and `learn_all()`
- `src/vre/core/grounding/engine.py` — `_filter_depths` copies `metrics` on Primitive
- `tests/vre/test_metrics.py` — 18 new tests
- `tests/vre/test_vre.py` — `update_metrics` + `find_by_name` on StubRepository

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)