### PR TITLE
Add seeders package with idempotent upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,17 +207,20 @@ If you already have neo4j installed locally, ensure it is running and note the c
 
 ### Seeding the Graph
 
-The VRE repository includes seed scripts that populate the graph with testing scenarios. Each script clears the graph before seeding
-to ensure a clean slate. See [`scripts/README.md`](scripts/README.md) for full
-details.
+The VRE repository ships with domain seeders in [`seeders/`](seeders/) and a
+gap-demonstration script in [`scripts/`](scripts/). Seeders upsert primitives
+by name (idempotent re-runs); the demo script clears the graph first to
+produce its deterministic output. Use `scripts/clear_graph.py` if you want
+a clean slate before seeding. See [`scripts/README.md`](scripts/README.md)
+for details.
 
 ```bash
-# Fully grounded graph — 16 primitives, all at D3 with complete relata
-poetry run python scripts/seed_all.py \
+# Fully grounded filesystem domain — 20 primitives, all at D3+ with complete relata
+python seeders/seed_filesystem.py \
 --neo4j-uri neo4j://localhost:7687 --neo4j-user neo4j --neo4j-password password
 
 # Gap demonstration graph — 10 primitives, deliberately shaped to produce each gap type
-poetry run python scripts/seed_gaps.py \
+python scripts/seed_gaps.py \
 --neo4j-uri neo4j://localhost:7687 --neo4j-user neo4j --neo4j-password password
 ```
 
@@ -878,8 +881,10 @@ src/vre/
 
 scripts/
 ├── clear_graph.py               # Clear all primitives from the Neo4j graph
-├── seed_all.py                  # Seed fully grounded graph (16 primitives)
 └── seed_gaps.py                 # Seed gap-demonstration graph (10 primitives)
+
+seeders/
+└── seed_filesystem.py           # Filesystem domain — 20 primitives, idempotent upsert
 
 examples/
 ├── claude-code/

--- a/examples/langchain_ollama/policies.py
+++ b/examples/langchain_ollama/policies.py
@@ -1,10 +1,12 @@
 """
 Demo PolicyCallback — blocks deletion of files matching `protected*`.
 
-Registered on the Delete → File APPLIES_TO relatum via seed_all.py.
-Demonstrates a callback that inspects the shell command to make a
-domain-specific policy decision, including filesystem inspection when
-a wildcard or directory deletion could affect protected files.
+Intended to be attached to the Delete → File APPLIES_TO relatum by the
+integrator (via the policy wizard or a direct attachment), not by the
+domain seeder. Demonstrates a callback that inspects the shell command
+to make a domain-specific policy decision, including filesystem
+inspection when a wildcard or directory deletion could affect protected
+files.
 """
 
 from __future__ import annotations

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,32 +4,17 @@ Utility scripts for managing the VRE Neo4j graph. All scripts accept
 `--neo4j-uri`, `--neo4j-user`, and `--neo4j-password` arguments
 (defaults: `neo4j://localhost:7687`, `neo4j`, `password`).
 
+Domain seed scripts live in [`../seeders/`](../seeders/). The scripts here
+are graph maintenance and demo utilities.
+
 ## clear_graph.py
 
 Deletes every `Primitive` node and its relationships from the graph.
-Called automatically by both seed scripts to ensure a clean slate, but
-can also be run standalone.
+Used by `seed_gaps.py` to produce its deterministic demo output; can be
+run standalone before a seeder if you want a clean slate.
 
 ```bash
-poetry run python scripts/clear_graph.py
-```
-
-## seed_all.py
-
-Seeds the fully grounded epistemic graph — 20 primitives covering the
-filesystem domain end-to-end. Every primitive is grounded to at least D3
-(CONSTRAINTS) with complete structural relata (DEPENDS_ON, REQUIRES,
-INCLUDES, APPLIES_TO, CONSTRAINED_BY). Two primitives (`delete`,
-`execute`) extend to D4 (IMPLICATIONS) to demonstrate consequential
-relationships and the full depth model.
-
-Primitives: `operating_system`, `filesystem`, `path`, `permission`,
-`ownership`, `directory`, `file`, `symlink`, `user`, `group`,
-`process`, `create`, `read`, `write`, `modify`, `delete`, `list`,
-`move`, `copy`, `execute`
-
-```bash
-poetry run python scripts/seed_all.py
+python scripts/clear_graph.py
 ```
 
 ## seed_gaps.py
@@ -37,10 +22,11 @@ poetry run python scripts/seed_all.py
 Seeds a deliberately shaped graph (10 primitives) designed to
 demonstrate depth-gated traversal and the full gap taxonomy. Each
 action primitive is truncated or structured to produce a specific gap
-type when queried.
+type when queried. Clears the graph before seeding to guarantee the
+expected gap output.
 
 ```bash
-poetry run python scripts/seed_gaps.py
+python scripts/seed_gaps.py
 ```
 
 ### Primitives
