### PR TITLE
Batch metrics updates and cache name resolution in check()

### DIFF
--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -187,9 +187,8 @@ class VRE:
         """
         Update per-primitive grounding metrics after a `check` call.
 
-        For each root concept in the trace, reads current metrics from the
-        repository, increments `grounding_count` or `failure_count` based
-        on gap membership, and persists the updated metrics. Updates are
+        Batch-reads current metrics for all resolved root concepts, computes
+        increments in-process, and batch-writes the results. Updates are
         best-effort — failures are logged but never block the caller.
         """
         if not result.trace:
@@ -199,16 +198,26 @@ class VRE:
         gap_ids = self._gap_primitive_ids(result.gaps)
         resolved_lower = {r.lower() for r in result.resolved}
 
-        for prim in result.trace.result.primitives:
-            if prim.name.lower() not in resolved_lower:
-                continue
+        target_prims = [
+            prim for prim in result.trace.result.primitives
+            if prim.name.lower() in resolved_lower
+        ]
+        if not target_prims:
+            return
 
-            # Read current metrics from the repo — trace primitives are
-            # copies created by _filter_depths and may be stale.
-            current = self._repo.find_by_id(prim.id)
-            if current is None:
+        target_ids = [p.id for p in target_prims]
+
+        try:
+            current_metrics = self._repo.batch_read_metrics(target_ids)
+        except Exception:
+            logger.warning("Failed to batch-read metrics", exc_info=True)
+            return
+
+        updates: dict[UUID, PrimitiveMetrics] = {}
+        for prim in target_prims:
+            if prim.id not in current_metrics:
                 continue
-            metrics = current.metrics or PrimitiveMetrics()
+            metrics = current_metrics[prim.id] or PrimitiveMetrics()
 
             if prim.id in gap_ids:
                 metrics.failure_count += 1
@@ -217,10 +226,13 @@ class VRE:
                 metrics.grounding_count += 1
                 metrics.last_grounded = now
 
+            updates[prim.id] = metrics
+
+        if updates:
             try:
-                self._repo.update_metrics(current.id, metrics)
+                self._repo.batch_update_metrics(updates)
             except Exception:
