### PR TITLE
Fix GroundingResult.gaps typing: list[Any] → list[KnowledgeGap]

### DIFF
--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -5,7 +5,6 @@
 GroundingResult — the public result type returned by VRE grounding checks.
 """
 
-from typing import Any
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -126,7 +125,7 @@ class GroundingResult(BaseModel):
 
     grounded: bool
     resolved: list[str]
-    gaps: list[Any]
+    gaps: list[KnowledgeGap]
     trace: EpistemicResponse | None = None
     agent_id: UUID | None = None
 

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 from uuid import uuid4
 
 from vre.core.grounding import GroundingResult
+from vre.core.models import ExistenceGap, Primitive
 from vre.core.policy import PolicyAction, PolicyResult
 from vre.core.policy.models import PolicyViolation, Policy
 from vre.guard import vre_guard
@@ -43,7 +44,8 @@ def test_vre_guard_returns_grounding_result_when_not_grounded():
     """When grounding fails, vre_guard returns GroundingResult without calling fn."""
     from vre.guard import vre_guard
 
-    mock_vre = _mock_vre(_grounding(grounded=False, gaps=[MagicMock()]))
+    gap = ExistenceGap(primitive=Primitive(name="unknown", depths=[]))
+    mock_vre = _mock_vre(_grounding(grounded=False, gaps=[gap]))
 
     @vre_guard(mock_vre, concepts=["file"])
     def my_fn():


### PR DESCRIPTION
## Summary
- Narrows `GroundingResult.gaps` from `list[Any]` to `list[KnowledgeGap]`, enforcing Pydantic's discriminated union validation at construction time
- Removes the now-unused `from typing import Any` import
- Updates the guard test to use a real `ExistenceGap` instead of a `MagicMock` that the stricter typing now rejects

## Test plan
- [x] Full test suite passes (251/251)
- [x] Coverage threshold met (74.86% ≥ 70%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)