@@ -64,7 +50,7 @@ poetry run python scripts/seed_gaps.py
 |---|---|---|
 | `["list", "directory"]` | None | list@D2 sees APPLIES_TO@D2; directory@D3 >= target D2 |
 | `["read", "file"]` | RelationalGap(read→file, req=D2, cur=D1) | read@D2 sees APPLIES_TO@D2, but file@D1 < target D2 |
-| `["delete", "file"]` | ReachabilityGap(file) | APPLIES_TO lives at D3 in seed_all; D3 omitted here, no edges exist |
+| `["delete", "file"]` | ReachabilityGap(file) | APPLIES_TO lives at D3 in the filesystem seeder; D3 omitted here, no edges exist |
 | `["delete", "directory"]` | ReachabilityGap(directory) | Same — no visible connection between delete and directory |
 | `["create", "file"]` | DepthGap(create, req=D3, cur=D1) + ReachabilityGap(file) | create contiguous max=D1; APPLIES_TO@D3 gated, nodes disconnected |
 | `["create", "directory"]` | DepthGap(create, req=D3, cur=D1) + ReachabilityGap(directory) | Same mechanism — edge gated, target unreachable |

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -3,7 +3,7 @@ Clear all primitives and relationships from the VRE Neo4j graph.
 
 Can be run standalone or imported by seed scripts to ensure a clean slate.
 
-Run: poetry run python scripts/clear_graph.py
+Run: python scripts/clear_graph.py
 """
 import argparse
 from typing import LiteralString, cast

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -7,7 +7,7 @@ when queried by the grounding engine.
 
 See scripts/README.md for the full primitive table and expected gap scenarios.
 
-Run: poetry run python scripts/seed_gaps.py
+Run: python scripts/seed_gaps.py
 """
 import argparse
 
