### PR TITLE
chore: codebase audit cleanup + 0.5.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,10 @@ def on_trace(grounding: GroundingResult) -> None:
 - `trace: EpistemicResponse | None` — the full subgraph with all primitives, depths, relata, and pathway
 - `agent_id: UUID | None` — the stable agent identifier, when the VRE instance was created with an `agent_key`
 
+For convenience, `result.get_primitives()` and `result.get_pathway_steps()` return the trace's primitives
+and pathway steps directly (or empty lists when no trace is present), so callers don't have to drill into
+`result.trace.result.*` themselves.
+
 The reference integration renders `on_trace` as a Rich tree:
 
 ```
@@ -858,7 +862,8 @@ grounding history, and affect the agent's confidence in related concepts.
 src/vre/
 ├── __init__.py                  # VRE public interface (check, learn_all, check_policy)
 ├── guard.py                     # vre_guard decorator (grounding → learning → policy → execution)
-├── tracing.py                   # JSONL persistence of epistemic traces
+├── metrics.py                   # MetricsManager — best-effort grounding/learning metric updates
+├── tracing.py                   # TraceWriter + TraceManager — JSONL persistence + suppression
 │
 ├── identity/
 │   ├── models.py                # AgentIdentity — stable UUID bound to a registration key
@@ -881,7 +886,7 @@ src/vre/
 └── learning/
     ├── callback.py              # LearningCallback ABC
     ├── models.py                # Candidate models, CandidateDecision, LearningResult
-    ├── templates.py             # TemplateFactory — gap → structured candidate template
+    ├── templates.py             # template_for_gap — gap → structured candidate template
     └── engine.py                # LearningEngine — template → callback → validate → persist
 
 scripts/

--- a/README.md
+++ b/README.md
@@ -829,11 +829,13 @@ reveals a constraint that was not modeled. The agent proposes the missing relatu
 (e.g. `create --[CONSTRAINED_BY]--> permission`), seeks human validation, and persists the new knowledge. Depth was
 honest before the failure and more complete after.
 
-### VRE Networks
+### Knowledge Import
 
-An agentic network of agents that share grounded knowledge across different epistemic graphs while applying the same
-enforcement mechanisms. A concept grounded at D3 in one agent's graph carries its
-epistemic justification with it — the network federates knowledge while keeping each agent's epistemic contract intact.
+A pathway for growing an agent's graph from peer-published knowledge. An agent fetches a peer's subgraph for a target
+concept and persists it locally as ordinary primitives stamped with `provenance.source = PEER` and a
+`(peer_name, imported_at)` attestation. Imports are one-shot — refresh is an explicit operator action, never a live
+link — which preserves the depth-explicit *validated trust* VRE's enforcement depends on while letting an agent grow
+its graph from a community of peers instead of authoring every concept from scratch.
 
 ### Epistemic Memory
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1164,17 +1164,11 @@ const NODES = [
           </p>
         </div>
         <div class="roadmap-item">
-          <div class="roadmap-name">VRE NETWORKS</div>
+          <div class="roadmap-name">KNOWLEDGE IMPORT</div>
           <p class="roadmap-desc">
-            Federated epistemic graphs. Agents share grounded knowledge across
-            trust boundaries while preserving each agent's epistemic contract.
-          </p>
-        </div>
-        <div class="roadmap-item">
-          <div class="roadmap-name">EPISTEMIC SCORE</div>
-          <p class="roadmap-desc">
-            Composite confidence from depth, recency, provenance, and exercise
-            history.
+            Grow the graph from peer-published knowledge. One-shot, validated
+            imports persisted locally with PEER provenance — explicit refresh,
+            no live link, no eroded validated-trust contract.
           </p>
         </div>
         <div class="roadmap-item">

--- a/examples/langchain_ollama/callbacks.py
+++ b/examples/langchain_ollama/callbacks.py
@@ -172,7 +172,7 @@ def on_trace(grounding: "GroundingResult") -> None:
         console.print(tree)
         return
 
-    primitives = grounding.trace.result.primitives
+    primitives = grounding.get_primitives()
     id_to_name = {p.id: p.name for p in primitives}
 
     depth_gap_map: dict = {

--- a/examples/langchain_ollama/learner.py
+++ b/examples/langchain_ollama/learner.py
@@ -145,15 +145,14 @@ def _fmt_existing_depths(primitive) -> str:
 
 def _fmt_available_targets(grounding: GroundingResult, source_id) -> str:
     lines = []
-    if grounding.trace:
-        for p in grounding.trace.result.primitives:
-            if p.id == source_id:
-                continue
-            lines.append(f"  {p.name}:")
-            if p.depths:
-                for d in sorted(p.depths, key=lambda d: d.level):
-                    props = ", ".join(f"{k}={v}" for k, v in d.properties.items()) if d.properties else "none"
-                    lines.append(f"    D{d.level.value} {d.level.name}: {props}")
+    for p in grounding.get_primitives():
+        if p.id == source_id:
+            continue
+        lines.append(f"  {p.name}:")
+        if p.depths:
+            for d in sorted(p.depths, key=lambda d: d.level):
+                props = ", ".join(f"{k}={v}" for k, v in d.properties.items()) if d.properties else "none"
+                lines.append(f"    D{d.level.value} {d.level.name}: {props}")
             else:
                 lines.append("    (no depths)")
     return "\n".join(lines) or "  (none)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.4.3"
+version = "0.5.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -176,13 +176,11 @@ class VRE:
         increments in-process, and batch-writes the results. Updates are
         best-effort — failures are logged but never block the caller.
         """
-        target_prims: list = []
-        if result.trace:
-            resolved_lower = {r.lower() for r in result.resolved}
-            target_prims = [
-                prim for prim in result.trace.result.primitives
-                if prim.name.lower() in resolved_lower
-            ]
+        resolved_lower = {r.lower() for r in result.resolved}
+        target_prims = [
+            prim for prim in result.get_primitives()
+            if prim.name.lower() in resolved_lower
+        ]
 
         current_metrics: dict[UUID, PrimitiveMetrics | None] | None = None
         if target_prims:

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -16,13 +16,9 @@ Usage::
 """
 
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Callable
-from uuid import UUID
 
-from vre.core.graph import PrimitiveRepository
-from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
 from vre.core.errors import (
     CandidateValidationError,
     CyclicRelationshipError,
@@ -34,15 +30,13 @@ from vre.core.errors import (
     ResolutionError,
     VREError,
 )
+from vre.core.graph import PrimitiveRepository
+from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
 from vre.core.models import (
-    DepthGap,
     DepthLevel,
-    ExistenceGap,
     PrimitiveMetrics,
     Provenance,
     ProvenanceSource,
-    ReachabilityGap,
-    RelationalGap,
 )
 from vre.core.policy import Cardinality, PolicyAction, PolicyCallbackResult, PolicyResult, PolicyViolation
 from vre.core.policy.callback import PolicyCallContext
@@ -55,7 +49,8 @@ from vre.learning import (
     LearningEngine,
     LearningResult,
 )
-from vre.tracing import TraceWriter, build_trace_entry
+from vre.metrics import MetricsManager
+from vre.tracing import TraceManager, TraceWriter
 
 logging.getLogger("vre").addHandler(logging.NullHandler())
 
@@ -126,14 +121,13 @@ class VRE:
         self._resolver = ConceptResolver(repository)
         self._engine = GroundingEngine(repository)
         self._learning_engine = LearningEngine(repository)
+        self._metrics = MetricsManager(repository)
+        self._traces = TraceManager(TraceWriter() if persist_traces else None)
 
         if agent_key is not None:
             self._identity: AgentIdentity | None = AgentRegistry(registry_path).get_or_create(agent_key, name=agent_name)
         else:
             self._identity = None
-
-        self._suppress_trace = False
-        self._trace_writer: TraceWriter | None = TraceWriter() if persist_traces else None
 
     @property
     def identity(self) -> AgentIdentity | None:
@@ -149,105 +143,6 @@ class VRE:
         if self._identity is not None and result.agent_id is None:
             result.agent_id = self._identity.agent_id
         return result
-
-    @staticmethod
-    def _gap_primitive_ids(gaps: list) -> set[UUID]:
-        """
-        Collect the set of primitive UUIDs that are epistemically deficient.
-
-        RelationalGaps contribute only the target ID — the relationship
-        is a pure structural declaration and the source is epistemically
-        sound if the edge is visible. The failure belongs to the target
-        that lacks the required depth.
-        """
-        ids: set[UUID] = set()
-        for gap in gaps:
-            if gap.kind == "RELATIONAL":
-                ids.add(gap.target.id)
-            else:
-                ids.add(gap.primitive.id)
-        return ids
-
-    def _update_grounding_metrics(self, result: GroundingResult) -> None:
-        """
-        Update per-primitive grounding metrics after a `check` call.
-
-        Batch-reads current metrics for all resolved root concepts, computes
-        increments in-process, and batch-writes the results. Updates are
-        best-effort — failures are logged but never block the caller.
-        """
-        resolved_lower = {r.lower() for r in result.resolved}
-        target_prims = [
-            prim for prim in result.get_primitives()
-            if prim.name.lower() in resolved_lower
-        ]
-
-        current_metrics: dict[UUID, PrimitiveMetrics | None] | None = None
-        if target_prims:
-            try:
-                current_metrics = self._repo.batch_read_metrics([p.id for p in target_prims])
-            except Exception:
-                logger.warning("Failed to batch-read metrics", exc_info=True)
-
-        updates: dict[UUID, PrimitiveMetrics] = {}
-        if current_metrics is not None:
-            now = datetime.now(timezone.utc)
-            gap_ids = self._gap_primitive_ids(result.gaps)
-            for prim in target_prims:
-                if prim.id not in current_metrics:
-                    continue
-                metrics = current_metrics[prim.id] or PrimitiveMetrics()
-                if prim.id in gap_ids:
-                    metrics.failure_count += 1
-                    metrics.last_failed = now
-                else:
-                    metrics.grounding_count += 1
-                    metrics.last_grounded = now
-                updates[prim.id] = metrics
-
-        if updates:
-            try:
-                self._repo.batch_update_metrics(updates)
-            except Exception:
-                logger.warning("Failed to batch-update metrics for %d primitives", len(updates), exc_info=True)
-
-    def _update_learning_metric(
-        self,
-        gap: DepthGap | ExistenceGap | RelationalGap | ReachabilityGap,
-        decision: CandidateDecision,
-    ) -> None:
-        """
-        Update learning metrics on the primitive targeted by a gap.
-
-        Increments `learning_count` for accepted/modified decisions and
-        `rejection_count` for rejected decisions. Skipped decisions are
-        ignored. Looks up the primitive by ID first, falling back to name
-        for ExistenceGaps where the gap carries a transient ID.
-        """
-        prim_id: UUID | None = None
-        prim_name: str | None = None
-        if decision != CandidateDecision.SKIPPED:
-            if isinstance(gap, RelationalGap):
-                prim_id, prim_name = gap.target.id, gap.target.name
-            elif isinstance(gap, (DepthGap, ExistenceGap, ReachabilityGap)):
-                prim_id, prim_name = gap.primitive.id, gap.primitive.name
-
-        found = None
-        if prim_id is not None:
-            found = self._repo.find_by_id(prim_id)
-            if found is None and prim_name is not None:
-                found = self._repo.find_by_name(prim_name)
-
-        if found is not None:
-            metrics = found.metrics or PrimitiveMetrics()
-            if decision in (CandidateDecision.ACCEPTED, CandidateDecision.MODIFIED):
-                metrics.learning_count += 1
-            elif decision == CandidateDecision.REJECTED:
-                metrics.rejection_count += 1
-            try:
-                self._repo.update_metrics(found.id, metrics)
-            except Exception:
-                logger.warning("Failed to update learning metrics for %r", prim_name, exc_info=True)
 
     def resolve(self, concepts: list[str]) -> list[str]:
         """
@@ -268,12 +163,8 @@ class VRE:
         integrator override that can only raise the floor, never lower it.
         """
         result = self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
-        self._update_grounding_metrics(result)
-        if self._trace_writer is not None and not self._suppress_trace:
-            try:
-                self._trace_writer.write(build_trace_entry("check", concepts, result))
-            except Exception:
-                logger.warning("Failed to persist trace for check()", exc_info=True)
+        self._metrics.update_grounding(result)
+        self._traces.write_check(concepts, result)
         return result
 
     def learn_all(
@@ -293,38 +184,28 @@ class VRE:
         """
         skipped: set[int] = set()
         learning_outcomes: list[LearningResult] = []
-        self._suppress_trace = True
-        try:
-            with callback:
-                while not grounding.grounded and grounding.gaps:
-                    gap_index = next(
-                        (i for i, g in enumerate(grounding.gaps) if i not in skipped),
-                        None,
-                    )
-                    if gap_index is None:
-                        break
-                    result = self._learning_engine.learn_at(grounding, gap_index, callback)
-                    learning_outcomes.append(result)
-                    self._update_learning_metric(grounding.gaps[gap_index], result.decision)
-                    if result.decision == CandidateDecision.REJECTED:
-                        break
-                    if result.decision == CandidateDecision.SKIPPED:
-                        skipped.add(gap_index)
-                        continue
-                    self._resolver.invalidate()
-                    grounding = self.check(concepts, min_depth=min_depth)
-                    skipped.clear()
-        finally:
-            self._suppress_trace = False
-
-        if self._trace_writer is not None and learning_outcomes:
-            try:
-                self._trace_writer.write(
-                    build_trace_entry("learn", concepts, grounding, learning_outcomes)
+        with self._traces.suppress(), callback:
+            while not grounding.grounded and grounding.gaps:
+                gap_index = next(
+                    (i for i, g in enumerate(grounding.gaps) if i not in skipped),
+                    None,
                 )
-            except Exception:
-                logger.warning("Failed to persist trace for learn_all()", exc_info=True)
+                if gap_index is None:
+                    break
+                result = self._learning_engine.learn_at(grounding, gap_index, callback)
+                learning_outcomes.append(result)
+                self._metrics.update_learning(grounding.gaps[gap_index], result.decision)
+                if result.decision == CandidateDecision.REJECTED:
+                    break
+                if result.decision == CandidateDecision.SKIPPED:
+                    skipped.add(gap_index)
+                    continue
+                self._resolver.invalidate()
+                grounding = self.check(concepts, min_depth=min_depth)
+                skipped.clear()
 
+        if learning_outcomes:
+            self._traces.write_learn(concepts, grounding, learning_outcomes)
         return grounding
 
     def check_policy(

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -117,25 +117,10 @@ class VRE:
         """
         Initialize VRE with the given primitive repository.
 
-        Parameters
-        ----------
-        repository:
-            The Neo4j primitive repository for graph operations.
-        agent_key:
-            Optional registration key for agent identity. When provided,
-            the key is resolved via the persisted registry to a stable
-            AgentIdentity whose `agent_id` is stamped on every
-            GroundingResult produced by this instance.
-        agent_name:
-            Optional human-readable name for the agent. Only used on
-            first registration; ignored on subsequent calls with the
-            same `agent_key`.
-        registry_path:
-            Path to the agent registry JSON file. Defaults to
-            `AgentRegistry`'s built-in default when None.
-        persist_traces:
-            When True (default), grounding traces are persisted to daily
-            JSONL files under `~/.vre/traces/`.
+        When `agent_key` is provided, it resolves via the persisted registry
+        to a stable AgentIdentity stamped on every GroundingResult; `agent_name`
+        is used only on first registration. Traces are persisted to daily JSONL
+        files under `~/.vre/traces/` when `persist_traces` is True.
         """
         self._repo = repository
         self._resolver = ConceptResolver(repository)
@@ -191,42 +176,36 @@ class VRE:
         increments in-process, and batch-writes the results. Updates are
         best-effort — failures are logged but never block the caller.
         """
-        if not result.trace:
-            return
+        target_prims: list = []
+        if result.trace:
+            resolved_lower = {r.lower() for r in result.resolved}
+            target_prims = [
+                prim for prim in result.trace.result.primitives
+                if prim.name.lower() in resolved_lower
+            ]
 
-        now = datetime.now(timezone.utc)
-        gap_ids = self._gap_primitive_ids(result.gaps)
-        resolved_lower = {r.lower() for r in result.resolved}
-
-        target_prims = [
-            prim for prim in result.trace.result.primitives
-            if prim.name.lower() in resolved_lower
-        ]
-        if not target_prims:
-            return
-
-        target_ids = [p.id for p in target_prims]
-
-        try:
-            current_metrics = self._repo.batch_read_metrics(target_ids)
-        except Exception:
-            logger.warning("Failed to batch-read metrics", exc_info=True)
-            return
+        current_metrics: dict[UUID, PrimitiveMetrics | None] | None = None
+        if target_prims:
+            try:
+                current_metrics = self._repo.batch_read_metrics([p.id for p in target_prims])
+            except Exception:
+                logger.warning("Failed to batch-read metrics", exc_info=True)
 
         updates: dict[UUID, PrimitiveMetrics] = {}
-        for prim in target_prims:
-            if prim.id not in current_metrics:
-                continue
-            metrics = current_metrics[prim.id] or PrimitiveMetrics()
-
-            if prim.id in gap_ids:
-                metrics.failure_count += 1
-                metrics.last_failed = now
-            else:
-                metrics.grounding_count += 1
-                metrics.last_grounded = now
-
-            updates[prim.id] = metrics
+        if current_metrics is not None:
+            now = datetime.now(timezone.utc)
+            gap_ids = self._gap_primitive_ids(result.gaps)
+            for prim in target_prims:
+                if prim.id not in current_metrics:
+                    continue
+                metrics = current_metrics[prim.id] or PrimitiveMetrics()
+                if prim.id in gap_ids:
+                    metrics.failure_count += 1
+                    metrics.last_failed = now
+                else:
+                    metrics.grounding_count += 1
+                    metrics.last_grounded = now
+                updates[prim.id] = metrics
 
         if updates:
             try:
@@ -247,33 +226,30 @@ class VRE:
         ignored. Looks up the primitive by ID first, falling back to name
         for ExistenceGaps where the gap carries a transient ID.
         """
-        if decision == CandidateDecision.SKIPPED:
-            return
+        prim_id: UUID | None = None
+        prim_name: str | None = None
+        if decision != CandidateDecision.SKIPPED:
+            if isinstance(gap, RelationalGap):
+                prim_id, prim_name = gap.target.id, gap.target.name
+            elif isinstance(gap, (DepthGap, ExistenceGap, ReachabilityGap)):
+                prim_id, prim_name = gap.primitive.id, gap.primitive.name
 
-        if isinstance(gap, RelationalGap):
-            prim_id, prim_name = gap.target.id, gap.target.name
-        elif isinstance(gap, (DepthGap, ExistenceGap, ReachabilityGap)):
-            prim_id, prim_name = gap.primitive.id, gap.primitive.name
-        else:
-            return
+        found = None
+        if prim_id is not None:
+            found = self._repo.find_by_id(prim_id)
+            if found is None and prim_name is not None:
+                found = self._repo.find_by_name(prim_name)
 
-        found = self._repo.find_by_id(prim_id)
-        if found is None:
-            found = self._repo.find_by_name(prim_name)
-        if found is None:
-            return
-
-        metrics = found.metrics or PrimitiveMetrics()
-
-        if decision in (CandidateDecision.ACCEPTED, CandidateDecision.MODIFIED):
-            metrics.learning_count += 1
-        elif decision == CandidateDecision.REJECTED:
-            metrics.rejection_count += 1
-
-        try:
-            self._repo.update_metrics(found.id, metrics)
-        except Exception:
-            logger.warning("Failed to update learning metrics for %r", prim_name, exc_info=True)
+        if found is not None:
+            metrics = found.metrics or PrimitiveMetrics()
+            if decision in (CandidateDecision.ACCEPTED, CandidateDecision.MODIFIED):
+                metrics.learning_count += 1
+            elif decision == CandidateDecision.REJECTED:
+                metrics.rejection_count += 1
+            try:
+                self._repo.update_metrics(found.id, metrics)
+            except Exception:
+                logger.warning("Failed to update learning metrics for %r", prim_name, exc_info=True)
 
     def resolve(self, concepts: list[str]) -> list[str]:
         """
@@ -290,15 +266,8 @@ class VRE:
         Ground concepts with graph-derived depth gating.
 
         Returns a GroundingResult with grounded=True only when all resolved
-        concepts are fully grounded with no gaps.
-
-        Parameters
-        ----------
-        concepts:
-            List of free-form concept names to ground.
-        min_depth:
-            Optional integrator override — enforces a minimum depth floor
-            on all root primitives. Can only raise the floor, never lower it.
+        concepts are fully grounded with no gaps. `min_depth` is an optional
+        integrator override that can only raise the floor, never lower it.
         """
         result = self._stamp_identity(self._engine.ground(concepts, self._resolver, min_depth=min_depth))
         self._update_grounding_metrics(result)
@@ -390,50 +359,47 @@ class VRE:
             grounding = self._stamp_identity(self._engine.ground(concepts, self._resolver))
 
         if grounding.trace is None:
-            return PolicyResult(action=PolicyAction.PASS)
-
-        card_enum: Cardinality | None = None
-        if cardinality is not None:
-            try:
-                card_enum = Cardinality(cardinality)
-            except ValueError:
-                card_enum = None  # unknown → fire all policies
-
-        gate = PolicyGate()
-        violations = gate.evaluate(grounding.trace, card_enum, call_context)
-
-        if not violations:
             policy_result = PolicyResult(action=PolicyAction.PASS)
         else:
-            hard_blocks = [v for v in violations if not v.requires_confirmation]
-            pending = [v for v in violations if v.requires_confirmation]
+            card_enum: Cardinality | None = None
+            if cardinality is not None:
+                try:
+                    card_enum = Cardinality(cardinality)
+                except ValueError:
+                    card_enum = None  # unknown → fire all policies
 
-            # Hard blocks do not consult on_policy — they are immediate BLOCKs with their own messages
-            if hard_blocks:
-                messages = "; ".join(v.message for v in hard_blocks)
-                policy_result = PolicyResult(
-                    action=PolicyAction.BLOCK,
-                    reason=messages,
-                    violations=violations,
-                )
+            gate = PolicyGate()
+            violations = gate.evaluate(grounding.trace, card_enum, call_context)
+
+            if not violations:
+                policy_result = PolicyResult(action=PolicyAction.PASS)
             else:
-                # Only confirmation-required violations remain — consult on_policy
-                if on_policy is not None:
-                    if on_policy(pending):
-                        policy_result = PolicyResult(
-                            action=PolicyAction.PASS,
-                            violations=pending,
-                        )
-                    else:
-                        policy_result = PolicyResult(
-                            action=PolicyAction.BLOCK,
-                            reason="User declined",
-                            violations=pending,
-                        )
-                else:
+                hard_blocks = [v for v in violations if not v.requires_confirmation]
+                pending = [v for v in violations if v.requires_confirmation]
+
+                # Hard blocks do not consult on_policy — they are immediate BLOCKs with their own messages
+                if hard_blocks:
+                    messages = "; ".join(v.message for v in hard_blocks)
+                    policy_result = PolicyResult(
+                        action=PolicyAction.BLOCK,
+                        reason=messages,
+                        violations=violations,
+                    )
+                elif on_policy is None:
                     policy_result = PolicyResult(
                         action=PolicyAction.BLOCK,
                         reason="Confirmation required, no handler",
+                        violations=pending,
+                    )
+                elif on_policy(pending):
+                    policy_result = PolicyResult(
+                        action=PolicyAction.PASS,
+                        violations=pending,
+                    )
+                else:
+                    policy_result = PolicyResult(
+                        action=PolicyAction.BLOCK,
+                        reason="User declined",
                         violations=pending,
                     )
 

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -122,9 +122,14 @@ class PrimitiveRepository:
         """
         Parse a Neo4j property that may be a JSON string or already-decoded dict/list.
         """
-        if isinstance(value, str):
-            return json.loads(value)
-        return value
+        return json.loads(value) if isinstance(value, str) else value
+
+    @staticmethod
+    def _dump_model_json(model: Any) -> str | None:
+        """
+        Serialize an optional Pydantic model to a JSON string, or None when absent.
+        """
+        return json.dumps(model.model_dump(mode="json")) if model is not None else None
 
     @staticmethod
     def _record_to_node_data(record: Any) -> dict[str, Any]:
@@ -300,7 +305,7 @@ class PrimitiveRepository:
                         "target_depth": int(relatum.target_depth),
                         "metadata_json": json.dumps(relatum.metadata) if relatum.metadata else "{}",
                         "policies": json.dumps([p.model_dump() for p in relatum.policies]) if relatum.policies else "[]",
-                        "provenance": json.dumps(relatum.provenance.model_dump(mode="json")) if relatum.provenance else None,
+                        "provenance": self._dump_model_json(relatum.provenance),
                     }
                 )
 
@@ -311,8 +316,8 @@ class PrimitiveRepository:
 
         rel_types = [rt.value for rt in RelationType]
 
-        node_provenance = json.dumps(primitive.provenance.model_dump(mode="json")) if primitive.provenance else None
-        node_metrics = json.dumps(primitive.metrics.model_dump(mode="json")) if primitive.metrics else None
+        node_provenance = self._dump_model_json(primitive.provenance)
+        node_metrics = self._dump_model_json(primitive.metrics)
 
         def _tx(tx: Any) -> None:
             tx.run(
@@ -398,35 +403,34 @@ class PrimitiveRepository:
         """
         Read current metrics for multiple primitives in a single query.
         """
-        if not primitive_ids:
-            return {}
-        cypher = cast(
-            LiteralString,
-            "MATCH (p:Primitive) WHERE p.id IN $ids "
-            "RETURN p.id AS id, p.metrics_json AS metrics_json",
-        )
-        try:
-            with self._driver.session(database=self._database) as session:
-                records = session.run(cypher, ids=[str(pid) for pid in primitive_ids])
-                result: dict[UUID, PrimitiveMetrics | None] = {}
-                for record in records:
-                    pid = UUID(record["id"])
-                    raw = record["metrics_json"]
-                    if raw:
-                        try:
-                            parsed = self._parse_json_field(raw)
-                            result[pid] = PrimitiveMetrics.model_validate(parsed)
-                        except Exception as exc:
-                            raise HydrationError(
-                                f"Failed to hydrate metrics for primitive '{pid}': {exc}"
-                            ) from exc
-                    else:
-                        result[pid] = None
-                return result
-        except HydrationError:
-            raise
-        except Neo4jError as exc:
-            raise GraphError(f"Failed to batch-read metrics: {exc}") from exc
+        result: dict[UUID, PrimitiveMetrics | None] = {}
+        if primitive_ids:
+            cypher = cast(
+                LiteralString,
+                "MATCH (p:Primitive) WHERE p.id IN $ids "
+                "RETURN p.id AS id, p.metrics_json AS metrics_json",
+            )
+            try:
+                with self._driver.session(database=self._database) as session:
+                    records = session.run(cypher, ids=[str(pid) for pid in primitive_ids])
+                    for record in records:
+                        pid = UUID(record["id"])
+                        raw = record["metrics_json"]
+                        if raw:
+                            try:
+                                parsed = self._parse_json_field(raw)
+                                result[pid] = PrimitiveMetrics.model_validate(parsed)
+                            except Exception as exc:
+                                raise HydrationError(
+                                    f"Failed to hydrate metrics for primitive '{pid}': {exc}"
+                                ) from exc
+                        else:
+                            result[pid] = None
+            except HydrationError:
+                raise
+            except Neo4jError as exc:
+                raise GraphError(f"Failed to batch-read metrics: {exc}") from exc
+        return result
 
     def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
         """
@@ -495,17 +499,18 @@ class PrimitiveRepository:
                 record = session.run(cypher, id=str(id)).single()
                 if record is None or record["id"] is None:
                     logger.debug("Primitive not found by id=%s", id)
-                    return None
-
-                return self._hydrate_primitive(
-                    self._record_to_node_data(record),
-                    self._record_to_relationships(record),
-                )
+                    primitive = None
+                else:
+                    primitive = self._hydrate_primitive(
+                        self._record_to_node_data(record),
+                        self._record_to_relationships(record),
+                    )
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
             logger.error("Neo4j error finding primitive by id=%s: %s", id, exc)
             raise GraphError(f"Failed to find primitive by id '{id}': {exc}") from exc
+        return primitive
 
     def find_by_name(self, name: str) -> Primitive | None:
         """
@@ -540,17 +545,18 @@ class PrimitiveRepository:
                 record = session.run(cypher, name=name).single()
                 if record is None or record["id"] is None:
                     logger.debug("Primitive not found by name=%r", name)
-                    return None
-
-                return self._hydrate_primitive(
-                    self._record_to_node_data(record),
-                    self._record_to_relationships(record),
-                )
+                    primitive = None
+                else:
+                    primitive = self._hydrate_primitive(
+                        self._record_to_node_data(record),
+                        self._record_to_relationships(record),
+                    )
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
             logger.error("Neo4j error finding primitive by name=%r: %s", name, exc)
             raise GraphError(f"Failed to find primitive by name '{name}': {exc}") from exc
+        return primitive
 
     def delete_primitive(self, id: UUID) -> bool:
         """
@@ -625,54 +631,55 @@ class PrimitiveRepository:
                 ).single()
 
                 if record is None:
-                    return ResolvedSubgraph(roots=[], nodes=[], edges=[])
+                    subgraph = ResolvedSubgraph(roots=[], nodes=[], edges=[])
+                else:
+                    raw_roots = record["roots"]
+                    raw_nodes = record["nodes"]
+                    raw_edges = record["edges"]
 
-                raw_roots = record["roots"]
-                raw_nodes = record["nodes"]
-                raw_edges = record["edges"]
+                    edges_by_source: dict[str, list[dict[str, Any]]] = {}
+                    for e in raw_edges:
+                        sid = e["source_id"]
+                        edges_by_source.setdefault(sid, []).append({
+                            "rel_type": e["rel_type"],
+                            "target_id": e["target_id"],
+                            "rel_props": {
+                                "source_depth": e["source_depth"],
+                                "target_depth": e["target_depth"],
+                                "metadata_json": e.get("metadata_json", "{}"),
+                                "policies": e.get("policies", "[]"),
+                                "provenance": e.get("provenance"),
+                            },
+                        })
 
-                edges_by_source: dict[str, list[dict[str, Any]]] = {}
-                for e in raw_edges:
-                    sid = e["source_id"]
-                    edges_by_source.setdefault(sid, []).append({
-                        "rel_type": e["rel_type"],
-                        "target_id": e["target_id"],
-                        "rel_props": {
-                            "source_depth": e["source_depth"],
-                            "target_depth": e["target_depth"],
-                            "metadata_json": e.get("metadata_json", "{}"),
-                            "policies": e.get("policies", "[]"),
-                            "provenance": e.get("provenance"),
-                        },
-                    })
+                    roots = [
+                        self._hydrate_primitive(r, edges_by_source.get(r["id"], []))
+                        for r in raw_roots
+                    ]
+                    nodes = [
+                        self._hydrate_primitive(n, edges_by_source.get(n["id"], []))
+                        for n in raw_nodes
+                    ]
 
-                roots = [
-                    self._hydrate_primitive(r, edges_by_source.get(r["id"], []))
-                    for r in raw_roots
-                ]
-                nodes = [
-                    self._hydrate_primitive(n, edges_by_source.get(n["id"], []))
-                    for n in raw_nodes
-                ]
+                    edges = [
+                        EpistemicStep(
+                            source_id=UUID(e["source_id"]),
+                            target_id=UUID(e["target_id"]),
+                            relation_type=RelationType(e["rel_type"]),
+                            source_depth=DepthLevel(e["source_depth"]),
+                            target_depth=DepthLevel(e["target_depth"]),
+                        )
+                        for e in raw_edges
+                    ]
 
-                edges = [
-                    EpistemicStep(
-                        source_id=UUID(e["source_id"]),
-                        target_id=UUID(e["target_id"]),
-                        relation_type=RelationType(e["rel_type"]),
-                        source_depth=DepthLevel(e["source_depth"]),
-                        target_depth=DepthLevel(e["target_depth"]),
+                    logger.debug(
+                        "Subgraph resolved: %d roots, %d nodes, %d edges",
+                        len(roots), len(nodes), len(edges),
                     )
-                    for e in raw_edges
-                ]
-
-                logger.debug(
-                    "Subgraph resolved: %d roots, %d nodes, %d edges",
-                    len(roots), len(nodes), len(edges),
-                )
-                return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+                    subgraph = ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
         except (GraphError, HydrationError):
             raise
         except Neo4jError as exc:
             logger.error("Neo4j error resolving subgraph for %s: %s", names, exc)
             raise GraphError(f"Failed to resolve subgraph for {names}: {exc}") from exc
+        return subgraph

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -285,58 +285,59 @@ class GroundingEngine:
         """
         if not concepts:
             logger.debug("Empty concept list, returning empty response")
-            return _empty_response()
+            response = _empty_response()
+        else:
+            subgraph = self._repo.resolve_subgraph(concepts)
 
-        subgraph = self._repo.resolve_subgraph(concepts)
-
-        roots, transients = self._identify_roots(concepts, subgraph.roots)
-        transient_ids = {t.id for t in transients}
-        root_ids = {r.id for r in roots}
-        all_nodes = list(subgraph.nodes) + transients
-        logger.debug(
-            "Query for %s: resolved %d roots (%d transient), %d nodes, %d edges",
-            concepts, len(roots), len(transients), len(all_nodes), len(subgraph.edges),
-        )
-
-        id_to_prim = {n.id: n for n in all_nodes}
-        visible_edges, gated_edges = self._partition_edges_by_source_depth(
-            subgraph.edges, id_to_prim,
-        )
-
-        gaps: list[DepthGap | ExistenceGap | RelationalGap | ReachabilityGap] = self._detect_gaps(
-            all_nodes,
-            visible_edges,
-            gated_edges,
-            root_ids,
-            transient_ids,
-            min_depth=min_depth,
-        )
-
-        # Undirected connectivity check across all non-transient roots
-        # using only visible edges. Anchor on the root with the largest
-        # reachable component so truly isolated nodes get reported.
-        non_transient_roots = [r for r in roots if r.id not in transient_ids]
-        if len(non_transient_roots) > 1:
-            neighbors: dict[UUID, set[UUID]] = {}
-            for edge in visible_edges:
-                neighbors.setdefault(edge.source_id, set()).add(edge.target_id)
-                neighbors.setdefault(edge.target_id, set()).add(edge.source_id)
-            anchor = max(
-                non_transient_roots,
-                key=lambda r: len(self._reachable_undirected(r.id, neighbors)),
+            roots, transients = self._identify_roots(concepts, subgraph.roots)
+            transient_ids = {t.id for t in transients}
+            root_ids = {r.id for r in roots}
+            all_nodes = list(subgraph.nodes) + transients
+            logger.debug(
+                "Query for %s: resolved %d roots (%d transient), %d nodes, %d edges",
+                concepts, len(roots), len(transients), len(all_nodes), len(subgraph.edges),
             )
-            reachable = self._reachable_undirected(anchor.id, neighbors)
-            for root in non_transient_roots:
-                if root.id != anchor.id and root.id not in reachable:
-                    logger.warning("Reachability gap: %r is isolated from other query roots", root.name)
-                    gaps.append(ReachabilityGap(primitive=root))
 
-        filtered = self._filter_depths(all_nodes)
+            id_to_prim = {n.id: n for n in all_nodes}
+            visible_edges, gated_edges = self._partition_edges_by_source_depth(
+                subgraph.edges, id_to_prim,
+            )
 
-        return EpistemicResponse(
-            query=EpistemicQuery(concept_ids=[r.id for r in roots]),
-            result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=visible_edges),
-        )
+            gaps: list[DepthGap | ExistenceGap | RelationalGap | ReachabilityGap] = self._detect_gaps(
+                all_nodes,
+                visible_edges,
+                gated_edges,
+                root_ids,
+                transient_ids,
+                min_depth=min_depth,
+            )
+
+            # Undirected connectivity check across all non-transient roots
+            # using only visible edges. Anchor on the root with the largest
+            # reachable component so truly isolated nodes get reported.
+            non_transient_roots = [r for r in roots if r.id not in transient_ids]
+            if len(non_transient_roots) > 1:
+                neighbors: dict[UUID, set[UUID]] = {}
+                for edge in visible_edges:
+                    neighbors.setdefault(edge.source_id, set()).add(edge.target_id)
+                    neighbors.setdefault(edge.target_id, set()).add(edge.source_id)
+                anchor = max(
+                    non_transient_roots,
+                    key=lambda r: len(self._reachable_undirected(r.id, neighbors)),
+                )
+                reachable = self._reachable_undirected(anchor.id, neighbors)
+                for root in non_transient_roots:
+                    if root.id != anchor.id and root.id not in reachable:
+                        logger.warning("Reachability gap: %r is isolated from other query roots", root.name)
+                        gaps.append(ReachabilityGap(primitive=root))
+
+            filtered = self._filter_depths(all_nodes)
+
+            response = EpistemicResponse(
+                query=EpistemicQuery(concept_ids=[r.id for r in roots]),
+                result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=visible_edges),
+            )
+        return response
 
     def ground(
         self,
@@ -354,24 +355,25 @@ class GroundingEngine:
         """
         if not concepts:
             logger.debug("Ground called with empty concepts")
-            return GroundingResult(grounded=False, resolved=[], gaps=[], trace=None)
+            result = GroundingResult(grounded=False, resolved=[], gaps=[], trace=None)
+        else:
+            # Resolve to canonical names where possible; unknown names pass through
+            # as-is — the engine will surface ExistenceGaps for them.
+            name_map = resolver.build_name_map()
+            canonical = [
+                (resolver.lookup(c, name_map) or c)
+                for c in concepts
+            ]
+            logger.info("Grounding %d concept(s)", len(concepts))
+            logger.debug("Grounding concepts: %s -> canonical: %s", concepts, canonical)
 
-        # Resolve to canonical names where possible; unknown names pass through
-        # as-is — the engine will surface ExistenceGaps for them.
-        name_map = resolver.build_name_map()
-        canonical = [
-            (resolver.lookup(c, name_map) or c)
-            for c in concepts
-        ]
-        logger.info("Grounding %d concept(s)", len(concepts))
-        logger.debug("Grounding concepts: %s -> canonical: %s", concepts, canonical)
-
-        response = self.query(canonical, min_depth=min_depth)
-        grounded = len(response.result.gaps) == 0
-        logger.info("Grounding result: grounded=%s, gaps=%d", grounded, len(response.result.gaps))
-        return GroundingResult(
-            grounded=grounded,
-            resolved=canonical,
-            gaps=response.result.gaps,
-            trace=response,
-        )
+            response = self.query(canonical, min_depth=min_depth)
+            grounded = len(response.result.gaps) == 0
+            logger.info("Grounding result: grounded=%s, gaps=%d", grounded, len(response.result.gaps))
+            result = GroundingResult(
+                grounded=grounded,
+                resolved=canonical,
+                gaps=response.result.gaps,
+                trace=response,
+            )
+        return result

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -24,7 +24,6 @@ from vre.core.graph import PrimitiveRepository
 from vre.core.grounding.models import GroundingResult
 from vre.core.grounding.resolver import ConceptResolver
 from vre.core.models import (
-    Depth,
     DepthGap,
     DepthLevel,
     EpistemicQuery,

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -17,6 +17,7 @@ lever to enforce a stricter floor than the graph alone would require.
 from __future__ import annotations
 
 import logging
+from functools import cache
 from uuid import UUID
 
 from vre.core.graph import PrimitiveRepository
@@ -93,17 +94,30 @@ class GroundingEngine:
         return all_roots, transients
 
     @staticmethod
-    def _contiguous_max_depth(node: Primitive) -> DepthLevel | None:
+    @cache
+    def _max_contiguous_from_levels(present: frozenset[DepthLevel]) -> DepthLevel | None:
         """
-        Return the highest DepthLevel forming a contiguous chain from D0, or None if no depths.
+        Highest DepthLevel forming a contiguous chain from D0 in *present*, or None.
+
+        Pure function of the level set — memoized so all primitives sharing a
+        depth shape share the cached answer. Cache grows with the number of
+        distinct level-sets the process sees (typically tiny).
         """
-        present = {d.level for d in node.depths}
         result: DepthLevel | None = None
         for level in sorted(DepthLevel):
             if level not in present:
                 break
             result = level
         return result
+
+    @staticmethod
+    def _contiguous_max_depth(node: Primitive) -> DepthLevel | None:
+        """
+        Return the highest DepthLevel forming a contiguous chain from D0, or None if no depths.
+        """
+        return GroundingEngine._max_contiguous_from_levels(
+            frozenset(d.level for d in node.depths)
+        )
 
     @staticmethod
     def _partition_edges_by_source_depth(
@@ -240,23 +254,26 @@ class GroundingEngine:
     def _filter_depths(all_nodes: list[Primitive]) -> list[Primitive]:
         """
         Return copies of all_nodes with relata filtered to targets present in the collected set.
+
+        Uses model_copy(deep=True) to skip Pydantic re-validation while still
+        producing fully detached instances — downstream consumers (metrics
+        updates, tracing) can treat the result as independent of the source.
         """
         collected_ids = {n.id for n in all_nodes}
         return [
-            Primitive(
-                id=p.id,
-                name=p.name,
-                provenance=p.provenance,
-                metrics=p.metrics,
-                depths=[
-                    Depth(
-                        level=d.level,
-                        properties=d.properties,
-                        provenance=d.provenance,
-                        relata=[r for r in d.relata if r.target_id in collected_ids],
-                    )
-                    for d in p.depths
-                ],
+            p.model_copy(
+                update={
+                    "depths": [
+                        d.model_copy(
+                            update={
+                                "relata": [r for r in d.relata if r.target_id in collected_ids],
+                            },
+                            deep=True,
+                        )
+                        for d in p.depths
+                    ],
+                },
+                deep=True,
             )
             for p in all_nodes
         ]

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -10,43 +10,44 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from vre.core.models import EpistemicResponse
+from vre.core.models import (
+    Depth,
+    EpistemicResponse,
+    KnowledgeGap,
+    Primitive,
+    Relatum,
+    format_depth_label,
+)
 
 
 # ── Private formatting helpers ────────────────────────────────────────────────
 
-def _fmt_gap(gap: Any) -> str:
+def _fmt_gap(gap: KnowledgeGap) -> str:
     """
     Format a KnowledgeGap as a human-readable string.
     """
     kind = gap.kind
     if kind == "EXISTENCE":
-        return f"EXISTENCE: '{gap.primitive.name}' is not in the knowledge graph"
-    if kind == "DEPTH":
-        curr = (
-            f"D{gap.current_depth.value} {gap.current_depth.name}"
-            if gap.current_depth is not None
-            else "none"
-        )
-        req = f"D{gap.required_depth.value} {gap.required_depth.name}"
-        return f"DEPTH: '{gap.primitive.name}' known to {curr}, requires {req}"
-    if kind == "RELATIONAL":
-        curr = (
-            f"D{gap.current_depth.value} {gap.current_depth.name}"
-            if gap.current_depth is not None
-            else "none"
-        )
-        req = f"D{gap.required_depth.value} {gap.required_depth.name}"
-        return (
+        out = f"EXISTENCE: '{gap.primitive.name}' is not in the knowledge graph"
+    elif kind == "DEPTH":
+        curr = format_depth_label(gap.current_depth)
+        req = format_depth_label(gap.required_depth)
+        out = f"DEPTH: '{gap.primitive.name}' known to {curr}, requires {req}"
+    elif kind == "RELATIONAL":
+        curr = format_depth_label(gap.current_depth)
+        req = format_depth_label(gap.required_depth)
+        out = (
             f"RELATIONAL: '{gap.source.name}' → '{gap.target.name}' "
             f"requires {req} on target, found {curr}"
         )
-    if kind == "REACHABILITY":
-        return f"REACHABILITY: '{gap.primitive.name}' is not connected to other concepts"
-    return f"UNKNOWN: {gap}"
+    elif kind == "REACHABILITY":
+        out = f"REACHABILITY: '{gap.primitive.name}' is not connected to other concepts"
+    else:
+        out = f"UNKNOWN: {gap}"
+    return out
 
 
-def _fmt_relatum(r: Any, id_to_name: dict) -> list[str]:
+def _fmt_relatum(r: Relatum, id_to_name: dict[UUID, str]) -> list[str]:
     """
     Format a single Relatum as display lines, including metadata, policy count, and provenance.
     """
@@ -65,12 +66,12 @@ def _fmt_relatum(r: Any, id_to_name: dict) -> list[str]:
     return lines
 
 
-def _fmt_depth(depth: Any, id_to_name: dict) -> list[str]:
+def _fmt_depth(depth: Depth, id_to_name: dict[UUID, str]) -> list[str]:
     """
     Format a single Depth level as display lines, including its relata.
     """
     prov_tag = f"  [{depth.provenance.source.value}]" if depth.provenance else ""
-    lines = [f"  D{depth.level.value} {depth.level.name}{prov_tag}"]
+    lines = [f"  {format_depth_label(depth.level)}{prov_tag}"]
     if depth.properties:
         lines.append("    properties:")
         for k, v in depth.properties.items():
@@ -82,7 +83,7 @@ def _fmt_depth(depth: Any, id_to_name: dict) -> list[str]:
     return lines
 
 
-def _fmt_primitive(primitive: Any, id_to_name: dict) -> list[str]:
+def _fmt_primitive(primitive: Primitive, id_to_name: dict[UUID, str]) -> list[str]:
     """
     Format a Primitive and all its depths as display lines.
     """
@@ -94,20 +95,18 @@ def _fmt_primitive(primitive: Any, id_to_name: dict) -> list[str]:
         date_str = primitive.provenance.created_at.strftime("%Y-%m-%d")
         lines.append(f"  provenance: {primitive.provenance.source.value} ({date_str})")
 
-    if not primitive.depths:
-        return lines
-
-    # Compact single-line format when all depths have no properties or relata
-    all_empty = all(not d.properties and not d.relata for d in primitive.depths)
-    if all_empty:
-        labels = [
-            f"D{d.level.value} {d.level.name}"
-            for d in sorted(primitive.depths, key=lambda d: d.level)
-        ]
-        lines.append("  " + " → ".join(labels))
-    else:
-        for depth in sorted(primitive.depths, key=lambda d: d.level):
-            lines.extend(_fmt_depth(depth, id_to_name))
+    if primitive.depths:
+        # Compact single-line format when all depths have no properties or relata
+        all_empty = all(not d.properties and not d.relata for d in primitive.depths)
+        if all_empty:
+            labels = [
+                format_depth_label(d.level)
+                for d in sorted(primitive.depths, key=lambda d: d.level)
+            ]
+            lines.append("  " + " → ".join(labels))
+        else:
+            for depth in sorted(primitive.depths, key=lambda d: d.level):
+                lines.extend(_fmt_depth(depth, id_to_name))
 
     return lines
 

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from vre.core.models import (
     Depth,
     EpistemicResponse,
+    EpistemicStep,
     KnowledgeGap,
     Primitive,
     Relatum,
@@ -128,6 +129,18 @@ class GroundingResult(BaseModel):
     gaps: list[Any]
     trace: EpistemicResponse | None = None
     agent_id: UUID | None = None
+
+    def get_primitives(self) -> list[Primitive]:
+        """
+        Return the primitives from the underlying trace, or [] when absent.
+        """
+        return self.trace.result.primitives if self.trace is not None else []
+
+    def get_pathway_steps(self) -> list[EpistemicStep]:
+        """
+        Return the pathway steps from the underlying trace, or [] when absent.
+        """
+        return self.trace.result.pathway if self.trace is not None else []
 
     def __str__(self) -> str:
         """

--- a/src/vre/core/grounding/resolver.py
+++ b/src/vre/core/grounding/resolver.py
@@ -90,17 +90,20 @@ class ConceptResolver:
         """
         Return canonical name for concept, or None if not found.
         """
-        # Try direct lowercase match first
-        if concept.lower() in name_map:
-            logger.debug("Concept %r matched directly to %r", concept, name_map[concept.lower()])
-            return name_map[concept.lower()]
-        # Try each lemma
-        for lemma in lemmatize(concept):
-            if lemma in name_map:
-                logger.debug("Concept %r matched via lemma %r to %r", concept, lemma, name_map[lemma])
-                return name_map[lemma]
-        logger.debug("Concept %r: no match found in name map", concept)
-        return None
+        result: str | None = None
+        lower = concept.lower()
+        if lower in name_map:
+            result = name_map[lower]
+            logger.debug("Concept %r matched directly to %r", concept, result)
+        else:
+            for lemma in lemmatize(concept):
+                if lemma in name_map:
+                    result = name_map[lemma]
+                    logger.debug("Concept %r matched via lemma %r to %r", concept, lemma, result)
+                    break
+            if result is None:
+                logger.debug("Concept %r: no match found in name map", concept)
+        return result
 
     def resolve(self, concepts: list[str]) -> list[str]:
         """

--- a/src/vre/core/grounding/resolver.py
+++ b/src/vre/core/grounding/resolver.py
@@ -79,11 +79,12 @@ class ConceptResolver:
         Map lowercased primitive names to their canonical form.
 
         Results are cached on the instance; call `invalidate` after
-        mutations that add, rename, or remove primitives.
+        mutations that add, rename, or remove primitives. Returns the
+        cached dict directly — callers must not mutate it.
         """
         if self._name_map_cache is None:
             self._name_map_cache = {name.lower(): name for name in self._repo.list_names()}
-        return self._name_map_cache.copy()
+        return self._name_map_cache
 
     @staticmethod
     def lookup(concept: str, name_map: dict[str, str]) -> str | None:

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -5,6 +5,7 @@
 Core epistemic models for the Volute Reasoning Engine.
 """
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
 from enum import Enum, IntEnum
 from typing import Annotated, Any, Literal, NamedTuple
@@ -226,6 +227,23 @@ KnowledgeGap = Annotated[
     DepthGap | ExistenceGap | RelationalGap | ReachabilityGap,
     Field(discriminator="kind"),
 ]
+
+
+def gap_primitive_ids(gaps: Iterable[KnowledgeGap]) -> set[UUID]:
+    """
+    Collect the IDs of the primitives each gap is "about".
+
+    RelationalGaps point at the target — the visible edge means the source
+    is epistemically sound; the failure belongs to the under-grounded target.
+    All other gap kinds point at .primitive.
+    """
+    ids: set[UUID] = set()
+    for gap in gaps:
+        if gap.kind == "RELATIONAL":
+            ids.add(gap.target.id)
+        else:
+            ids.add(gap.primitive.id)
+    return ids
 
 
 class EpistemicStep(BaseModel):

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -27,6 +27,13 @@ class DepthLevel(IntEnum):
     IMPLICATIONS = 4
 
 
+def format_depth_label(level: "DepthLevel | None") -> str:
+    """
+    Render a DepthLevel as "D{value} {NAME}", or "none" when level is None.
+    """
+    return "none" if level is None else f"D{level.value} {level.name}"
+
+
 class RelationType(str, Enum):
     """
     Constrained relationship types between primitives.
@@ -87,8 +94,10 @@ class PrimitiveMetrics(BaseModel):
         The most recent time this primitive was exercised in any way.
         """
         if self.last_grounded and self.last_failed:
-            return max(self.last_grounded, self.last_failed)
-        return self.last_grounded or self.last_failed
+            result = max(self.last_grounded, self.last_failed)
+        else:
+            result = self.last_grounded or self.last_failed
+        return result
 
 
 class Relatum(BaseModel):

--- a/src/vre/core/policy/callback.py
+++ b/src/vre/core/policy/callback.py
@@ -48,7 +48,7 @@ class PolicyCallContext(BaseModel):
 
     tool_name: str
     grounding: GroundingResult
-    call_args: tuple
+    call_args: tuple[Any, ...]
     call_kwargs: dict[str, Any]
 
 

--- a/src/vre/core/policy/models.py
+++ b/src/vre/core/policy/models.py
@@ -70,20 +70,23 @@ class Policy(BaseModel):
         A result with passed=True suppresses the violation; passed=False
         (or no callback) means the policy fires.
         """
+        callback: PolicyCallback | None
         if self.callback is None:
-            return None
-        module_path, _, func_name = self.callback.rpartition(".")
-        if not module_path or not func_name:
-            raise VREError(
-                f"Invalid policy callback path '{self.callback}': expected 'module.attr'"
-            )
-        try:
-            module = importlib.import_module(module_path)
-            return getattr(module, func_name)
-        except (ImportError, AttributeError, ValueError) as exc:
-            raise VREError(
-                f"Failed to resolve policy callback '{self.callback}': {exc}"
-            ) from exc
+            callback = None
+        else:
+            module_path, _, func_name = self.callback.rpartition(".")
+            if not module_path or not func_name:
+                raise VREError(
+                    f"Invalid policy callback path '{self.callback}': expected 'module.attr'"
+                )
+            try:
+                module = importlib.import_module(module_path)
+                callback = getattr(module, func_name)
+            except (ImportError, AttributeError, ValueError) as exc:
+                raise VREError(
+                    f"Failed to resolve policy callback '{self.callback}': {exc}"
+                ) from exc
+        return callback
 
 
 def parse_policy(data: dict[str, Any]) -> Policy:
@@ -124,5 +127,7 @@ class PolicyResult(BaseModel):
         Render the policy result as a human-readable status string.
         """
         if self.action == PolicyAction.PASS:
-            return "[VRE Policy] PASSED"
-        return f"[VRE Policy] BLOCKED — {self.reason}"
+            msg = "[VRE Policy] PASSED"
+        else:
+            msg = f"[VRE Policy] BLOCKED — {self.reason}"
+        return msg

--- a/src/vre/core/policy/wizard.py
+++ b/src/vre/core/policy/wizard.py
@@ -14,24 +14,8 @@ import importlib
 from uuid import UUID
 
 from vre.core.graph import PrimitiveRepository
-from vre.core.models import DepthLevel, RelationType, Relatum
+from vre.core.models import DepthLevel, RelationType, Relatum, format_depth_label
 from vre.core.policy.models import Cardinality, Policy
-
-
-_DEPTH_LABELS: dict[DepthLevel, str] = {
-    DepthLevel.EXISTENCE:    "D0 EXISTENCE",
-    DepthLevel.IDENTITY:     "D1 IDENTITY",
-    DepthLevel.CAPABILITIES: "D2 CAPABILITIES",
-    DepthLevel.CONSTRAINTS:  "D3 CONSTRAINTS",
-    DepthLevel.IMPLICATIONS: "D4 IMPLICATIONS",
-}
-
-
-def _depth_label(level: DepthLevel) -> str:
-    """
-    Return the human-readable label for a DepthLevel, e.g. "D2 CAPABILITIES".
-    """
-    return _DEPTH_LABELS.get(level, f"D{int(level)}")
 
 
 def _prompt(msg: str, default: str = "") -> str:
@@ -39,8 +23,10 @@ def _prompt(msg: str, default: str = "") -> str:
     Prompt the user for input, using default if the response is blank.
     """
     if default:
-        return input(f"  {msg} [{default}]: ").strip() or default
-    return input(f"  {msg}: ").strip()
+        response = input(f"  {msg} [{default}]: ").strip() or default
+    else:
+        response = input(f"  {msg}: ").strip()
+    return response
 
 
 def _prompt_yn(msg: str, default: str = "y") -> bool:
@@ -71,20 +57,20 @@ def _validate_callback(path: str) -> bool:
     """
     Attempt to import and resolve a dotted-path callback string; return True if valid.
     """
+    valid = False
     module_path, _, attr = path.rpartition(".")
     if not module_path or not attr:
         print("    Callback must be a dotted path, e.g. my_module.my_fn")
-        return False
-    try:
-        mod = importlib.import_module(module_path)
-        getattr(mod, attr)
-        return True
-    except ImportError as exc:
-        print(f"    Import error: {exc}")
-        return False
-    except AttributeError as exc:
-        print(f"    Attribute error: {exc}")
-        return False
+    else:
+        try:
+            mod = importlib.import_module(module_path)
+            getattr(mod, attr)
+            valid = True
+        except ImportError as exc:
+            print(f"    Import error: {exc}")
+        except AttributeError as exc:
+            print(f"    Attribute error: {exc}")
+    return valid
 
 
 def _display_relata_table(
@@ -107,10 +93,10 @@ def _display_relata_table(
             target_name = name_cache[relatum.target_id]
             marker = "  <- policies here" if relatum.relation_type == RelationType.APPLIES_TO else ""
             print(
-                f"  {_depth_label(depth.level):<22}"
+                f"  {format_depth_label(depth.level):<22}"
                 f" {relatum.relation_type.value:<16}"
                 f" {target_name:<22}"
-                f" {_depth_label(relatum.target_depth):<18}"
+                f" {format_depth_label(relatum.target_depth):<18}"
                 f" {len(relatum.policies)}{marker}"
             )
     print()
@@ -237,46 +223,44 @@ def run_wizard(repo: PrimitiveRepository) -> None:
 
     if not matching:
         print(f"\n  No APPLIES_TO edge exists from '{source.name}' to '{target.name}'. Exiting.")
-        return
-
-    # Step 5: choose depth if ambiguous
-    if len(matching) == 1:
-        chosen_depth_level, _chosen_idx, chosen_relatum = matching[0]
     else:
-        print("\n  Multiple APPLIES_TO edges found. Choose one:")
-        for i, (lvl, _, rel) in enumerate(matching, 1):
-            print(f"    {i}. {_depth_label(lvl)} -> {target.name}  (policies: {len(rel.policies)})")
-        while True:
-            raw = input("  Enter number: ").strip()
-            try:
-                sel = int(raw)
-                if 1 <= sel <= len(matching):
-                    chosen_depth_level, _chosen_idx, chosen_relatum = matching[sel - 1]
-                    break
-            except ValueError:
-                pass
-            print(f"    Enter a number between 1 and {len(matching)}")
+        # Step 5: choose depth if ambiguous
+        if len(matching) == 1:
+            chosen_depth_level, _chosen_idx, chosen_relatum = matching[0]
+        else:
+            print("\n  Multiple APPLIES_TO edges found. Choose one:")
+            for i, (lvl, _, rel) in enumerate(matching, 1):
+                print(f"    {i}. {format_depth_label(lvl)} -> {target.name}  (policies: {len(rel.policies)})")
+            while True:
+                raw = input("  Enter number: ").strip()
+                try:
+                    sel = int(raw)
+                    if 1 <= sel <= len(matching):
+                        chosen_depth_level, _chosen_idx, chosen_relatum = matching[sel - 1]
+                        break
+                except ValueError:
+                    pass
+                print(f"    Enter a number between 1 and {len(matching)}")
 
-    # Step 6: show existing policies
-    _display_existing_policies(chosen_relatum)
+        # Step 6: show existing policies
+        _display_existing_policies(chosen_relatum)
 
-    # Step 7: collect new policy
-    policy = _collect_policy()
+        # Step 7: collect new policy
+        policy = _collect_policy()
 
-    # Step 8: confirm
-    _print_policy_summary(policy)
-    confirm = input("Save? [y/N]: ").strip().lower()
-    if confirm != "y":
-        print("  Aborted. No changes saved.")
-        return
-
-    # Step 9: mutate in memory and persist
-    chosen_relatum.policies.append(policy)
-    repo.save_primitive(source)
-    print(
-        f"\n  Saved policy '{policy.name}' on "
-        f"{source.name} --[APPLIES_TO @ {_depth_label(chosen_depth_level)}]--> {target.name}\n"
-    )
+        # Step 8: confirm
+        _print_policy_summary(policy)
+        confirm = input("Save? [y/N]: ").strip().lower()
+        if confirm != "y":
+            print("  Aborted. No changes saved.")
+        else:
+            # Step 9: mutate in memory and persist
+            chosen_relatum.policies.append(policy)
+            repo.save_primitive(source)
+            print(
+                f"\n  Saved policy '{policy.name}' on "
+                f"{source.name} --[APPLIES_TO @ {format_depth_label(chosen_depth_level)}]--> {target.name}\n"
+            )
 
 
 def main() -> None:

--- a/src/vre/identity/registry.py
+++ b/src/vre/identity/registry.py
@@ -44,26 +44,24 @@ class AgentRegistry:
         """
         Load registry from disk. Returns empty dict if file doesn't exist.
         """
-        if not self._path.exists():
-            return {}
-
-        try:
-            raw = self._path.read_text(encoding="utf-8")
-            if not raw.strip():
-                return {}
-            data = json.loads(raw)
-            if not isinstance(data, dict):
-                raise RegistryError(
-                    f"Corrupt registry at {self._path}: expected JSON object at top level"
-                )
-            registry = {
-                key: AgentIdentity.model_validate(value) for key, value in data.items()
-            }
-            return registry
-        except (json.JSONDecodeError, ValueError) as exc:
-            raise RegistryError(f"Corrupt registry at {self._path}: {exc}") from exc
-        except OSError as exc:
-            raise RegistryError(f"Cannot read registry at {self._path}: {exc}") from exc
+        registry: dict[str, AgentIdentity] = {}
+        if self._path.exists():
+            try:
+                raw = self._path.read_text(encoding="utf-8")
+                if raw.strip():
+                    data = json.loads(raw)
+                    if not isinstance(data, dict):
+                        raise RegistryError(
+                            f"Corrupt registry at {self._path}: expected JSON object at top level"
+                        )
+                    registry = {
+                        key: AgentIdentity.model_validate(value) for key, value in data.items()
+                    }
+            except (json.JSONDecodeError, ValueError) as exc:
+                raise RegistryError(f"Corrupt registry at {self._path}: {exc}") from exc
+            except OSError as exc:
+                raise RegistryError(f"Cannot read registry at {self._path}: {exc}") from exc
+        return registry
 
     def _save(self, registry: dict[str, AgentIdentity]) -> None:
         """

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -39,7 +39,7 @@ from vre.learning.models import (
     ReachabilityCandidate,
     RelationalCandidate,
 )
-from vre.learning.templates import TemplateFactory
+from vre.learning.templates import template_for_gap
 
 
 def _make_provenance(decision: CandidateDecision) -> Provenance:
@@ -71,10 +71,9 @@ def _resolve_name_to_id(name: str, grounding: GroundingResult) -> UUID:
     """
     Resolve a primitive name to its UUID from the grounding trace.
     """
-    if grounding.trace:
-        for p in grounding.trace.result.primitives:
-            if p.name.lower() == name.lower():
-                return p.id
+    for p in grounding.get_primitives():
+        if p.name.lower() == name.lower():
+            return p.id
     raise CandidateValidationError(f"Cannot resolve '{name}' to a primitive ID from the grounding trace")
 
 
@@ -228,7 +227,7 @@ class LearningEngine:
                 required_depth=required_level,
                 current_depth=current_depth,
             )
-            template = TemplateFactory.from_gap(gap)
+            template = template_for_gap(gap)
             filled, decision = callback(template, grounding, gap)
 
             if decision in (CandidateDecision.SKIPPED, CandidateDecision.REJECTED):
@@ -369,7 +368,7 @@ class LearningEngine:
 
         gap = grounding.gaps[gap_index]
         logger.info("Learning at gap_index=%d, gap_kind=%s", gap_index, gap.kind)
-        candidate = TemplateFactory.from_gap(gap)
+        candidate = template_for_gap(gap)
         filled, decision = callback(candidate, grounding, gap)
 
         result: LearningResult

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -254,7 +254,8 @@ class LearningEngine:
         1. Learn any missing depths on source and target via the callback
         2. Place the edge once both sides have the required depths
 
-        If depth learning is rejected or skipped, edge placement is abandoned.
+        If depth learning is rejected or skipped, edge placement is abandoned
+        and the decision propagates back as the outcome.
         """
         if candidate.target_name is None or candidate.relation_type is None:
             logger.warning(
@@ -281,54 +282,54 @@ class LearningEngine:
         if target is None:
             raise CandidateValidationError(f"Target '{candidate.target_name}' ({target_id}) not found")
 
-        # Phase 1: learn missing depths on source, then target
+        # Phase 1: learn missing depths on source, then target. Either rejection
+        # or skip overrides the outcome and short-circuits phase 2.
         logger.debug(
             "Reachability two-phase: learning missing depths on source=%r, target=%r",
             source.name, target.name,
         )
-        result = self._learn_missing_depths(source, candidate.source_depth_level, grounding, callback)
-        if result in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
-            return result
-        if result is not None:
-            source = self._repo.find_by_id(source.id)
+        outcome: CandidateDecision = CandidateDecision.ACCEPTED
+        src_decision = self._learn_missing_depths(source, candidate.source_depth_level, grounding, callback)
+        if src_decision in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+            outcome = src_decision
+        else:
+            if src_decision is not None:
+                source = self._repo.find_by_id(source.id)
+            tgt_decision = self._learn_missing_depths(target, candidate.target_depth_level, grounding, callback)
+            if tgt_decision in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+                outcome = tgt_decision
 
-        result = self._learn_missing_depths(target, candidate.target_depth_level, grounding, callback)
-        if result in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
-            return result
-
-        # Phase 2: place the edge
-        logger.debug(
-            "Reachability two-phase: placing %s edge from %r (D%d) to %r (D%d)",
-            candidate.relation_type.value, source.name, int(candidate.source_depth_level),
-            candidate.target_name, int(candidate.target_depth_level),
-        )
-        depth_obj = next(d for d in source.depths if d.level == candidate.source_depth_level)
-
-        new_relatum = Relatum(
-            relation_type=candidate.relation_type,
-            target_id=target_id,
-            target_depth=candidate.target_depth_level,
-            provenance=provenance,
-        )
-        depth_obj.relata.append(new_relatum)
-
-        source.depths.sort(key=lambda d: int(d.level))
-
-        try:
-            self._repo.save_primitive(source)
-        except CyclicRelationshipError:
-            logger.exception(
-                "Cyclic relationship error placing %s edge from %r (%s) to %r (%s)",
-                candidate.relation_type.value,
-                source.name,
-                source.id,
-                target.name,
-                target.id,
+        if outcome == CandidateDecision.ACCEPTED:
+            # Phase 2: place the edge
+            logger.debug(
+                "Reachability two-phase: placing %s edge from %r (D%d) to %r (D%d)",
+                candidate.relation_type.value, source.name, int(candidate.source_depth_level),
+                candidate.target_name, int(candidate.target_depth_level),
             )
-            depth_obj.relata.remove(new_relatum)
-            raise
+            depth_obj = next(d for d in source.depths if d.level == candidate.source_depth_level)
+            new_relatum = Relatum(
+                relation_type=candidate.relation_type,
+                target_id=target_id,
+                target_depth=candidate.target_depth_level,
+                provenance=provenance,
+            )
+            depth_obj.relata.append(new_relatum)
+            source.depths.sort(key=lambda d: int(d.level))
+            try:
+                self._repo.save_primitive(source)
+            except CyclicRelationshipError:
+                logger.exception(
+                    "Cyclic relationship error placing %s edge from %r (%s) to %r (%s)",
+                    candidate.relation_type.value,
+                    source.name,
+                    source.id,
+                    target.name,
+                    target.id,
+                )
+                depth_obj.relata.remove(new_relatum)
+                raise
 
-        return CandidateDecision.ACCEPTED
+        return outcome
 
     def _persist(
         self,
@@ -342,15 +343,17 @@ class LearningEngine:
         Validate and persist a filled candidate to the graph.
         Returns a decision override for reachability (two-phase), or None.
         """
-        if isinstance(gap, ExistenceGap) and isinstance(candidate, ExistenceCandidate):
-            self._persist_existence(gap, candidate, provenance)
-        elif isinstance(gap, DepthGap) and isinstance(candidate, DepthCandidate):
-            self._persist_depth(gap, candidate, provenance)
-        elif isinstance(gap, RelationalGap) and isinstance(candidate, RelationalCandidate):
-            self._persist_relational(gap, candidate, provenance)
-        elif isinstance(gap, ReachabilityGap) and isinstance(candidate, ReachabilityCandidate):
-            return self._persist_reachability(gap, candidate, grounding, callback, provenance)
-        return None
+        override: CandidateDecision | None = None
+        match (gap, candidate):
+            case (ExistenceGap(), ExistenceCandidate()):
+                self._persist_existence(gap, candidate, provenance)
+            case (DepthGap(), DepthCandidate()):
+                self._persist_depth(gap, candidate, provenance)
+            case (RelationalGap(), RelationalCandidate()):
+                self._persist_relational(gap, candidate, provenance)
+            case (ReachabilityGap(), ReachabilityCandidate()):
+                override = self._persist_reachability(gap, candidate, grounding, callback, provenance)
+        return override
 
     def learn_at(
         self,

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -12,9 +12,9 @@ import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
+from vre.core.errors import CandidateValidationError, CyclicRelationshipError
 from vre.core.graph import PrimitiveRepository
 from vre.core.grounding.models import GroundingResult
-from vre.core.errors import CandidateValidationError, CyclicRelationshipError
 from vre.core.models import (
     Depth,
     DepthGap,
@@ -213,33 +213,34 @@ class LearningEngine:
         decision if learning was needed, or None if the depth already exists.
         """
         existing_levels = {d.level for d in primitive.depths}
+        result: CandidateDecision | None = None
         if required_level in existing_levels:
             logger.debug("Depth D%d already present on %r, skipping sub-learning", int(required_level), primitive.name)
-            return None
+        else:
+            current_depth = max(existing_levels, key=lambda lv: lv.value) if existing_levels else None
+            logger.debug(
+                "Synthesized DepthGap for %r: requires D%d, current=%s",
+                primitive.name, int(required_level),
+                ("D" + str(int(current_depth))) if current_depth is not None else "None",
+            )
+            gap = DepthGap(
+                primitive=primitive,
+                required_depth=required_level,
+                current_depth=current_depth,
+            )
+            template = TemplateFactory.from_gap(gap)
+            filled, decision = callback(template, grounding, gap)
 
-        current_depth = max(existing_levels, key=lambda lv: lv.value) if existing_levels else None
-        logger.debug(
-            "Synthesized DepthGap for %r: requires D%d, current=%s",
-            primitive.name, int(required_level),
-            ("D" + str(int(current_depth))) if current_depth is not None else "None",
-        )
-        gap = DepthGap(
-            primitive=primitive,
-            required_depth=required_level,
-            current_depth=current_depth,
-        )
-        template = TemplateFactory.from_gap(gap)
-        filled, decision = callback(template, grounding, gap)
-
-        if decision in (CandidateDecision.SKIPPED, CandidateDecision.REJECTED):
-            return decision
-        if filled is None:
-            logger.warning("Callback returned None for synthesized depth gap on %r, treating as REJECTED", primitive.name)
-            return CandidateDecision.REJECTED
-
-        provenance = _make_provenance(decision)
-        self._persist_depth(gap, filled, provenance)
-        return decision
+            if decision in (CandidateDecision.SKIPPED, CandidateDecision.REJECTED):
+                result = decision
+            elif filled is None:
+                logger.warning("Callback returned None for synthesized depth gap on %r, treating as REJECTED", primitive.name)
+                result = CandidateDecision.REJECTED
+            else:
+                provenance = _make_provenance(decision)
+                self._persist_depth(gap, filled, provenance)
+                result = decision
+        return result
 
     def _persist_reachability(
         self,
@@ -371,34 +372,34 @@ class LearningEngine:
         candidate = TemplateFactory.from_gap(gap)
         filled, decision = callback(candidate, grounding, gap)
 
+        result: LearningResult
         if decision == CandidateDecision.SKIPPED:
             logger.info("Gap %d skipped by callback", gap_index)
-            return LearningResult(decision=CandidateDecision.SKIPPED, candidate=candidate)
-
-        if decision == CandidateDecision.REJECTED:
+            result = LearningResult(decision=CandidateDecision.SKIPPED, candidate=candidate)
+        elif decision == CandidateDecision.REJECTED:
             logger.info("Gap %d rejected by callback", gap_index)
-            return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
-
-        if filled is None:
+            result = LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
+        elif filled is None:
             logger.warning(
                 "Callback for gap %d returned no candidate (decision=%s); treating as REJECTED",
                 gap_index,
                 decision.value,
             )
-            return LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
+            result = LearningResult(decision=CandidateDecision.REJECTED, candidate=candidate)
+        else:
+            logger.debug(
+                "Persisting %s candidate for gap %d (decision=%s)",
+                type(filled).__name__, gap_index, decision.value,
+            )
+            provenance = _make_provenance(decision)
+            override = self._persist(gap, filled, grounding, callback, provenance)
 
-        logger.debug(
-            "Persisting %s candidate for gap %d (decision=%s)",
-            type(filled).__name__, gap_index, decision.value,
-        )
-        provenance = _make_provenance(decision)
-        override = self._persist(gap, filled, grounding, callback, provenance)
-
-        # Reachability two-phase can override the decision if depth
-        # learning was rejected or skipped
-        if override in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
-            logger.info("Reachability two-phase override: %s", override.value)
-            return LearningResult(decision=override, candidate=filled)
-
-        return LearningResult(decision=decision, candidate=filled)
+            # Reachability two-phase can override the decision if depth
+            # learning was rejected or skipped
+            if override in (CandidateDecision.REJECTED, CandidateDecision.SKIPPED):
+                logger.info("Reachability two-phase override: %s", override.value)
+                result = LearningResult(decision=override, candidate=filled)
+            else:
+                result = LearningResult(decision=decision, candidate=filled)
+        return result
 

--- a/src/vre/learning/templates.py
+++ b/src/vre/learning/templates.py
@@ -2,11 +2,13 @@
 # Licensed under the Apache License, Version 2.0
 
 """
-TemplateFactory — converts knowledge gaps into structured candidate templates.
+template_for_gap — converts knowledge gaps into structured candidate templates.
 
 VRE presents the shape of what is needed; the agent fills in the content.
 Context (primitive IDs, existing depths) lives on the gap; the candidate
-carries only the new knowledge to be proposed.
+carries only the new knowledge to be proposed. ExistenceGap pre-fills the
+concept name; all other candidates start empty since context lives on the
+gap itself.
 """
 
 from vre.core.models import (
@@ -25,25 +27,20 @@ from vre.learning.models import (
 )
 
 
-class TemplateFactory:
+def template_for_gap(gap: KnowledgeGap) -> LearningCandidate:
     """
-    Converts typed knowledge gaps into candidate templates.
-
-    ExistenceGap pre-fills the concept name; all other candidates start
-    empty since context lives on the gap itself.
+    Build the candidate template that matches the given gap kind.
     """
-
-    @staticmethod
-    def from_gap(gap: KnowledgeGap) -> LearningCandidate:
-        candidate: LearningCandidate
-        if isinstance(gap, ExistenceGap):
+    candidate: LearningCandidate
+    match gap:
+        case ExistenceGap():
             candidate = ExistenceCandidate(name=gap.primitive.name)
-        elif isinstance(gap, DepthGap):
+        case DepthGap():
             candidate = DepthCandidate()
-        elif isinstance(gap, RelationalGap):
+        case RelationalGap():
             candidate = RelationalCandidate()
-        elif isinstance(gap, ReachabilityGap):
+        case ReachabilityGap():
             candidate = ReachabilityCandidate()
-        else:
+        case _:
             raise ValueError(f"Unknown gap type: {type(gap)}")
-        return candidate
+    return candidate

--- a/src/vre/learning/templates.py
+++ b/src/vre/learning/templates.py
@@ -35,12 +35,15 @@ class TemplateFactory:
 
     @staticmethod
     def from_gap(gap: KnowledgeGap) -> LearningCandidate:
+        candidate: LearningCandidate
         if isinstance(gap, ExistenceGap):
-            return ExistenceCandidate(name=gap.primitive.name)
-        if isinstance(gap, DepthGap):
-            return DepthCandidate()
-        if isinstance(gap, RelationalGap):
-            return RelationalCandidate()
-        if isinstance(gap, ReachabilityGap):
-            return ReachabilityCandidate()
-        raise ValueError(f"Unknown gap type: {type(gap)}")
+            candidate = ExistenceCandidate(name=gap.primitive.name)
+        elif isinstance(gap, DepthGap):
+            candidate = DepthCandidate()
+        elif isinstance(gap, RelationalGap):
+            candidate = RelationalCandidate()
+        elif isinstance(gap, ReachabilityGap):
+            candidate = ReachabilityCandidate()
+        else:
+            raise ValueError(f"Unknown gap type: {type(gap)}")
+        return candidate

--- a/src/vre/metrics.py
+++ b/src/vre/metrics.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+MetricsManager — coordinates per-primitive metric updates after grounding
+and learning operations. Updates are best-effort; failures are logged and
+never raise to the caller.
+"""
+
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from vre.core.graph import PrimitiveRepository
+from vre.core.grounding.models import GroundingResult
+from vre.core.models import (
+    DepthGap,
+    ExistenceGap,
+    KnowledgeGap,
+    PrimitiveMetrics,
+    ReachabilityGap,
+    RelationalGap,
+    gap_primitive_ids,
+)
+from vre.learning.models import CandidateDecision
+
+
+logger = logging.getLogger(__name__)
+
+
+class MetricsManager:
+    """
+    Internal coordinator for primitive-level grounding and learning metrics.
+    """
+
+    def __init__(self, repository: PrimitiveRepository) -> None:
+        self._repo = repository
+
+    def update_grounding(self, result: GroundingResult) -> None:
+        """
+        Update per-primitive grounding metrics after a `check` call.
+
+        Batch-reads current metrics for all resolved root concepts, computes
+        increments in-process, and batch-writes the results.
+        """
+        resolved_lower = {r.lower() for r in result.resolved}
+        target_prims = [
+            prim for prim in result.get_primitives()
+            if prim.name.lower() in resolved_lower
+        ]
+
+        current_metrics: dict[UUID, PrimitiveMetrics | None] | None = None
+        if target_prims:
+            try:
+                current_metrics = self._repo.batch_read_metrics([p.id for p in target_prims])
+            except Exception:
+                logger.warning("Failed to batch-read metrics", exc_info=True)
+
+        updates: dict[UUID, PrimitiveMetrics] = {}
+        if current_metrics is not None:
+            now = datetime.now(timezone.utc)
+            gap_ids = gap_primitive_ids(result.gaps)
+            for prim in target_prims:
+                if prim.id not in current_metrics:
+                    continue
+                metrics = current_metrics[prim.id] or PrimitiveMetrics()
+                if prim.id in gap_ids:
+                    metrics.failure_count += 1
+                    metrics.last_failed = now
+                else:
+                    metrics.grounding_count += 1
+                    metrics.last_grounded = now
+                updates[prim.id] = metrics
+
+        if updates:
+            try:
+                self._repo.batch_update_metrics(updates)
+            except Exception:
+                logger.warning("Failed to batch-update metrics for %d primitives", len(updates), exc_info=True)
+
+    def update_learning(
+        self,
+        gap: KnowledgeGap,
+        decision: CandidateDecision,
+    ) -> None:
+        """
+        Update learning metrics on the primitive targeted by a gap.
+
+        Increments `learning_count` for accepted/modified decisions and
+        `rejection_count` for rejected decisions. SKIPPED decisions are
+        ignored. Looks up the primitive by ID first, falling back to name
+        for ExistenceGaps where the gap carries a transient ID.
+        """
+        prim_id: UUID | None = None
+        prim_name: str | None = None
+        if decision != CandidateDecision.SKIPPED:
+            match gap:
+                case RelationalGap():
+                    prim_id, prim_name = gap.target.id, gap.target.name
+                case DepthGap() | ExistenceGap() | ReachabilityGap():
+                    prim_id, prim_name = gap.primitive.id, gap.primitive.name
+
+        found = None
+        if prim_id is not None:
+            found = self._repo.find_by_id(prim_id)
+            if found is None and prim_name is not None:
+                found = self._repo.find_by_name(prim_name)
+
+        if found is not None:
+            metrics = found.metrics or PrimitiveMetrics()
+            if decision in (CandidateDecision.ACCEPTED, CandidateDecision.MODIFIED):
+                metrics.learning_count += 1
+            elif decision == CandidateDecision.REJECTED:
+                metrics.rejection_count += 1
+            try:
+                self._repo.update_metrics(found.id, metrics)
+            except Exception:
+                logger.warning("Failed to update learning metrics for %r", prim_name, exc_info=True)

--- a/src/vre/tracing.py
+++ b/src/vre/tracing.py
@@ -46,9 +46,7 @@ def build_trace_entry(
     """
     gaps = [gap.model_dump(mode="json") for gap in result.gaps]
 
-    steps: list[dict[str, Any]] = []
-    if result.trace is not None:
-        steps = [step.model_dump(mode="json") for step in result.trace.result.pathway]
+    steps = [step.model_dump(mode="json") for step in result.get_pathway_steps()]
 
     serialized_outcomes: list[dict[str, Any]] | None = None
     if learning_outcomes is not None:

--- a/src/vre/tracing.py
+++ b/src/vre/tracing.py
@@ -8,7 +8,10 @@ Enabled by default on every VRE instance. Traces are written to
 ``~/.vre/traces/YYYY-MM-DD.jsonl``. Disable with ``persist_traces=False``.
 """
 
+import logging
 import os
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Literal
@@ -17,6 +20,9 @@ from pydantic import BaseModel, Field
 
 from vre.core.grounding.models import GroundingResult
 from vre.learning.models import LearningResult
+
+
+logger = logging.getLogger(__name__)
 
 
 class TraceEntry(BaseModel):
@@ -89,3 +95,65 @@ class TraceWriter:
             f.write(line)
             f.flush()
             os.fsync(f.fileno())
+
+
+class TraceManager:
+    """
+    Internal coordinator owning the TraceWriter and the in-flight suppression
+    state used by `learn_all` to skip per-iteration `check()` traces in favor
+    of a single summary trace at the end of the loop.
+
+    All write paths are best-effort: persistence failures are logged and never
+    raise to the caller.
+    """
+
+    def __init__(self, writer: TraceWriter | None) -> None:
+        self._writer = writer
+        self._suppressed = False
+
+    @contextmanager
+    def suppress(self) -> Iterator[None]:
+        """
+        Suppress writes via `write_check` for the duration of the block.
+
+        Re-entrant: nested suppress() blocks restore the prior state on exit.
+        """
+        was, self._suppressed = self._suppressed, True
+        try:
+            yield
+        finally:
+            self._suppressed = was
+
+    def _safe_write(self, entry: TraceEntry, *, label: str) -> None:
+        """
+        Persist a trace entry, swallowing and logging any writer failures.
+        """
+        try:
+            self._writer.write(entry)  # type: ignore[union-attr]
+        except Exception:
+            logger.warning("Failed to persist trace for %s()", label, exc_info=True)
+
+    def write_check(self, concepts: list[str], result: GroundingResult) -> None:
+        """
+        Persist a 'check' trace entry. No-op when no writer is configured or
+        when called inside a `suppress()` block.
+        """
+        if self._writer is not None and not self._suppressed:
+            self._safe_write(build_trace_entry("check", concepts, result), label="check")
+
+    def write_learn(
+        self,
+        concepts: list[str],
+        result: GroundingResult,
+        outcomes: list[LearningResult],
+    ) -> None:
+        """
+        Persist a 'learn' trace entry summarizing a learning loop. No-op when
+        no writer is configured. Not affected by `suppress()` — learning
+        summaries are the reason `learn_all` suppresses its inner check writes.
+        """
+        if self._writer is not None:
+            self._safe_write(
+                build_trace_entry("learn", concepts, result, outcomes),
+                label="learn_all",
+            )

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -40,7 +40,7 @@ from vre.learning.models import (
     ReachabilityCandidate,
     RelationalCandidate,
 )
-from vre.learning.templates import TemplateFactory
+from vre.learning.templates import template_for_gap
 
 
 # ---------------------------------------------------------------------------
@@ -144,10 +144,10 @@ class StubRepository:
 # Template tests
 # ---------------------------------------------------------------------------
 
-class TestTemplateFactory:
+class TestTemplateForGap:
     def test_existence_has_name(self):
         gap = ExistenceGap(primitive=_primitive("Copy"))
-        template = TemplateFactory.from_gap(gap)
+        template = template_for_gap(gap)
         assert isinstance(template, ExistenceCandidate)
         assert template.name == "Copy"
         assert template.d1 is None
@@ -156,7 +156,7 @@ class TestTemplateFactory:
     def test_depth_is_empty(self):
         prim = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
         gap = DepthGap(primitive=prim, required_depth=DepthLevel.CAPABILITIES, current_depth=DepthLevel.EXISTENCE)
-        template = TemplateFactory.from_gap(gap)
+        template = template_for_gap(gap)
         assert isinstance(template, DepthCandidate)
         assert template.new_depths == []
         assert template.kind == "DEPTH"
@@ -168,7 +168,7 @@ class TestTemplateFactory:
             required_depth=DepthLevel.CAPABILITIES,
             current_depth=None,
         )
-        template = TemplateFactory.from_gap(gap)
+        template = template_for_gap(gap)
         assert isinstance(template, RelationalCandidate)
         assert template.new_depths == []
         assert template.kind == "RELATIONAL"
@@ -176,7 +176,7 @@ class TestTemplateFactory:
     def test_reachability_is_empty(self):
         prim = _primitive("Delete", depths=[_depth(DepthLevel.EXISTENCE)])
         gap = ReachabilityGap(primitive=prim)
-        template = TemplateFactory.from_gap(gap)
+        template = template_for_gap(gap)
         assert isinstance(template, ReachabilityCandidate)
         assert template.target_name is None
         assert template.relation_type is None
@@ -630,13 +630,13 @@ class TestLearningCallbackLifecycle:
 # Template edge cases
 # ---------------------------------------------------------------------------
 
-class TestTemplateFactoryEdgeCases:
+class TestTemplateForGapEdgeCases:
     def test_unknown_gap_type_raises(self):
         class UnknownGap:
             pass
 
         with pytest.raises(ValueError, match="Unknown gap type"):
-            TemplateFactory.from_gap(UnknownGap())
+            template_for_gap(UnknownGap())
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Multi-slice refactor pass driven by a parallel-agent codebase audit (duplication, multi-return style, bloat, consistency, coupling, perf). Public API is **net-additive only** — the single addition is `GroundingResult.get_primitives()` / `.get_pathway_steps()`, hence the **0.5.0 minor bump**. All other changes are internal refactors with preserved behavior; all 256 tests pass without modification.

- **Slice 1 (`6bbe259`)** — 23 functions converted to single-return; extracted `format_depth_label` and `_dump_model_json` helpers; `Any`-typed formatters tightened; bare `tuple` annotation fixed; trimmed two oversized parameter docstrings.
- **Slice 2 (`fa3a813`)** — Added `GroundingResult.get_primitives()` / `.get_pathway_steps()` and migrated 7 callers off `.trace.result.*` drill-down. Memoized `_contiguous_max_depth` via `@functools.cache` keyed on a `frozenset[DepthLevel]` shape. Dropped defensive `.copy()` in `build_name_map`; switched `_filter_depths` to `model_copy(deep=True)`. `TemplateFactory` class → module-level `template_for_gap` rewritten with `match/case`.
- **Slice 3 (`301a866`)** — The two "hard" multi-returns in `learning/engine.py` (`_persist`, `_persist_reachability`) collapsed via `match/case` and a single outcome variable. Codebase now has **zero multi-return functions** per AST audit.
- **Slice 4 (`8caf8bf`)** — VRE god-class split into focused coordinators. New `vre/metrics.py` (`MetricsManager`) and `TraceManager` in `vre/tracing.py` encapsulate the metrics-update and trace-suppression bookkeeping that was inlined in VRE. `gap_primitive_ids` moved to `core/models.py` as a free function next to the gap types. VRE class body shrunk **~290 → ~175 LOC**; `learn_all` now reads as orchestration via `with self._traces.suppress(), callback:`.
- **Release + docs sync (`185af17`, `505cc8f`)** — Bumped to 0.5.0; updated README project tree to reflect new modules and renamed helper; aligned README + docs/index.html roadmap (renamed deferred "VRE Networks" → "Knowledge Import" matching the imports-over-hydration resume path documented in project memory; dropped redundant EPISTEMIC SCORE entry from docs).

**Deferred** (tracked in issue #58): the `PolicyCallContext` redesign — both the leaky `grounding: GroundingResult` field and the missing edge-identity in policy callbacks. Surfaced during this pass; deserves its own design pass.

## Test plan

- [x] Full pytest suite — 256/256 passing without modification (only test change: `TemplateFactory` → `template_for_gap` import + class rename, per "import changes due to refactor")
- [x] Coverage held / improved — 75.56% → 76.80%
- [x] AST audit — zero multi-return functions across `src/vre/`
- [x] Ruff clean across `src/`, `tests/`, `examples/`
- [ ] Reviewer spot-check: `GroundingResult.get_primitives()` migration sites in `vre/__init__.py:_update_grounding_metrics`, `vre/learning/engine.py:_resolve_name_to_id`, `vre/tracing.py:build_trace_entry`, plus the two example callers
- [ ] Reviewer spot-check: `TraceManager.suppress()` re-entrant context manager swap-in for the old `_suppress_trace` mutex in `learn_all`
- [ ] Reviewer spot-check: `_filter_depths` now uses `model_copy(deep=True)` instead of full reconstruction (deliberate trade-off — discussed in the session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)