### PR TITLE
Persist grounding traces to daily JSONL files (#34)

### DIFF
--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -55,6 +55,7 @@ from vre.learning import (
     LearningEngine,
     LearningResult,
 )
+from vre.tracing import TraceWriter, build_trace_entry
 
 logging.getLogger("vre").addHandler(logging.NullHandler())
 
@@ -111,6 +112,7 @@ class VRE:
         agent_key: str | None = None,
         agent_name: str | None = None,
         registry_path: str | Path | None = None,
+        persist_traces: bool = True,
     ) -> None:
         """
         Initialize VRE with the given primitive repository.
@@ -131,6 +133,9 @@ class VRE:
         registry_path:
             Path to the agent registry JSON file. Defaults to
             `AgentRegistry`'s built-in default when None.
+        persist_traces:
+            When True (default), grounding traces are persisted to daily
+            JSONL files under `~/.vre/traces/`.
         """
         self._repo = repository
         self._resolver = ConceptResolver(repository)
@@ -141,6 +146,9 @@ class VRE:
             self._identity: AgentIdentity | None = AgentRegistry(registry_path).get_or_create(agent_key, name=agent_name)
         else:
             self._identity = None
+
+        self._suppress_trace = False
+        self._trace_writer: TraceWriter | None = TraceWriter() if persist_traces else None
 
     @property
     def identity(self) -> AgentIdentity | None:
@@ -282,6 +290,11 @@ class VRE:
         """
         result = self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
         self._update_grounding_metrics(result)
+        if self._trace_writer is not None and not self._suppress_trace:
+            try:
+                self._trace_writer.write(build_trace_entry("check", concepts, result))
+            except Exception:
+                logger.warning("Failed to persist trace for check()", exc_info=True)
         return result
 
     def learn_all(
@@ -300,23 +313,38 @@ class VRE:
         Returns the final GroundingResult.
         """
         skipped: set[int] = set()