@@ -525,7 +525,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     """
     Seed the Delete primitive at D0–D2 only.
 
-    Destructive action. In the fully grounded graph (seed_all), delete's
+    Destructive action. In the fully grounded filesystem seeder, delete's
     APPLIES_TO edges live at D3 (CONSTRAINTS). Here D3 is omitted, so
     those edges simply don't exist — delete has no visible connection to
     its targets → ReachabilityGap on file or directory.
@@ -554,7 +554,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                     "inputs": ["target_entity"],
                     "outputs": ["confirmation_of_removal"],
                 },
-                # No relata — APPLIES_TO lives at D3 in seed_all, omitted here.
+                # No relata — APPLIES_TO lives at D3 in seed_filesystem, omitted here.
             ),
         ],
     )

--- a/seeders/CONTRIBUTING.md
+++ b/seeders/CONTRIBUTING.md
@@ -1,0 +1,274 @@
+# Authoring a Seeder
+
+This package is where contributors author **domain seed scripts** — modules
+that upsert a connected set of primitives into a VRE Neo4j graph. Each module
+is a self-contained domain (filesystem, HTTP, billing, etc.) that an
+integrator can install standalone or alongside others.
+
+Read this before adding a new seeder. The canonical reference implementation
+is [`seed_filesystem.py`](./seed_filesystem.py) — copy its shape.
+
+## Mental model: graph as policy
+
+VRE doesn't enforce behavior with imperative rules — it enforces it with the
+**shape of the graph**. Two axes do the policing:
+
+1. **Depth coverage.** A primitive grounded only to D1 (IDENTITY) cannot
+   answer questions that require D2 (CAPABILITIES) or deeper. Depth-gated
+   traversal refuses to consult depths that haven't been authored. When a
+   contributor stops at D1, the contributor has declared "this is all we
+   know" — the engine respects that and surfaces a `DepthGap`.
+
+2. **Relation placement.** Every relatum carries a `source_depth` (the depth
+   on the source primitive where the edge lives) and a `target_depth` (the
+   minimum depth the target must reach for the edge to be satisfied).
+   - The edge is **invisible** until the source is grounded to `source_depth`.
+   - The edge is **unsatisfied** if the target hasn't reached `target_depth`,
+     producing a `RelationalGap`.
+
+   Placing `Delete → File [APPLIES_TO]` at the source's D3 (CONSTRAINTS)
+   instead of D2 (CAPABILITIES) means: "to know what delete acts on, you
+   must first understand its constraints." That's policy, expressed as
+   topology.
+
+Seeders ship **epistemic facts**: what the domain knows, structured into
+depths and connected via typed relations. Seeders do **not** ship
+operational policy (`Policy(...)` objects belong to the integrator that
+runs the application). The graph is the user's epistemic property; a
+seeder describes a domain to it, no more.
+
+## Depth levels (D0–D4)
+
+| Depth | Name | Authoring intent |
+|------:|------|------------------|
+| D0 | EXISTENCE | The primitive exists. No properties; cheap to declare. |
+| D1 | IDENTITY | What the thing **is** — attributes, defining properties, names of its parts. |
+| D2 | CAPABILITIES | What the thing **can do** — operations, services, the verbs it supports. |
+| D3 | CONSTRAINTS | What **bounds** it — preconditions, invariants, what restricts or governs the thing. |
+| D4 | IMPLICATIONS | What **follows** from operating on it — cascading consequences, downstream epistemic effects. |
+
+A primitive's depths must be **contiguous starting at D0**. You can stop at
+any level (D0–D1 is fine for a placeholder entity), but you cannot have D0,
+D1, D3 with D2 missing — the contiguous-max gates D3 to invisibility. Use
+this deliberately: omitting D2 is how you say "we haven't grounded
+capabilities yet."
+
+Substrates and shared structurals (operating systems, filesystems,
+permissions) typically need D0–D3. Actions usually need D0–D2 at minimum;
+destructive or consequential actions extend to D3 (preconditions, required
+permissions) and sometimes D4 (cascades). These are heuristics, not rules.
+
+## Relation types
+
+Relation types describe the **kind of epistemic connection** between two
+primitives. Any relation can be authored at any depth — the depth is where
+the *fact* is asserted, not a fixed slot for the relation type. The same
+target may even appear at multiple depths via different relations.
+
+| Relation | Transitive? | What it asserts |
+|----------|:-----------:|-----------------|
+| `REQUIRES` | yes | A hard prerequisite — the target must exist and be grounded for the source to be coherent. |
+| `DEPENDS_ON` | yes | A runtime dependency — the source needs the target's services to function. |
+| `CONSTRAINED_BY` | yes | Restriction — the source's behavior is bounded by the target. |
+| `INCLUDES` | no | Composition — the source contains the target as a member. |
+| `APPLIES_TO` | no | Action targeting — declares what an action operates on. |
+
+**Transitive vs non-transitive.** Grounding resolution walks transitive
+edges (`REQUIRES`, `DEPENDS_ON`, `CONSTRAINED_BY`) to compute the substrate
+an action sits on. Non-transitive edges (`APPLIES_TO`, `INCLUDES`) define
+one-step structural facts but do not contribute to the transitive substrate
+— they are queried at the depth they live on, not followed recursively.
+
+### Choosing a depth for an edge
+
+Ask: **at what depth does this fact become true?** That's where the relatum
+belongs. Some illustrative placements from the filesystem seeder:
+
+- `Directory [D1] —REQUIRES→ Path [D1]`: a directory's *identity* is
+  partly constituted by having a path. The fact lives at D1 because that's
+  where directory becomes itself.
+- `Directory [D2] —DEPENDS_ON→ Filesystem [D1]`: a directory's
+  *capabilities* (create, list, delete) need a filesystem to operate
+  against. The dependency is a runtime fact, asserted at D2.
+- `Directory [D3] —CONSTRAINED_BY→ Permission [D1]`: a directory's
+  *constraints* include permission checks. The fact lives at D3 because
+  it's part of what bounds the directory's use.
+- `Read [D2] —APPLIES_TO→ File [D2]`: read's targeting is known once its
+  capabilities are grounded.
+- `Delete [D3] —APPLIES_TO→ File [D2]`: delete's targeting is gated by
+  understanding its constraints. Authoring this at D3 instead of D2 means
+  the engine refuses to traverse the edge until delete is grounded
+  through D3. Seeding delete at only D0–D2 → APPLIES_TO invisible →
+  `ReachabilityGap` from delete to file (intentional).
+
+The lesson: **the same relation type can sit at any depth**, and where it
+sits is itself a policy decision. Use depth to declare what an agent must
+understand before the connection is consultable.
+
+## Idempotency contract
+
+- Use `repo.upsert_primitive(prim)` — never `repo.save_primitive(prim)`.
+  Upsert preserves the existing UUID when a primitive of the same name is
+  already in the graph and logs an INFO message on overwrite.
+- **Do not call `clear_graph`** from a seeder. Multiple domains may be
+  installed in the same graph; clearing is the user's choice, not the
+  seeder's. If a user wants a clean slate, they run
+  `python scripts/clear_graph.py` first.
+- Re-running a seeder is a no-op when the declared state matches the
+  graph state, and an overwrite when it doesn't. Depths and relata are
+  full-replaced for each upserted primitive — within-domain idempotency
+  only. Cross-domain primitive merging is not handled by seeders; if two
+  domains declare `file`, the second to run wins.
+
+## What NOT to include
+
+- **`Policy(...)` objects.** Operational policy (confirmation prompts,
+  cardinality triggers, callbacks) belongs to the application that uses
+  the graph, not to the seed.
+- **Integrator-specific metadata.** Anything tied to a particular harness,
+  agent framework, or runtime should not appear in seeded relata.
+- **Ephemeral or runtime state.** Metrics, learned candidates, session
+  data — these are written by the engine at runtime.
+- **Redundant depth content.** Don't restate the IDENTITY description at
+  D2. Each depth answers a different question.
+
+## Authoring template
+
+Structure the module **top-down**: substrates → structurals → entities →
+actors → actions. Each `seed_*` function is defined above the functions
+that depend on it. `main` lives at the bottom.
+
+```python
+"""
+Seeder for the <domain> domain.
+
+Upserts <one-sentence summary>. Idempotent — re-running preserves existing
+primitive ids by name. Does not clear the graph.
+
+Run: python seeders/seed_<domain>.py
+"""
+import argparse
+
+from vre.core.graph import PrimitiveRepository
+from vre.core.models import (
+    Depth, DepthLevel, Primitive, Provenance, ProvenanceSource,
+    Relatum, RelationType,
+)
+
+SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
+
+
+def seed_substrate(repo: PrimitiveRepository) -> Primitive:
+    """Seed the foundational substrate at D0–D3."""
+    substrate = Primitive(
+        name="substrate",
+        provenance=SEED_PROVENANCE,
+        depths=[
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
+                properties={"description": "...", "attribute_a": "..."},
+            ),
+            # D2, D3 as needed
+        ],
+    )
+    substrate = repo.upsert_primitive(substrate)
+    print(f"Saved: substrate ({substrate.id})")
+    return substrate
+
+
+def seed_entity(repo: PrimitiveRepository, substrate: Primitive) -> Primitive:
+    """Seed an entity that depends on the substrate."""
+    entity = Primitive(
+        name="entity",
+        provenance=SEED_PROVENANCE,
+        depths=[
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
+                properties={"description": "..."},
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.REQUIRES,
+                        target_id=substrate.id,
+                        target_depth=DepthLevel.IDENTITY,
+                        provenance=SEED_PROVENANCE,
+                    ),
+                ],
+            ),
+        ],
+    )
+    entity = repo.upsert_primitive(entity)
+    print(f"Saved: entity ({entity.id})")
+    return entity
+
+
+def seed_action(repo: PrimitiveRepository, entity: Primitive) -> Primitive:
+    """Seed an action whose APPLIES_TO targeting lives at D2."""
+    action = Primitive(
+        name="action",
+        provenance=SEED_PROVENANCE,
+        depths=[
+            Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE),
+            Depth(
+                level=DepthLevel.IDENTITY,
+                provenance=SEED_PROVENANCE,
+                properties={"description": "..."},
+            ),
+            Depth(
+                level=DepthLevel.CAPABILITIES,
+                provenance=SEED_PROVENANCE,
+                properties={"description": "..."},
+                relata=[
+                    Relatum(
+                        relation_type=RelationType.APPLIES_TO,
+                        target_id=entity.id,
+                        target_depth=DepthLevel.CAPABILITIES,
+                        provenance=SEED_PROVENANCE,
+                    ),
+                ],
+            ),
+        ],
+    )
+    action = repo.upsert_primitive(action)
+    print(f"Saved: action ({action.id})")
+    return action
+
+
+def main(repository: PrimitiveRepository) -> None:
+    with repository as repo:
+        repo.ensure_constraints()
+        substrate = seed_substrate(repo)
+        entity = seed_entity(repo, substrate)
+        seed_action(repo, entity)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="<domain> domain seeder")
+    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
+    parser.add_argument("--neo4j-user", default="neo4j")
+    parser.add_argument("--neo4j-password", default="password")
+    args = parser.parse_args()
+
+    repo = PrimitiveRepository(
+        uri=args.neo4j_uri,
+        user=args.neo4j_user,
+        password=args.neo4j_password,
+    )
+    main(repository=repo)
+```
+
+### Post-creation wiring
+
+When two primitives reference each other (e.g., a filesystem `INCLUDES` a
+file, but the file was seeded after the filesystem), seed both first, then
+mutate one and re-upsert. See the post-creation block at the bottom of
+`main()` in `seed_filesystem.py` for the pattern.
+
+## Verifying a new seeder
+
+1. Run the seeder against a local Neo4j and confirm no exceptions.
+2. Re-run it. You should see `INFO  vre.core.graph  Upserting '<name>': overwriting existing primitive (id=...)` for every primitive — no duplicates created.
+3. Use the grounding engine in a small script (or REPL) to query a representative concept from your domain. Inspect the resulting gaps and verify they match your authored shape — both clean passes and the gaps you intentionally left.

--- a/seeders/CONTRIBUTING.md
+++ b/seeders/CONTRIBUTING.md
@@ -105,6 +105,88 @@ The lesson: **the same relation type can sit at any depth**, and where it
 sits is itself a policy decision. Use depth to declare what an agent must
 understand before the connection is consultable.
 
+## Shared primitives across domains
+
+When two seeders declare a primitive with the same name, they're asserting
+it's the same concept. That's not a collision to resolve away — it's how
+the graph stops being a collection of disconnected silos. A shared `delete`
+across filesystem and database, a shared `permission` across filesystem
+and auth, a shared `lock` across database and concurrency — each of those
+is the seam where multi-domain reasoning becomes possible.
+
+**Convention.** When a primitive is being shared across domains, abstract
+it. Lift its domain-specific properties off the primitive's depth
+properties and place them on the **relata metadata** where the
+domain-specific entities connect to it. The primitive itself becomes
+thinner; the relationships carry the domain knowledge.
+
+For example, a filesystem-only `delete` might describe itself as
+"Removes the file from the filesystem permanently" at D2. If `delete`
+becomes shared with the HTTP and database domains, that description is
+filesystem-specific — it doesn't apply to deleting a row or a resource.
+The convention is to thin the primitive's own description to something
+concept-level ("Removes a target entity from existence") and move the
+filesystem-specific framing onto the metadata of the `delete →
+filesystem_entity` APPLIES_TO relatum. Each consuming domain attaches
+its own framing to its own edge.
+
+Primitives that get shared frequently become *thin* — the work shifts to
+the relata metadata that connects them back to each domain's concrete
+entities. The primitive becomes a nexus, and the rich domain knowledge
+sits on the edges.
+
+You don't need to abstract a primitive preemptively. A first-author
+seeder can give a primitive a domain-specific description if no sharing
+is in view. The convention kicks in when sharing happens — at that
+moment, lift the domain-specific properties to relata metadata so the
+primitive can host both framings cleanly. The interactive merge flow
+(see `--interactive` on seed scripts) supports this when two seeders
+collide on the same name.
+
+## Edge directionality across domains
+
+Cross-domain edges are directional, and the hierarchy flows one way:
+**edges originate in specialized domains and point into general
+domains, never backwards.** General primitives stay self-contained and
+domain-agnostic; specialized primitives reach into them when they need
+to. The dependency graph across domains is a DAG with general concepts
+at the roots.
+
+Examples:
+
+- `repository INCLUDES file` is valid. The git domain reaches into the
+  filesystem domain because git operates on files. The filesystem
+  domain doesn't reach back — `file` does not know about `repository`.
+  The filesystem graph has no edges pointing into git concepts.
+- `commit CONSTRAINED_BY authentication` is valid. The git domain
+  reaches into the auth domain because pushing requires credentials.
+  The auth domain doesn't reach back — `authentication` does not know
+  about `commit`.
+
+The runtime consequence: a traversal that starts from a filesystem
+concept never enters the git domain (no filesystem primitive has an
+outward edge into a git primitive). A traversal that starts from a git
+concept enters the filesystem domain through `repository INCLUDES file`
+and picks up `file`'s local neighborhood (`path`, `permission`,
+`ownership`), which is correct and useful — the git-aware agent needs
+to understand files to work with them. The DAG produces clean,
+direction-aware traversal without any explicit scoping logic.
+
+This is also why merge review matters. If someone authors an edge from
+`file` back into `repository` (or any general primitive into a
+specialized one), the interactive merge buffer surfaces the
+bidirectional connection and the reviewer catches it: "`file`
+shouldn't know about repositories — that's backwards." The convention
+is what enforces the clean DAG; the merge buffer is what makes
+violations visible.
+
+Restated as a principle:
+
+> Edges flow from specialized domains into general domains, never
+> backwards. General primitives are thin and domain-agnostic.
+> Domain-specific knowledge lives on the edges from specialized
+> concepts, not on the shared primitive.
+
 ## Idempotency contract
 
 - Use `repo.upsert_primitive(prim)` — never `repo.save_primitive(prim)`.

--- a/seeders/__init__.py
+++ b/seeders/__init__.py
@@ -1,0 +1,11 @@
+"""
+Domain seed scripts for the Volute Reasoning Engine.
+
+Each module in this package authors a self-contained epistemic domain by
+upserting primitives into a Neo4j graph. Seeders are idempotent (via
+PrimitiveRepository.upsert_primitive) and do not clear the graph — multiple
+domains can be installed side by side.
+
+Add a new domain by dropping a module here that exposes a `main(repository)`
+entry point.
+"""

--- a/seeders/seed_filesystem.py
+++ b/seeders/seed_filesystem.py
@@ -1,14 +1,19 @@
 """