-                logger.warning("Failed to update metrics for %r", prim.name, exc_info=True)
+                logger.warning("Failed to batch-update metrics for %d primitives", len(updates), exc_info=True)
 
     def _update_learning_metric(
         self,
@@ -332,6 +344,7 @@ class VRE:
                     if result.decision == CandidateDecision.SKIPPED:
                         skipped.add(gap_index)
                         continue
+                    self._resolver.invalidate()
                     grounding = self.check(concepts, min_depth=min_depth)
                     skipped.clear()
         finally:

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -394,6 +394,62 @@ class PrimitiveRepository:
             logger.error("Failed to update metrics for primitive %s: %s", primitive_id, exc)
             raise PersistenceError(f"Failed to update metrics for '{primitive_id}': {exc}") from exc
 
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        """
+        Read current metrics for multiple primitives in a single query.
+        """
+        if not primitive_ids:
+            return {}
+        cypher = cast(
+            LiteralString,
+            "MATCH (p:Primitive) WHERE p.id IN $ids "
+            "RETURN p.id AS id, p.metrics_json AS metrics_json",
+        )
+        try:
+            with self._driver.session(database=self._database) as session:
+                records = session.run(cypher, ids=[str(pid) for pid in primitive_ids])
+                result: dict[UUID, PrimitiveMetrics | None] = {}
+                for record in records:
+                    pid = UUID(record["id"])
+                    raw = record["metrics_json"]
+                    if raw:
+                        try:
+                            parsed = self._parse_json_field(raw)
+                            result[pid] = PrimitiveMetrics.model_validate(parsed)
+                        except Exception as exc:
+                            raise HydrationError(
+                                f"Failed to hydrate metrics for primitive '{pid}': {exc}"
+                            ) from exc
+                    else:
+                        result[pid] = None
+                return result
+        except HydrationError:
+            raise
+        except Neo4jError as exc:
+            raise GraphError(f"Failed to batch-read metrics: {exc}") from exc
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        """
+        Persist metrics for multiple primitives in a single query.
+        """
+        if not updates:
+            return
+        params = [
+            {"id": str(pid), "metrics_json": json.dumps(m.model_dump(mode="json"))}
+            for pid, m in updates.items()
+        ]
+        cypher = cast(
+            LiteralString,
+            "UNWIND $updates AS u "
+            "MATCH (p:Primitive {id: u.id}) "
+            "SET p.metrics_json = u.metrics_json",
+        )
+        try:
+            with self._driver.session(database=self._database) as session:
+                session.run(cypher, updates=params)
+        except Neo4jError as exc:
+            raise PersistenceError(f"Failed to batch-update metrics: {exc}") from exc
+
     def list_names(self) -> list[str]:
         """
         Return the names of all primitives in the graph, sorted alphabetically.

--- a/src/vre/core/grounding/resolver.py
+++ b/src/vre/core/grounding/resolver.py
@@ -66,12 +66,24 @@ class ConceptResolver:
         Initialize the resolver with a primitive repository.
         """
         self._repo = repository
+        self._name_map_cache: dict[str, str] | None = None
+
+    def invalidate(self) -> None:
+        """
+        Clear the cached name map so the next `build_name_map` re-queries.
+        """
+        self._name_map_cache = None
 
     def build_name_map(self) -> dict[str, str]:
         """
         Map lowercased primitive names to their canonical form.
+
+        Results are cached on the instance; call `invalidate` after
+        mutations that add, rename, or remove primitives.
         """
-        return {name.lower(): name for name in self._repo.list_names()}
+        if self._name_map_cache is None:
+            self._name_map_cache = {name.lower(): name for name in self._repo.list_names()}
+        return self._name_map_cache.copy()
 
     @staticmethod
     def lookup(concept: str, name_map: dict[str, str]) -> str | None:

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -62,6 +62,15 @@ class StubRepository:
         if prim is not None:
             prim.metrics = metrics
 
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        return {pid: self._by_id[pid].metrics for pid in primitive_ids if pid in self._by_id}
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        for pid, metrics in updates.items():
+            prim = self._by_id.get(pid)
+            if prim is not None:
+                prim.metrics = metrics
+
     def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
         roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
 

--- a/tests/vre/test_tracing.py
+++ b/tests/vre/test_tracing.py
@@ -66,6 +66,15 @@ class StubRepository:
         if prim is not None:
             prim.metrics = metrics
 
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        return {pid: self._by_id[pid].metrics for pid in primitive_ids if pid in self._by_id}
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        for pid, metrics in updates.items():
+            prim = self._by_id.get(pid)
+            if prim is not None:
+                prim.metrics = metrics
+
     def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
         roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
         visited: set[UUID] = {r.id for r in roots}

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -62,6 +62,15 @@ class StubRepository:
         if prim is not None:
             prim.metrics = metrics
 
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        return {pid: self._by_id[pid].metrics for pid in primitive_ids if pid in self._by_id}
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        for pid, metrics in updates.items():
+            prim = self._by_id.get(pid)
+            if prim is not None:
+                prim.metrics = metrics
+
     def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
         roots = [self._by_name[n.lower()] for n in names if n.lower() in self._by_name]
 


### PR DESCRIPTION
## Summary

- Batch `_update_grounding_metrics` into 2 Neo4j round-trips (down from 2N) via new `batch_read_metrics` and `batch_update_metrics` repository methods
- Cache `ConceptResolver.build_name_map` on the instance, eliminating a `list_names` query on every `check()` call; invalidated before re-grounding after learning mutations
- Update test stub repositories with batch method implementations

## Profiling Results

| Metric | Before | After |
|---|---|---|
| End-to-end `check()` | 13.36ms | 8.17ms (-39%) |
| `_update_grounding_metrics` min | 7.61ms | 3.03ms (-60%) |
| `build_name_map` (steady-state) | 2.02ms | 0ms (cached) |

## Test plan

- [x] All 256 existing tests pass
- [x] Run profiler against live Neo4j: `python scripts/profile_check.py --neo4j-password <pw>`

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)