-        with callback:
-            while not grounding.grounded and grounding.gaps:
-                gap_index = next(
-                    (i for i, g in enumerate(grounding.gaps) if i not in skipped),
-                    None,
+        learning_outcomes: list[LearningResult] = []
+        self._suppress_trace = True
+        try:
+            with callback:
+                while not grounding.grounded and grounding.gaps:
+                    gap_index = next(
+                        (i for i, g in enumerate(grounding.gaps) if i not in skipped),
+                        None,
+                    )
+                    if gap_index is None:
+                        break
+                    result = self._learning_engine.learn_at(grounding, gap_index, callback)
+                    learning_outcomes.append(result)
+                    self._update_learning_metric(grounding.gaps[gap_index], result.decision)
+                    if result.decision == CandidateDecision.REJECTED:
+                        break
+                    if result.decision == CandidateDecision.SKIPPED:
+                        skipped.add(gap_index)
+                        continue
+                    grounding = self.check(concepts, min_depth=min_depth)
+                    skipped.clear()
+        finally:
+            self._suppress_trace = False
+
+        if self._trace_writer is not None and learning_outcomes:
+            try:
+                self._trace_writer.write(
+                    build_trace_entry("learn", concepts, grounding, learning_outcomes)
                 )
-                if gap_index is None:
-                    break
-                result = self._learning_engine.learn_at(grounding, gap_index, callback)
-                self._update_learning_metric(grounding.gaps[gap_index], result.decision)
-                if result.decision == CandidateDecision.REJECTED:
-                    break
-                if result.decision == CandidateDecision.SKIPPED:
-                    skipped.add(gap_index)
-                    continue
-                grounding = self.check(concepts, min_depth=min_depth)
-                skipped.clear()
+            except Exception:
+                logger.warning("Failed to persist trace for learn_all()", exc_info=True)
+
         return grounding
 
     def check_policy(

--- a/src/vre/tracing.py
+++ b/src/vre/tracing.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Trace persistence — serializes grounding results to daily JSONL files.
+
+Enabled by default on every VRE instance. Traces are written to
+``~/.vre/traces/YYYY-MM-DD.jsonl``. Disable with ``persist_traces=False``.
+"""
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+from vre.core.grounding.models import GroundingResult
+from vre.learning.models import LearningResult
+
+
+class TraceEntry(BaseModel):
+    """
+    A single JSONL line representing one grounding or learning operation.
+    """
+
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    operation: Literal["check", "learn"]
+    concepts: list[str]
+    resolved: list[str]
+    grounded: bool
+    gaps: list[dict[str, Any]] = Field(default_factory=list)
+    steps: list[dict[str, Any]] = Field(default_factory=list)
+    agent_id: str | None = None
+    learning_outcomes: list[dict[str, Any]] | None = None
+
+
+def build_trace_entry(
+    operation: Literal["check", "learn"],
+    concepts: list[str],
+    result: GroundingResult,
+    learning_outcomes: list[LearningResult] | None = None,
+) -> TraceEntry:
+    """
+    Construct a `TraceEntry` from a `GroundingResult` and optional learning outcomes.
+    """
+    gaps = [gap.model_dump(mode="json") for gap in result.gaps]
+
+    steps: list[dict[str, Any]] = []
+    if result.trace is not None:
+        steps = [step.model_dump(mode="json") for step in result.trace.result.pathway]
+
+    serialized_outcomes: list[dict[str, Any]] | None = None
+    if learning_outcomes is not None:
+        serialized_outcomes = [lr.model_dump(mode="json") for lr in learning_outcomes]
+
+    return TraceEntry(
+        operation=operation,
+        concepts=concepts,
+        resolved=result.resolved,
+        grounded=result.grounded,
+        gaps=gaps,
+        steps=steps,
+        agent_id=str(result.agent_id) if result.agent_id is not None else None,
+        learning_outcomes=serialized_outcomes,
+    )
+
+
+DEFAULT_TRACE_DIR = Path.home() / ".vre" / "traces"
+
+
+class TraceWriter:
+    """
+    Appends `TraceEntry` objects to daily JSONL files.
+
+    Files are named `YYYY-MM-DD.jsonl` under the trace directory
+    (defaults to ``~/.vre/traces/``). Each line is independently valid JSON.
+    """
+
+    def __init__(self, trace_dir: Path | None = None) -> None:
+        self._trace_dir = trace_dir or DEFAULT_TRACE_DIR
+
+    def _path_for_today(self) -> Path:
+        return self._trace_dir / f"{datetime.now(timezone.utc).strftime('%Y-%m-%d')}.jsonl"
+
+    def write(self, entry: TraceEntry) -> None:
+        path = self._path_for_today()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        line = entry.model_dump_json() + "\n"
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -114,7 +114,7 @@ def _make_fully_grounded(name: str) -> Primitive:
 
 def _make_vre(primitives: list[Primitive]) -> tuple[VRE, StubRepository]:
     repo = StubRepository(primitives)
-    return VRE(repo), repo
+    return VRE(repo, persist_traces=False), repo
 
 
 class _AcceptLearner(LearningCallback):

--- a/tests/vre/test_tracing.py
+++ b/tests/vre/test_tracing.py
@@ -1,0 +1,415 @@
+"""
+Unit and integration tests for trace persistence.
+
+Tests build_trace_entry, TraceWriter, and VRE integration.
+"""
+
+import json
+from collections import deque
+from uuid import UUID, uuid4
+
+from vre import VRE
+from vre.core.grounding import GroundingResult
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    EpistemicQuery,
+    EpistemicResponse,
+    EpistemicResult,
+    EpistemicStep,
+    Primitive,
+    PrimitiveMetrics,
+    RelationType,
+    ResolvedSubgraph,
+)
+from vre.learning.callback import LearningCallback
+from vre.learning.models import (
+    CandidateDecision,
+    ExistenceCandidate,
+    LearningResult,
+    ProposedDepth,
+)
+import vre.tracing as tracing_module
+from vre.tracing import TraceWriter, build_trace_entry
+
+
+# ---------------------------------------------------------------------------
+# Stub repository (matches test_vre.py pattern)
+# ---------------------------------------------------------------------------
+
+_TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
+
+
+class StubRepository:
+    def __init__(self, primitives: list[Primitive] | None = None) -> None:
+        self._by_id: dict[UUID, Primitive] = {}
+        self._by_name: dict[str, Primitive] = {}
+        for p in primitives or []:
+            self._by_id[p.id] = p
+            self._by_name[p.name.lower()] = p
+
+    def list_names(self) -> list[str]:
+        return list(self._by_name.keys())
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        return self._by_id.get(id)
+
+    def find_by_name(self, name: str) -> Primitive | None:
+        return self._by_name.get(name.lower())
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        self._by_id[primitive.id] = primitive
+        self._by_name[primitive.name.lower()] = primitive
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        prim = self._by_id.get(primitive_id)
+        if prim is not None:
+            prim.metrics = metrics
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
+        visited: set[UUID] = {r.id for r in roots}
+        queue: deque[UUID] = deque(r.id for r in roots)
+        while queue:
+            uid = queue.popleft()
+            prim = self._by_id.get(uid)
+            if not prim:
+                continue
+            for depth in prim.depths:
+                for rel in depth.relata:
+                    if rel.relation_type not in _TRANSITIVE_RELS:
+                        continue
+                    if rel.target_id not in visited:
+                        visited.add(rel.target_id)
+                        queue.append(rel.target_id)
+        nodes = [self._by_id[uid] for uid in visited if uid in self._by_id]
+        node_ids = {n.id for n in nodes}
+        edges: list[EpistemicStep] = []
+        for n in nodes:
+            for depth in n.depths:
+                for rel in depth.relata:
+                    if rel.target_id not in node_ids:
+                        continue
+                    edges.append(EpistemicStep(
+                        source_id=n.id,
+                        target_id=rel.target_id,
+                        relation_type=rel.relation_type,
+                        source_depth=depth.level,
+                        target_depth=rel.target_depth,
+                    ))
+        return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_fully_grounded(name: str) -> Primitive:
+    return Primitive(name=name, depths=[
+        Depth(level=DepthLevel.EXISTENCE),
+        Depth(level=DepthLevel.IDENTITY),
+        Depth(level=DepthLevel.CAPABILITIES),
+        Depth(level=DepthLevel.CONSTRAINTS),
+    ])
+
+
+def _grounding_result(
+    grounded: bool = True,
+    resolved: list[str] | None = None,
+    gaps: list | None = None,
+    with_trace: bool = True,
+    agent_id: UUID | None = None,
+) -> GroundingResult:
+    """Build a GroundingResult with optional trace for testing."""
+    resolved = resolved or ["file"]
+    gaps = gaps or []
+
+    trace = None
+    if with_trace:
+        file_id = uuid4()
+        write_id = uuid4()
+        step = EpistemicStep(
+            source_id=write_id,
+            target_id=file_id,
+            relation_type=RelationType.APPLIES_TO,
+            source_depth=DepthLevel.CAPABILITIES,
+            target_depth=DepthLevel.CONSTRAINTS,
+        )
+        trace = EpistemicResponse(
+            query=EpistemicQuery(concept_ids=[file_id, write_id]),
+            result=EpistemicResult(
+                primitives=[
+                    Primitive(id=file_id, name="file"),
+                    Primitive(id=write_id, name="write"),
+                ],
+                gaps=gaps,
+                pathway=[step],
+            ),
+        )
+
+    return GroundingResult(
+        grounded=grounded,
+        resolved=resolved,
+        gaps=gaps,
+        trace=trace,
+        agent_id=agent_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# build_trace_entry tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTraceEntry:
+    def test_check_operation(self):
+        result = _grounding_result(grounded=True, resolved=["file", "write"])
+        entry = build_trace_entry("check", ["file", "write"], result)
+
+        assert entry.operation == "check"
+        assert entry.concepts == ["file", "write"]
+        assert entry.resolved == ["file", "write"]
+        assert entry.grounded is True
+        assert entry.gaps == []
+        assert len(entry.steps) == 1
+        assert entry.learning_outcomes is None
+        assert entry.timestamp is not None
+
+    def test_learn_operation_with_outcomes(self):
+        result = _grounding_result(grounded=True)
+        outcomes = [
+            LearningResult(
+                decision=CandidateDecision.ACCEPTED,
+                candidate=ExistenceCandidate(name="copy", d1=ProposedDepth(level=DepthLevel.IDENTITY)),
+            ),
+        ]
+        entry = build_trace_entry("learn", ["file", "copy"], result, outcomes)
+
+        assert entry.operation == "learn"
+        assert entry.learning_outcomes is not None
+        assert len(entry.learning_outcomes) == 1
+        assert entry.learning_outcomes[0]["decision"] == "accepted"
+        assert entry.learning_outcomes[0]["candidate"]["kind"] == "EXISTENCE"
+
+    def test_no_trace_gives_empty_steps(self):
+        result = _grounding_result(with_trace=False)
+        entry = build_trace_entry("check", ["file"], result)
+        assert entry.steps == []
+
+    def test_agent_id_serialized_as_string(self):
+        aid = uuid4()
+        result = _grounding_result(agent_id=aid)
+        entry = build_trace_entry("check", ["file"], result)
+        assert entry.agent_id == str(aid)
+
+    def test_agent_id_none_when_absent(self):
+        result = _grounding_result(agent_id=None)
+        entry = build_trace_entry("check", ["file"], result)
+        assert entry.agent_id is None
+
+    def test_gaps_preserve_kind_discriminator(self):
+        from vre.core.models import ExistenceGap
+
+        gap_prim = Primitive(name="unknown")
+        gap = ExistenceGap(primitive=gap_prim)
+        result = _grounding_result(grounded=False, gaps=[gap])
+        entry = build_trace_entry("check", ["unknown"], result)
+
+        assert len(entry.gaps) == 1
+        assert entry.gaps[0]["kind"] == "EXISTENCE"
+
+
+# ---------------------------------------------------------------------------
+# TraceEntry serialization tests
+# ---------------------------------------------------------------------------
+
+
+class TestTraceEntrySerialization:
+    def test_roundtrip(self):
+        result = _grounding_result()
+        entry = build_trace_entry("check", ["file"], result)
+        json_str = entry.model_dump_json()
+        parsed = json.loads(json_str)
+
+        assert parsed["operation"] == "check"
+        assert parsed["concepts"] == ["file"]
+        assert parsed["grounded"] is True
+        assert isinstance(parsed["timestamp"], str)
+
+    def test_each_field_present_in_json(self):
+        result = _grounding_result()
+        entry = build_trace_entry("check", ["file"], result)
+        parsed = json.loads(entry.model_dump_json())
+
+        expected_keys = {
+            "timestamp", "operation", "concepts", "resolved",
+            "grounded", "gaps", "steps", "agent_id", "learning_outcomes",
+        }
+        assert set(parsed.keys()) == expected_keys
+
+
+# ---------------------------------------------------------------------------
+# TraceWriter tests
+# ---------------------------------------------------------------------------
+
+
+class TestTraceWriter:
+    def test_write_creates_daily_file(self, tmp_path):
+        writer = TraceWriter(tmp_path / "traces")
+        entry = build_trace_entry("check", ["file"], _grounding_result())
+        writer.write(entry)
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        assert len(files) == 1
+        assert files[0].name.endswith(".jsonl")
+
+    def test_write_appends_multiple_entries(self, tmp_path):
+        writer = TraceWriter(tmp_path / "traces")
+        entry1 = build_trace_entry("check", ["file"], _grounding_result())
+        entry2 = build_trace_entry("check", ["write"], _grounding_result(resolved=["write"]))
+        writer.write(entry1)
+        writer.write(entry2)
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text().strip().split("\n")
+        assert len(lines) == 2
+
+    def test_creates_nested_directories(self, tmp_path):
+        writer = TraceWriter(tmp_path / "deep" / "nested" / "traces")
+        entry = build_trace_entry("check", ["file"], _grounding_result())
+        writer.write(entry)
+
+        assert (tmp_path / "deep" / "nested" / "traces").is_dir()
+        files = list((tmp_path / "deep" / "nested" / "traces").glob("*.jsonl"))
+        assert len(files) == 1
+
+    def test_each_line_is_valid_json(self, tmp_path):
+        writer = TraceWriter(tmp_path / "traces")
+        for concept in ["file", "write", "read"]:
+            entry = build_trace_entry("check", [concept], _grounding_result(resolved=[concept]))
+            writer.write(entry)
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        lines = files[0].read_text().strip().split("\n")
+        assert len(lines) == 3
+        for line in lines:
+            parsed = json.loads(line)
+            assert "operation" in parsed
+            assert "concepts" in parsed
+
+
+# ---------------------------------------------------------------------------
+# VRE integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestVRETraceIntegration:
+    def test_check_writes_trace_when_enabled(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(tracing_module, "DEFAULT_TRACE_DIR", tmp_path / "traces")
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo)
+
+        vre.check(["file"])
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text().strip().split("\n")
+        assert len(lines) == 1
+        parsed = json.loads(lines[0])
+        assert parsed["operation"] == "check"
+        assert parsed["concepts"] == ["file"]
+        assert parsed["grounded"] is True
+
+    def test_no_trace_when_disabled(self, tmp_path):
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo, persist_traces=False)
+
+        vre.check(["file"])
+
+        assert not (tmp_path / "traces").exists()
+
+    def test_trace_entry_content_structure(self, tmp_path, monkeypatch):
+        """Verify all acceptance-criteria fields are present in the trace entry."""
+        monkeypatch.setattr(tracing_module, "DEFAULT_TRACE_DIR", tmp_path / "traces")
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo)
+
+        vre.check(["file", "unknown_concept"])
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        parsed = json.loads(files[0].read_text().strip().split("\n")[0])
+
+        assert "timestamp" in parsed
+        assert parsed["concepts"] == ["file", "unknown_concept"]
+        assert isinstance(parsed["resolved"], list)
+        assert isinstance(parsed["grounded"], bool)
+        assert isinstance(parsed["gaps"], list)
+        assert isinstance(parsed["steps"], list)
+        # Existence gap should have kind field
+        existence_gaps = [g for g in parsed["gaps"] if g["kind"] == "EXISTENCE"]
+        assert len(existence_gaps) >= 1
+
+    def test_learn_all_writes_single_trace_with_outcomes(self, tmp_path, monkeypatch):
+        """learn_all suppresses intermediate check() traces and writes one learn entry."""
+        monkeypatch.setattr(tracing_module, "DEFAULT_TRACE_DIR", tmp_path / "traces")
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo)
+
+        grounding = vre.check(["file", "copy"])
+        assert grounding.grounded is False
+
+        class AcceptLearner(LearningCallback):
+            def __call__(self, candidate, grounding, gap):
+                if isinstance(candidate, ExistenceCandidate):
+                    filled = ExistenceCandidate(
+                        name=candidate.name,
+                        d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={"desc": "test"}),
+                    )
+                    return filled, CandidateDecision.ACCEPTED
+                return None, CandidateDecision.SKIPPED
+
+        vre.learn_all(grounding, AcceptLearner(), ["file", "copy"])
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        assert len(files) == 1
+        lines = files[0].read_text().strip().split("\n")
+
+        # One "check" from the initial check(), one "learn" from learn_all()
+        # Intermediate check() calls inside learn_all() should be suppressed
+        operations = [json.loads(line)["operation"] for line in lines]
+        assert operations.count("check") == 1
+        assert operations.count("learn") == 1
+
+        # The learn entry should have learning_outcomes
+        learn_entry = json.loads(lines[operations.index("learn")])
+        assert learn_entry["learning_outcomes"] is not None
+        assert len(learn_entry["learning_outcomes"]) >= 1
+
+    def test_learn_all_no_trace_without_outcomes(self, tmp_path, monkeypatch):
+        """learn_all does not write a trace when there are no learning outcomes."""
+        monkeypatch.setattr(tracing_module, "DEFAULT_TRACE_DIR", tmp_path / "traces")
+        file_p = _make_fully_grounded("file")
+        repo = StubRepository([file_p])
+        vre = VRE(repo)
+
+        # Grounded result — learn_all loop body never executes
+        grounding = vre.check(["file"])
+        assert grounding.grounded is True
+
+        vre.learn_all(grounding, _NullLearner(), ["file"])
+
+        files = list((tmp_path / "traces").glob("*.jsonl"))
+        lines = files[0].read_text().strip().split("\n")
+        # Only the initial check() trace, no learn trace
+        operations = [json.loads(line)["operation"] for line in lines]
+        assert operations == ["check"]
+
+
+class _NullLearner(LearningCallback):
+    def __call__(self, candidate, grounding, gap):
+        return None, CandidateDecision.SKIPPED

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -110,7 +110,7 @@ def _make_fully_grounded(name: str) -> Primitive:
 def _make_vre_with_stub(primitives: list[Primitive]) -> VRE:
     """Create a VRE instance with a stub repository."""
     repo = StubRepository(primitives)
-    return VRE(repo)
+    return VRE(repo, persist_traces=False)
 
 
 def _make_primitive_with_policy(
@@ -459,7 +459,7 @@ class TestAgentIdentityIntegration:
         """VRE with agent_key stamps agent_id on check() result."""
         file_p = _make_fully_grounded("file")
         repo = StubRepository([file_p])
-        vre = VRE(repo, agent_key="test-agent", registry_path=tmp_path / "agents.json")
+        vre = VRE(repo, agent_key="test-agent", registry_path=tmp_path / "agents.json", persist_traces=False)
         result = vre.check(["file"])
         assert result.agent_id is not None
         assert result.agent_id == vre.identity.agent_id
@@ -477,22 +477,22 @@ class TestAgentIdentityIntegration:
         file_p = _make_fully_grounded("file")
         path = tmp_path / "agents.json"
         repo = StubRepository([file_p])
-        vre1 = VRE(repo, agent_key="shared-agent", registry_path=path)
-        vre2 = VRE(repo, agent_key="shared-agent", registry_path=path)
+        vre1 = VRE(repo, agent_key="shared-agent", registry_path=path, persist_traces=False)
+        vre2 = VRE(repo, agent_key="shared-agent", registry_path=path, persist_traces=False)
         assert vre1.identity.agent_id == vre2.identity.agent_id
 
     def test_agent_name_stored_on_identity(self, tmp_path):
         """VRE with agent_name passes it through to the registered identity."""
         file_p = _make_fully_grounded("file")
         repo = StubRepository([file_p])
-        vre = VRE(repo, agent_key="named-agent", agent_name="My Agent", registry_path=tmp_path / "agents.json")
+        vre = VRE(repo, agent_key="named-agent", agent_name="My Agent", registry_path=tmp_path / "agents.json", persist_traces=False)
         assert vre.identity.name == "My Agent"
 
     def test_check_policy_with_agent_key_passes(self, tmp_path):
         """check_policy runs without error when VRE has an agent identity."""
         file_p = _make_fully_grounded("file")
         repo = StubRepository([file_p])
-        vre = VRE(repo, agent_key="policy-agent", registry_path=tmp_path / "agents.json")
+        vre = VRE(repo, agent_key="policy-agent", registry_path=tmp_path / "agents.json", persist_traces=False)
         # Pass concepts as list to trigger internal grounding path
         policy_result = vre.check_policy(["file"])
         assert policy_result.action == PolicyAction.PASS


### PR DESCRIPTION
## Summary

- Adds `src/vre/tracing.py` with `TraceEntry` model, `build_trace_entry()` helper, and `TraceWriter` class that appends to daily `~/.vre/traces/YYYY-MM-DD.jsonl` files
- Tracing is **on by default** — every VRE instance persists traces to a centralized location so the future VRE Workstation has a single root to scan. Disable with `persist_traces=False`
- `learn_all()` suppresses intermediate `check()` traces and writes one comprehensive entry with all learning outcomes
- Each JSONL line includes: timestamp, queried concepts, resolved names, grounded status, gaps (with kind discriminator), epistemic steps, agent_id, and learning outcomes

## Test plan

- [ ] `poetry run pytest tests/vre/test_tracing.py -v` — 17 new tests (build_trace_entry, TraceWriter, VRE integration)
- [ ] `poetry run pytest tests/ -v` — full suite (256 tests), no regressions
- [ ] Verify `tracing.py` at 100% coverage, overall coverage above 70% threshold

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)