-Seed script for populating VRE with epistemic primitives.
+Seeder for the filesystem domain.
 
-Run: poetry run python scripts/seed_all.py
+Upserts a fully grounded epistemic graph for operating system filesystem
+concepts (OS, filesystem, path, permission, ownership, directory, file,
+symlink, user, group, process) and their actions (create, read, write,
+delete, list, move, copy, modify, execute). Idempotent — re-running
+preserves existing primitive ids by name. Does not clear the graph;
+compose with `scripts/clear_graph.py` if a clean slate is wanted.
+
+Run: python seeders/seed_filesystem.py
 """
 import argparse
 
-from scripts.clear_graph import clear_graph
 from vre.core.graph import PrimitiveRepository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
-from vre.core.policy.models import Cardinality, Policy
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 
@@ -69,7 +74,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(os_prim)
+    os_prim = repo.upsert_primitive(os_prim)
     print(f"Saved: operating_system ({os_prim.id})")
     return os_prim
 
@@ -139,7 +144,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(filesystem)
+    filesystem = repo.upsert_primitive(filesystem)
     print(f"Saved: filesystem ({filesystem.id})")
     return filesystem
 
@@ -214,7 +219,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(path)
+    path = repo.upsert_primitive(path)
     print(f"Saved: path ({path.id})")
     return path
 
@@ -289,7 +294,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(permission)
+    permission = repo.upsert_primitive(permission)
     print(f"Saved: permission ({permission.id})")
     return permission
 
@@ -362,7 +367,7 @@ def seed_ownership(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(ownership)
+    ownership = repo.upsert_primitive(ownership)
     print(f"Saved: ownership ({ownership.id})")
     return ownership
 
@@ -455,7 +460,7 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
             ),
         ],
     )
-    repo.save_primitive(directory)
+    directory = repo.upsert_primitive(directory)
     print(f"Saved: directory ({directory.id})")
     return directory
 
@@ -546,7 +551,7 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
             ),
         ],
     )
-    repo.save_primitive(file)
+    file = repo.upsert_primitive(file)
     print(f"Saved: file ({file.id})")
     return file
 
@@ -646,7 +651,7 @@ def seed_symlink(repo: PrimitiveRepository, filesystem: Primitive, path: Primiti
             ),
         ],
     )
-    repo.save_primitive(symlink)
+    symlink = repo.upsert_primitive(symlink)
     print(f"Saved: symlink ({symlink.id})")
     return symlink
 
@@ -718,7 +723,7 @@ def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(user)
+    user = repo.upsert_primitive(user)
     print(f"Saved: user ({user.id})")
     return user
 
@@ -793,7 +798,7 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
             ),
         ],
     )
-    repo.save_primitive(group)
+    group = repo.upsert_primitive(group)
     print(f"Saved: group ({group.id})")
     return group
 
@@ -880,7 +885,7 @@ def seed_process(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(process)
+    process = repo.upsert_primitive(process)
     print(f"Saved: process ({process.id})")
     return process
 
@@ -948,7 +953,7 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
         ],
     )
-    repo.save_primitive(create)
+    create = repo.upsert_primitive(create)
     print(f"Saved: create ({create.id})")
     return create
 
@@ -1013,7 +1018,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(read)
+    read = repo.upsert_primitive(read)
     print(f"Saved: read ({read.id})")
     return read
 
@@ -1080,7 +1085,7 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(write)
+    write = repo.upsert_primitive(write)
     print(f"Saved: write ({write.id})")
     return write
 
@@ -1139,20 +1144,6 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
                         metadata={
                             "description": "Removes the file from the filesystem permanently",
                         },
-                        policies=[
-                            Policy(
-                                name="BulkFileDeletePolicy",
-                                requires_confirmation=True,
-                                trigger_cardinality=Cardinality.MULTIPLE,
-                                confirmation_message="Bulk file deletion requires user approval. Proceed?",
-                            ),
-                            Policy(
-                                name="ProtectedFileDeletePolicy",
-                                requires_confirmation=True,
-                                callback="examples.langchain_ollama.policies.protected_file_delete",
-                                confirmation_message="Deletion may affect protected files. Proceed?",
-                            ),
-                        ],
                     ),
                     Relatum(
                         relation_type=RelationType.APPLIES_TO,
@@ -1182,7 +1173,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
         ],
     )
-    repo.save_primitive(delete)
+    delete = repo.upsert_primitive(delete)
     print(f"Saved: delete ({delete.id})")
     return delete
 
@@ -1247,7 +1238,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(list_prim)
+    list_prim = repo.upsert_primitive(list_prim)
     print(f"Saved: list ({list_prim.id})")
     return list_prim
 
@@ -1337,7 +1328,7 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
         ],
     )
-    repo.save_primitive(move)
+    move = repo.upsert_primitive(move)
     print(f"Saved: move ({move.id})")
     return move
 
@@ -1424,7 +1415,7 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
             ),
         ],
     )
-    repo.save_primitive(copy)
+    copy = repo.upsert_primitive(copy)
     print(f"Saved: copy ({copy.id})")
     return copy
 
@@ -1516,7 +1507,7 @@ def seed_modify(repo: PrimitiveRepository, file: Primitive, directory: Primitive
             ),
         ],
     )
-    repo.save_primitive(modify)
+    modify = repo.upsert_primitive(modify)
     print(f"Saved: modify ({modify.id})")
     return modify
 
@@ -1605,7 +1596,7 @@ def seed_execute(repo: PrimitiveRepository, file: Primitive) -> Primitive:
             ),
         ],
     )
-    repo.save_primitive(execute)
+    execute = repo.upsert_primitive(execute)
     print(f"Saved: execute ({execute.id})")
     return execute
 
@@ -1613,8 +1604,6 @@ def seed_execute(repo: PrimitiveRepository, file: Primitive) -> Primitive:
 def main(repository: PrimitiveRepository) -> None:
     with repository as repo:
         repo.ensure_constraints()
-        deleted = clear_graph(repo)
-        print(f"Cleared {deleted} existing primitive(s).\n")
 
         # ── Substrates ───────────────────────────────────────────────────
         os_prim = seed_operating_system(repo)
@@ -1672,7 +1661,7 @@ def main(repository: PrimitiveRepository) -> None:
                 provenance=SEED_PROVENANCE,
             ),
         ])
-        repo.save_primitive(filesystem)
+        filesystem = repo.upsert_primitive(filesystem)
         print("Updated: filesystem with INCLUDES relata")
 
         # permission DEPENDS_ON ownership (eval starts with ownership)
@@ -1807,7 +1796,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             ),
         ])
-        repo.save_primitive(permission)
+        permission = repo.upsert_primitive(permission)
         print("Updated: permission with DEPENDS_ON ownership and APPLIES_TO relata")
 
         # ownership APPLIES_TO entities and actors
@@ -1859,7 +1848,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             ),
         ])
-        repo.save_primitive(ownership)
+        ownership = repo.upsert_primitive(ownership)
         print("Updated: ownership with APPLIES_TO relata")
 
         # file, directory, symlink REQUIRES ownership
@@ -1876,7 +1865,7 @@ def main(repository: PrimitiveRepository) -> None:
                     },
                 ),
             )
-            repo.save_primitive(entity_prim)
+            entity_prim = repo.upsert_primitive(entity_prim)
         print("Updated: file, directory, symlink with REQUIRES ownership")
 
         # user INCLUDES process
@@ -1892,7 +1881,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             ),
         )
-        repo.save_primitive(user)
+        user = repo.upsert_primitive(user)
         print("Updated: user with INCLUDES process")
 
         # CONSTRAINED_BY permission on all action primitives at D3
@@ -1910,7 +1899,7 @@ def main(repository: PrimitiveRepository) -> None:
                     },
                 )
             )
-            repo.save_primitive(action_prim)
+            action_prim = repo.upsert_primitive(action_prim)
         print("Updated: read, write, delete, create, modify with CONSTRAINED_BY permission at D3")
 
         # modify CONSTRAINED_BY ownership (owner authority required)
@@ -1927,7 +1916,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(modify)
+        modify = repo.upsert_primitive(modify)
         print("Updated: modify with CONSTRAINED_BY ownership at D3")
 
         list_constraints = next(d for d in list_prim.depths if d.level == DepthLevel.CONSTRAINTS)
@@ -1943,7 +1932,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(list_prim)
+        list_prim = repo.upsert_primitive(list_prim)
         print("Updated: list with CONSTRAINED_BY permission at D3")
 
         move_constraints = next(d for d in move.depths if d.level == DepthLevel.CONSTRAINTS)
@@ -1962,7 +1951,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(move)
+        move = repo.upsert_primitive(move)
         print("Updated: move with CONSTRAINED_BY permission at D3")
 
         copy_constraints = next(d for d in copy.depths if d.level == DepthLevel.CONSTRAINTS)
@@ -1980,7 +1969,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(copy)
+        copy = repo.upsert_primitive(copy)
         print("Updated: copy with CONSTRAINED_BY permission at D3")
 
         execute_constraints = next(d for d in execute.depths if d.level == DepthLevel.CONSTRAINTS)
@@ -1997,7 +1986,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(execute)
+        execute = repo.upsert_primitive(execute)
         print("Updated: execute with CONSTRAINED_BY permission at D3")
 
         # create, delete APPLIES_TO symlink (destructive — at D3)
@@ -2013,7 +2002,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(create)
+        create = repo.upsert_primitive(create)
         print("Updated: create with APPLIES_TO symlink at D3")
 
         delete_constraints = next(d for d in delete.depths if d.level == DepthLevel.CONSTRAINTS)
@@ -2051,7 +2040,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             ),
         ])
-        repo.save_primitive(delete)
+        delete = repo.upsert_primitive(delete)
         print("Updated: delete with APPLIES_TO symlink at D3 and D4 relata")
 
         # read APPLIES_TO symlink (safe — at D2)
@@ -2067,7 +2056,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(read)
+        read = repo.upsert_primitive(read)
         print("Updated: read with APPLIES_TO symlink at D2")
 
         # execute D4 relata — consequential relationships
@@ -2092,7 +2081,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             ),
         ])
-        repo.save_primitive(execute)
+        execute = repo.upsert_primitive(execute)
         print("Updated: execute with D4 relata")
 
         # process CONSTRAINED_BY permission
@@ -2110,7 +2099,7 @@ def main(repository: PrimitiveRepository) -> None:
                 },
             )
         )
-        repo.save_primitive(process)
+        process = repo.upsert_primitive(process)
         print("Updated: process with CONSTRAINED_BY permission at D3")
 
         print("\nDone. Seeded 20 primitives.")

--- a/src/vre/core/graph.py
+++ b/src/vre/core/graph.py
@@ -379,6 +379,27 @@ class PrimitiveRepository:
             logger.error("Neo4j error saving primitive %r: %s", primitive.name, exc)
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
 
+    def upsert_primitive(self, primitive: Primitive) -> Primitive:
+        """
+        Save `primitive`, preserving the id of any existing primitive with the
+        same name. Returns the reconciled primitive so callers can cite its
+        canonical id in downstream relata.
+
+        Within-domain idempotency only: depths and relata are full-replaced
+        (per save_primitive). Cross-domain merging is not handled here.
+        """
+        existing = self.find_by_name(primitive.name)
+        if existing is None:
+            canonical = primitive
+        else:
+            logger.info(
+                "Upserting %r: overwriting existing primitive (id=%s)",
+                primitive.name, existing.id,
+            )
+            canonical = primitive.model_copy(update={"id": existing.id})
+        self.save_primitive(canonical)
+        return canonical
+
     def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
         """
         Update only the metrics JSON on an existing primitive node.

--- a/tests/vre/test_graph.py
+++ b/tests/vre/test_graph.py
@@ -1,0 +1,82 @@
+"""
+Unit tests for PrimitiveRepository methods that have pure Python logic
+on top of the Neo4j calls. We bypass __init__ (which would require a
+live driver) and substitute the lower-level methods we need.
+"""
+
+import logging
+
+import pytest
+
+from vre.core.graph import PrimitiveRepository
+from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource
+
+
+SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
+
+
+def _make_primitive(name: str) -> Primitive:
+    return Primitive(
+        name=name,
+        provenance=SEED_PROVENANCE,
+        depths=[Depth(level=DepthLevel.EXISTENCE, provenance=SEED_PROVENANCE)],
+    )
+
+
+class _FakeRepo(PrimitiveRepository):
+    """PrimitiveRepository with find_by_name and save_primitive stubbed."""
+
+    def __init__(self) -> None:
+        self._existing: Primitive | None = None
+        self._saved: list[Primitive] = []
+
+    def find_by_name(self, name: str) -> Primitive | None:
+        return self._existing
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        self._saved.append(primitive)
+
+
+def test_upsert_creates_when_no_existing() -> None:
+    repo = _FakeRepo()
+    incoming = _make_primitive("file")
+    original_id = incoming.id
+
+    saved = repo.upsert_primitive(incoming)
+
+    assert saved.id == original_id
+    assert repo._saved == [saved]
+
+
+def test_upsert_preserves_existing_id() -> None:
+    repo = _FakeRepo()
+    existing = _make_primitive("file")
+    repo._existing = existing
+    incoming = _make_primitive("file")
+
+    saved = repo.upsert_primitive(incoming)
+
+    assert saved.id == existing.id
+    assert saved.id != incoming.id
+    assert repo._saved == [saved]
+
+
+def test_upsert_logs_on_overwrite(caplog: pytest.LogCaptureFixture) -> None:
+    repo = _FakeRepo()
+    repo._existing = _make_primitive("file")
+    incoming = _make_primitive("file")
+
+    with caplog.at_level(logging.INFO, logger="vre.core.graph"):
+        repo.upsert_primitive(incoming)
+
+    assert any("Upserting 'file'" in r.message for r in caplog.records)
+
+
+def test_upsert_does_not_log_when_new(caplog: pytest.LogCaptureFixture) -> None:
+    repo = _FakeRepo()
+    incoming = _make_primitive("file")
+
+    with caplog.at_level(logging.INFO, logger="vre.core.graph"):
+        repo.upsert_primitive(incoming)
+
+    assert not any("Upserting" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary
- New `seeders/` package at the project root as a contributor home for domain seed scripts (pycon 2026 sprint prep).
- New `PrimitiveRepository.upsert_primitive` — finds by name, preserves existing UUID, logs on overwrite. Seeders are now idempotent by name across reruns and can be composed without clearing the graph.
- `scripts/seed_all.py` → `seeders/seed_filesystem.py`. All `save_primitive` calls converted to `upsert_primitive`; the implicit `clear_graph` call is dropped; `Policy(...)` blocks on the Delete → File relatum stripped (operational policy is integrator-owned, not seeder content).
- `seeders/CONTRIBUTING.md` documents the graph-as-policy mental model, depth/relation reference, idempotency contract, and a copy-pasteable authoring template.

## Behavior changes
- Seeders no longer clear the graph. Multiple domains can be installed side by side. Run `python scripts/clear_graph.py` first if you want a clean slate.
- Re-running a seeder upserts by name — no duplicate primitives. An INFO log is emitted on each overwrite.
- The example `protected_file_delete` callback in `examples/langchain_ollama/policies.py` was previously auto-wired by the stripped Policy block. It's now integrator-attached; the example app no longer demonstrates the guard until the policy is wired separately. Docstring updated to reflect this.

## Out of scope
- `scripts/seed_gaps.py` still uses `save_primitive`. Intentional — it clears the graph before seeding for deterministic demo output, so idempotency isn't required.
- Cross-domain primitive merging (when two seeders both declare `file`) — second to run wins for now. Tracked separately.

## Test plan
- [x] `uv run pytest` — 251 passed, 75% coverage
- [x] New `tests/vre/test_graph.py` covers upsert: new insert preserves provided id, existing primitive reconciles id, log emitted only on overwrite
- [ ] Run `python seeders/seed_filesystem.py` against a fresh Neo4j and confirm 20 primitives saved
- [ ] Re-run and confirm INFO `Upserting '<name>': overwriting…` for each primitive with no duplicates
- [ ] Run `python scripts/seed_gaps.py` and confirm the demo still produces the expected gap scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)