### PR TITLE
Extract Repository ABC; rename PrimitiveRepository to Neo4jRepository

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,9 +232,9 @@ python scripts/seed_gaps.py \
 
 ```python
 from vre import VRE
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository
 
-repo = PrimitiveRepository(
+repo = Neo4jRepository(
     uri="neo4j://localhost:7687",
     user="neo4j",
     password="password",
@@ -861,9 +861,11 @@ src/vre/
 │   └── registry.py              # AgentRegistry — file-based, append-only identity persistence
 │
 ├── core/
-│   ├── models.py                # Primitive, Depth, Relatum, RelationType, DepthLevel, gaps, Provenance
+│   ├── models.py                # Primitive, Depth, Relatum, RelationType, DepthLevel, KnowledgeGap, Provenance
 │   ├── errors.py                # VREError hierarchy — typed exceptions for all failure modes
-│   ├── graph.py                 # PrimitiveRepository (Neo4j)
+│   ├── backends/
+│   │   ├── repository.py        # Repository ABC — abstract persistence contract
+│   │   └── neo4j.py             # Neo4jRepository — Neo4j backend
 │   ├── grounding/
 │   │   ├── resolver.py          # ConceptResolver — spaCy lemmatization + name lookup
 │   │   ├── engine.py            # GroundingEngine — depth-gated query, gap detection

--- a/examples/claude-code/claude_code.py
+++ b/examples/claude-code/claude_code.py
@@ -246,9 +246,9 @@ def _run_hook() -> None:
         config = json.loads(_VRE_CONFIG_PATH.read_text())
 
         from vre import VRE, PolicyAction
-        from vre.core.graph import PrimitiveRepository
+        from vre.core.backends import Neo4jRepository
 
-        with PrimitiveRepository(
+        with Neo4jRepository(
             config["uri"], config["user"], config["password"], config.get("database", "neo4j")
         ) as repo:
             vre = VRE(repo)

--- a/examples/langchain_ollama/main.py
+++ b/examples/langchain_ollama/main.py
@@ -13,7 +13,7 @@ import os
 from langchain_core.tools import StructuredTool
 
 from vre import VRE
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository
 
 from examples.langchain_ollama.agent import make_agent
 from examples.langchain_ollama.callbacks import ConceptExtractor, get_cardinality, on_policy, on_trace
@@ -27,14 +27,14 @@ def main() -> None:
     parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
     parser.add_argument("--neo4j-user", default="neo4j")
     parser.add_argument("--neo4j-password", default="password")
-    parser.add_argument("--model", default="qwen3.5:latest")
+    parser.add_argument("--model", default="gemma4:26b")
     parser.add_argument("--sandbox", default="examples/langchain_ollama/workspace")
     parser.add_argument("--concepts-model", default="qwen2.5-coder:7b")
     args = parser.parse_args()
 
     os.makedirs(args.sandbox, exist_ok=True)
 
-    repo = PrimitiveRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
+    repo = Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
     vre = VRE(repo, agent_key="langchain-ollama-demo-agent", agent_name="Langchain Ollama Demo Agent")
 
     concepts = ConceptExtractor(model=args.concepts_model)

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -1,28 +1,20 @@
 """
-Clear all primitives and relationships from the VRE Neo4j graph.
+Clear all primitives and relationships from a VRE repository.
 
 Can be run standalone or imported by seed scripts to ensure a clean slate.
 
 Run: python scripts/clear_graph.py
 """
 import argparse
-from typing import LiteralString, cast
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 
 
-def clear_graph(repo: PrimitiveRepository) -> int:
+def clear_graph(repo: Repository) -> int:
     """
-    Delete every Primitive node and its relationships. Returns the count deleted.
+    Delete every Primitive and its relationships. Returns the count deleted.
     """
-    with repo._driver.session(database=repo._database) as session:
-        result = session.run(
-            cast(
-                LiteralString,
-                "MATCH (p:Primitive) DETACH DELETE p RETURN count(p) AS deleted",
-            ),
-        ).single()
-        return result["deleted"] if result else 0
+    return repo.clear()
 
 
 if __name__ == "__main__":
@@ -32,7 +24,7 @@ if __name__ == "__main__":
     parser.add_argument("--neo4j-password", default="password")
     args = parser.parse_args()
 
-    repo = PrimitiveRepository(
+    repo = Neo4jRepository(
         uri=args.neo4j_uri,
         user=args.neo4j_user,
         password=args.neo4j_password,

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -628,7 +628,6 @@ def seed_create(repo: Repository, file: Primitive, directory: Primitive) -> Prim
 
 def main(repository: Repository) -> None:
     with repository as repo:
-        repo.ensure_constraints()
         deleted = clear_graph(repo)
 
         print(f"Cleared {deleted} existing primitive(s).")

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -12,7 +12,7 @@ Run: python scripts/seed_gaps.py
 import argparse
 
 from scripts.clear_graph import clear_graph
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
@@ -21,7 +21,7 @@ SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 # ── Fully grounded substrates (D0–D3) ─────────────────────────────────────
 
 
-def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
+def seed_operating_system(repo: Repository) -> Primitive:
     """
     Seed the OperatingSystem primitive at D0–D3.
 
@@ -81,7 +81,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
     return os_prim
 
 
-def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_filesystem(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Filesystem primitive at D0–D3.
 
@@ -148,7 +148,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return filesystem
 
 
-def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
+def seed_path(repo: Repository, filesystem: Primitive) -> Primitive:
     """
     Seed the Path primitive at D0–D3.
 
@@ -212,7 +212,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
     return path
 
 
-def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_permission(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Permission primitive at D0–D3.
 
@@ -284,7 +284,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
 
 
 def seed_directory(
-    repo: PrimitiveRepository,
+    repo: Repository,
     filesystem: Primitive,
     path: Primitive,
     permission: Primitive,
@@ -377,7 +377,7 @@ def seed_directory(
 # ── Shallow entity (D0–D1) ────────────────────────────────────────────────
 
 
-def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
+def seed_file(repo: Repository, path: Primitive) -> Primitive:
     """
     Seed the File primitive at D0–D1 only.
 
@@ -416,7 +416,7 @@ def seed_file(repo: PrimitiveRepository, path: Primitive) -> Primitive:
 # ── Safe actions (D0–D2) ──────────────────────────────────────────────────
 
 
-def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
+def seed_read(repo: Repository, file: Primitive) -> Primitive:
     """
     Seed the Read primitive at D0–D2.
 
@@ -466,7 +466,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     return read
 
 
-def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
+def seed_list(repo: Repository, directory: Primitive) -> Primitive:
     """
     Seed the List primitive at D0–D2.
 
@@ -521,7 +521,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
 # ── Destructive actions ───────────────────────────────────────────────────
 
 
-def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+def seed_delete(repo: Repository, file: Primitive, directory: Primitive) -> Primitive:
     """
     Seed the Delete primitive at D0–D2 only.
 
@@ -563,7 +563,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     return delete
 
 
-def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+def seed_create(repo: Repository, file: Primitive, directory: Primitive) -> Primitive:
     """
     Seed the Create primitive at D0–D1 + D3 (non-contiguous).
 
@@ -626,7 +626,7 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
 # ── Main ──────────────────────────────────────────────────────────────────
 
 
-def main(repository: PrimitiveRepository) -> None:
+def main(repository: Repository) -> None:
     with repository as repo:
         repo.ensure_constraints()
         deleted = clear_graph(repo)
@@ -689,7 +689,7 @@ if __name__ == "__main__":
     parser.add_argument("--neo4j-password", default="password")
     args = parser.parse_args()
 
-    repo = PrimitiveRepository(
+    repo = Neo4jRepository(
         uri=args.neo4j_uri,
         user=args.neo4j_user,
         password=args.neo4j_password,

--- a/seeders/CONTRIBUTING.md
+++ b/seeders/CONTRIBUTING.md
@@ -321,7 +321,6 @@ def seed_action(repo: Repository, entity: Primitive) -> Primitive:
 
 def main(repository: Repository) -> None:
     with repository as repo:
-        repo.ensure_constraints()
         substrate = seed_substrate(repo)
         entity = seed_entity(repo, substrate)
         seed_action(repo, entity)

--- a/seeders/CONTRIBUTING.md
+++ b/seeders/CONTRIBUTING.md
@@ -231,7 +231,7 @@ Run: python seeders/seed_<domain>.py
 """
 import argparse
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 from vre.core.models import (
     Depth, DepthLevel, Primitive, Provenance, ProvenanceSource,
     Relatum, RelationType,
@@ -240,7 +240,7 @@ from vre.core.models import (
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 
 
-def seed_substrate(repo: PrimitiveRepository) -> Primitive:
+def seed_substrate(repo: Repository) -> Primitive:
     """Seed the foundational substrate at D0–D3."""
     substrate = Primitive(
         name="substrate",
@@ -260,7 +260,7 @@ def seed_substrate(repo: PrimitiveRepository) -> Primitive:
     return substrate
 
 
-def seed_entity(repo: PrimitiveRepository, substrate: Primitive) -> Primitive:
+def seed_entity(repo: Repository, substrate: Primitive) -> Primitive:
     """Seed an entity that depends on the substrate."""
     entity = Primitive(
         name="entity",
@@ -287,7 +287,7 @@ def seed_entity(repo: PrimitiveRepository, substrate: Primitive) -> Primitive:
     return entity
 
 
-def seed_action(repo: PrimitiveRepository, entity: Primitive) -> Primitive:
+def seed_action(repo: Repository, entity: Primitive) -> Primitive:
     """Seed an action whose APPLIES_TO targeting lives at D2."""
     action = Primitive(
         name="action",
@@ -319,7 +319,7 @@ def seed_action(repo: PrimitiveRepository, entity: Primitive) -> Primitive:
     return action
 
 
-def main(repository: PrimitiveRepository) -> None:
+def main(repository: Repository) -> None:
     with repository as repo:
         repo.ensure_constraints()
         substrate = seed_substrate(repo)
@@ -334,7 +334,7 @@ if __name__ == "__main__":
     parser.add_argument("--neo4j-password", default="password")
     args = parser.parse_args()
 
-    repo = PrimitiveRepository(
+    repo = Neo4jRepository(
         uri=args.neo4j_uri,
         user=args.neo4j_user,
         password=args.neo4j_password,

--- a/seeders/__init__.py
+++ b/seeders/__init__.py
@@ -2,8 +2,8 @@
 Domain seed scripts for the Volute Reasoning Engine.
 
 Each module in this package authors a self-contained epistemic domain by
-upserting primitives into a Neo4j graph. Seeders are idempotent (via
-PrimitiveRepository.upsert_primitive) and do not clear the graph — multiple
+upserting primitives into a repository. Seeders are idempotent (via
+Repository.upsert_primitive) and do not clear the graph — multiple
 domains can be installed side by side.
 
 Add a new domain by dropping a module here that exposes a `main(repository)`

--- a/seeders/seed_filesystem.py
+++ b/seeders/seed_filesystem.py
@@ -1603,8 +1603,6 @@ def seed_execute(repo: Repository, file: Primitive) -> Primitive:
 
 def main(repository: Repository) -> None:
     with repository as repo:
-        repo.ensure_constraints()
-
         # ── Substrates ───────────────────────────────────────────────────
         os_prim = seed_operating_system(repo)
         filesystem = seed_filesystem(repo, os_prim)

--- a/seeders/seed_filesystem.py
+++ b/seeders/seed_filesystem.py
@@ -12,13 +12,13 @@ Run: python seeders/seed_filesystem.py
 """
 import argparse
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
 
 
-def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
+def seed_operating_system(repo: Repository) -> Primitive:
     """
     Seed the OperatingSystem primitive at D0–D3.
 
@@ -79,7 +79,7 @@ def seed_operating_system(repo: PrimitiveRepository) -> Primitive:
     return os_prim
 
 
-def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_filesystem(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Filesystem primitive at D0–D3.
 
@@ -149,7 +149,7 @@ def seed_filesystem(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return filesystem
 
 
-def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
+def seed_path(repo: Repository, filesystem: Primitive) -> Primitive:
     """
     Seed the Path primitive at D0–D3.
 
@@ -224,7 +224,7 @@ def seed_path(repo: PrimitiveRepository, filesystem: Primitive) -> Primitive:
     return path
 
 
-def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_permission(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Permission primitive at D0–D3.
 
@@ -299,7 +299,7 @@ def seed_permission(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return permission
 
 
-def seed_ownership(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_ownership(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Ownership primitive at D0–D3.
 
@@ -372,7 +372,7 @@ def seed_ownership(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return ownership
 
 
-def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
+def seed_directory(repo: Repository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
     """
     Seed the Directory primitive at D0–D3.
 
@@ -465,7 +465,7 @@ def seed_directory(repo: PrimitiveRepository, filesystem: Primitive, path: Primi
     return directory
 
 
-def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
+def seed_file(repo: Repository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
     """
     Seed the File primitive at D0–D3.
 
@@ -556,7 +556,7 @@ def seed_file(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive,
     return file
 
 
-def seed_symlink(repo: PrimitiveRepository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
+def seed_symlink(repo: Repository, filesystem: Primitive, path: Primitive, permission: Primitive) -> Primitive:
     """
     Seed the Symlink primitive at D0–D3.
 
@@ -656,7 +656,7 @@ def seed_symlink(repo: PrimitiveRepository, filesystem: Primitive, path: Primiti
     return symlink
 
 
-def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_user(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the User primitive at D0–D3.
 
@@ -728,7 +728,7 @@ def seed_user(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return user
 
 
-def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -> Primitive:
+def seed_group(repo: Repository, os_prim: Primitive, user: Primitive) -> Primitive:
     """
     Seed the Group primitive at D0–D3.
 
@@ -803,7 +803,7 @@ def seed_group(repo: PrimitiveRepository, os_prim: Primitive, user: Primitive) -
     return group
 
 
-def seed_process(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
+def seed_process(repo: Repository, os_prim: Primitive) -> Primitive:
     """
     Seed the Process primitive at D0–D3.
 
@@ -890,7 +890,7 @@ def seed_process(repo: PrimitiveRepository, os_prim: Primitive) -> Primitive:
     return process
 
 
-def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+def seed_create(repo: Repository, file: Primitive, directory: Primitive) -> Primitive:
     """
     Seed the Create primitive at D0–D3 with APPLIES_TO relata to File and Directory.
     """
@@ -958,7 +958,7 @@ def seed_create(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     return create
 
 
-def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
+def seed_read(repo: Repository, file: Primitive) -> Primitive:
     """
     Seed the Read primitive at D0–D3.
 
@@ -1023,7 +1023,7 @@ def seed_read(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     return read
 
 
-def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
+def seed_write(repo: Repository, file: Primitive) -> Primitive:
     """
     Seed the Write primitive at D0–D3.
 
@@ -1090,7 +1090,7 @@ def seed_write(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     return write
 
 
-def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive) -> Primitive:
+def seed_delete(repo: Repository, file: Primitive, directory: Primitive) -> Primitive:
     """
     Seed the Delete primitive at D0–D4.
 
@@ -1178,7 +1178,7 @@ def seed_delete(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     return delete
 
 
-def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
+def seed_list(repo: Repository, directory: Primitive) -> Primitive:
     """
     Seed the List primitive at D0–D3.
 
@@ -1243,7 +1243,7 @@ def seed_list(repo: PrimitiveRepository, directory: Primitive) -> Primitive:
     return list_prim
 
 
-def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
+def seed_move(repo: Repository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
     """
     Seed the Move primitive at D0–D3.
 
@@ -1333,7 +1333,7 @@ def seed_move(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
     return move
 
 
-def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
+def seed_copy(repo: Repository, file: Primitive, directory: Primitive, path: Primitive) -> Primitive:
     """
     Seed the Copy primitive at D0–D3.
 
@@ -1420,7 +1420,7 @@ def seed_copy(repo: PrimitiveRepository, file: Primitive, directory: Primitive, 
     return copy
 
 
-def seed_modify(repo: PrimitiveRepository, file: Primitive, directory: Primitive, symlink: Primitive) -> Primitive:
+def seed_modify(repo: Repository, file: Primitive, directory: Primitive, symlink: Primitive) -> Primitive:
     """
     Seed the Modify primitive at D0–D3.
 
@@ -1512,7 +1512,7 @@ def seed_modify(repo: PrimitiveRepository, file: Primitive, directory: Primitive
     return modify
 
 
-def seed_execute(repo: PrimitiveRepository, file: Primitive) -> Primitive:
+def seed_execute(repo: Repository, file: Primitive) -> Primitive:
     """
     Seed the Execute primitive at D0–D4.
 
@@ -1601,7 +1601,7 @@ def seed_execute(repo: PrimitiveRepository, file: Primitive) -> Primitive:
     return execute
 
 
-def main(repository: PrimitiveRepository) -> None:
+def main(repository: Repository) -> None:
     with repository as repo:
         repo.ensure_constraints()
 
@@ -2112,7 +2112,7 @@ if __name__ == "__main__":
     parser.add_argument("--neo4j-password", default="password")
     args = parser.parse_args()
 
-    repo = PrimitiveRepository(
+    repo = Neo4jRepository(
         uri=args.neo4j_uri,
         user=args.neo4j_user,
         password=args.neo4j_password,

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -7,9 +7,9 @@ Volute Reasoning Engine — decorator-based epistemic enforcement.
 Usage::
 
     from vre import VRE
-    from vre.core.graph import PrimitiveRepository
+    from vre.core.backends import Neo4jRepository
 
-    repo = PrimitiveRepository("neo4j://localhost:7687", "neo4j", "password")
+    repo = Neo4jRepository("neo4j://localhost:7687", "neo4j", "password")
     vre = VRE(repo)
     result = vre.check(["file", "write"])
     print(result.grounded, result.resolved)
@@ -30,7 +30,7 @@ from vre.core.errors import (
     ResolutionError,
     VREError,
 )
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
 from vre.core.models import (
     DepthLevel,
@@ -63,7 +63,8 @@ __all__ = [
     "RegistryError",
     "ResolutionError",
     "VREError",
-    "PrimitiveRepository",
+    "Neo4jRepository",
+    "Repository",
     "ConceptResolver",
     "GroundingEngine",
     "GroundingResult",
@@ -94,7 +95,7 @@ class VRE:
 
     def __init__(
         self,
-        repository: PrimitiveRepository,
+        repository: Repository,
         agent_key: str | None = None,
         agent_name: str | None = None,
         registry_path: str | Path | None = None,

--- a/src/vre/core/__init__.py
+++ b/src/vre/core/__init__.py
@@ -1,6 +1,7 @@
 # Copyright 2026 Andrew Greene
 # Licensed under the Apache License, Version 2.0
 
+from vre.core.backends import Repository
 from vre.core.errors import (
     CandidateValidationError,
     CyclicRelationshipError,
@@ -26,6 +27,7 @@ __all__ = [
     "PersistenceError",
     "Provenance",
     "ProvenanceSource",
+    "Repository",
     "ResolutionError",
     "TRANSITIVE_RELATION_TYPES",
     "VREError",

--- a/src/vre/core/backends/__init__.py
+++ b/src/vre/core/backends/__init__.py
@@ -1,0 +1,10 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+from vre.core.backends.neo4j import Neo4jRepository
+from vre.core.backends.repository import Repository
+
+__all__ = [
+    "Neo4jRepository",
+    "Repository",
+]

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -65,6 +65,7 @@ class Neo4jRepository(Repository):
         self._ensure_constraints()
 
     def close(self) -> None:
+        """Close the underlying Neo4j driver and release all connections."""
         self._driver.close()
 
     def _ensure_constraints(self) -> None:
@@ -88,6 +89,7 @@ class Neo4jRepository(Repository):
 
     @staticmethod
     def _depths_to_json(depths: list[Depth]) -> str:
+        """Serialize depth levels and their properties to a JSON string for Neo4j storage."""
         stripped = []
         for depth in depths:
             entry: dict[str, Any] = {
@@ -101,14 +103,17 @@ class Neo4jRepository(Repository):
 
     @staticmethod
     def _parse_json_field(value: Any) -> Any:
+        """Parse a Neo4j property that may be a JSON string or already-decoded dict/list."""
         return json.loads(value) if isinstance(value, str) else value
 
     @staticmethod
     def _dump_model_json(model: Any) -> str | None:
+        """Serialize an optional Pydantic model to a JSON string, or None when absent."""
         return json.dumps(model.model_dump(mode="json")) if model is not None else None
 
     @staticmethod
     def _record_to_node_data(record: Any) -> dict[str, Any]:
+        """Extract the node property dict from a Cypher record row."""
         return {
             "id": record["id"],
             "name": record["name"],
@@ -119,6 +124,7 @@ class Neo4jRepository(Repository):
 
     @staticmethod
     def _record_to_relationships(record: Any) -> list[dict[str, Any]]:
+        """Extract the relationship list from a Cypher record row."""
         return [
             {
                 "rel_type": r["rel_type"],
@@ -140,6 +146,7 @@ class Neo4jRepository(Repository):
         node_data: dict[str, Any],
         relationships: list[dict[str, Any]],
     ) -> Primitive:
+        """Reconstruct a Primitive from raw Neo4j node data and its relationship records."""
         try:
             raw_depths = json.loads(node_data["depths_json"])
             depths_by_level: dict[int, Depth] = {}
@@ -211,6 +218,7 @@ class Neo4jRepository(Repository):
         relata_params: list[dict[str, Any]],
         transitive_types: list[str],
     ) -> None:
+        """Verify that no new transitive edge would create a cycle."""
         type_union = "|".join(transitive_types)
 
         for rp in relata_params:

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -62,11 +62,12 @@ class Neo4jRepository(Repository):
             notifications_disabled_categories=["UNRECOGNIZED"],
         )
         self._database = database
+        self._ensure_constraints()
 
     def close(self) -> None:
         self._driver.close()
 
-    def ensure_constraints(self) -> None:
+    def _ensure_constraints(self) -> None:
         logger.debug("Ensuring uniqueness constraint on Primitive.id")
         try:
             with self._driver.session(database=self._database) as session:

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -2,9 +2,9 @@
 # Licensed under the Apache License, Version 2.0
 
 """
-Neo4j persistence layer for the Volute Reasoning Engine.
+Neo4j persistence backend for the Volute Reasoning Engine.
 
-Provides PrimitiveRepository — the bridge between Pydantic epistemic
+Provides Neo4jRepository — the bridge between Pydantic epistemic
 models and the Neo4j graph database. Primitives are stored as nodes
 with embedded depth JSON; relata are stored as typed Neo4j relationships.
 """
@@ -17,6 +17,7 @@ from uuid import UUID
 from neo4j import GraphDatabase
 from neo4j.exceptions import Neo4jError
 
+from vre.core.backends.repository import Repository
 from vre.core.errors import (
     CyclicRelationshipError,
     GraphError,
@@ -43,9 +44,9 @@ _TRANSITIVE_RELS = [rt.value for rt in TRANSITIVE_RELATION_TYPES]
 logger = logging.getLogger(__name__)
 
 
-class PrimitiveRepository:
+class Neo4jRepository(Repository):
     """
-    Neo4j persistence layer for epistemic primitives.
+    Neo4j persistence backend for epistemic primitives.
     """
 
     def __init__(
@@ -55,9 +56,6 @@ class PrimitiveRepository:
         password: str,
         database: str = "neo4j",
     ) -> None:
-        """
-        Connect to a Neo4j instance at the given URI with the provided credentials.
-        """
         self._driver = GraphDatabase.driver(
             uri,
             auth=(user, password),
@@ -66,27 +64,9 @@ class PrimitiveRepository:
         self._database = database
 
     def close(self) -> None:
-        """
-        Close the underlying Neo4j driver and release all connections.
-        """
         self._driver.close()
 
-    def __enter__(self) -> "PrimitiveRepository":
-        """
-        Enter the context manager, returning self.
-        """
-        return self
-
-    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """
-        Exit the context manager, closing the driver.
-        """
-        self.close()
-
     def ensure_constraints(self) -> None:
-        """
-        Create uniqueness constraint on Primitive.id.
-        """
         logger.debug("Ensuring uniqueness constraint on Primitive.id")
         try:
             with self._driver.session(database=self._database) as session:
@@ -101,11 +81,12 @@ class PrimitiveRepository:
             logger.error("Failed to ensure Neo4j constraints: %s", exc)
             raise GraphError(f"Failed to ensure constraints: {exc}") from exc
 
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
     @staticmethod
     def _depths_to_json(depths: list[Depth]) -> str:
-        """
-        Serialize depth levels and their properties to a JSON string for Neo4j storage.
-        """
         stripped = []
         for depth in depths:
             entry: dict[str, Any] = {
@@ -119,23 +100,14 @@ class PrimitiveRepository:
 
     @staticmethod
     def _parse_json_field(value: Any) -> Any:
-        """
-        Parse a Neo4j property that may be a JSON string or already-decoded dict/list.
-        """
         return json.loads(value) if isinstance(value, str) else value
 
     @staticmethod
     def _dump_model_json(model: Any) -> str | None:
-        """
-        Serialize an optional Pydantic model to a JSON string, or None when absent.
-        """
         return json.dumps(model.model_dump(mode="json")) if model is not None else None
 
     @staticmethod
     def _record_to_node_data(record: Any) -> dict[str, Any]:
-        """
-        Extract the node property dict from a Cypher record row.
-        """
         return {
             "id": record["id"],
             "name": record["name"],
@@ -146,9 +118,6 @@ class PrimitiveRepository:
 
     @staticmethod
     def _record_to_relationships(record: Any) -> list[dict[str, Any]]:
-        """
-        Extract the relationship list from a Cypher record row.
-        """
         return [
             {
                 "rel_type": r["rel_type"],
@@ -170,9 +139,6 @@ class PrimitiveRepository:
         node_data: dict[str, Any],
         relationships: list[dict[str, Any]],
     ) -> Primitive:
-        """
-        Reconstruct a Primitive from raw Neo4j node data and its relationship records.
-        """
         try:
             raw_depths = json.loads(node_data["depths_json"])
             depths_by_level: dict[int, Depth] = {}
@@ -198,7 +164,7 @@ class PrimitiveRepository:
                 rel_prov_json = rel_props.get("provenance")
                 rel_prov = None
                 if rel_prov_json:
-                    rel_prov = Provenance(**PrimitiveRepository._parse_json_field(rel_prov_json))
+                    rel_prov = Provenance(**Neo4jRepository._parse_json_field(rel_prov_json))
 
                 relatum = Relatum(
                     relation_type=RelationType(rel["rel_type"]),
@@ -217,12 +183,12 @@ class PrimitiveRepository:
             node_prov_json = node_data.get("provenance")
             node_prov = None
             if node_prov_json:
-                node_prov = Provenance(**PrimitiveRepository._parse_json_field(node_prov_json))
+                node_prov = Provenance(**Neo4jRepository._parse_json_field(node_prov_json))
 
             node_metrics_json = node_data.get("metrics_json")
             node_metrics = None
             if node_metrics_json:
-                node_metrics = PrimitiveMetrics(**PrimitiveRepository._parse_json_field(node_metrics_json))
+                node_metrics = PrimitiveMetrics(**Neo4jRepository._parse_json_field(node_metrics_json))
 
             return Primitive(
                 id=UUID(node_data["id"]),
@@ -244,14 +210,6 @@ class PrimitiveRepository:
         relata_params: list[dict[str, Any]],
         transitive_types: list[str],
     ) -> None:
-        """
-        Verify that no new transitive edge would create a cycle.
-
-        Called inside the write transaction after old edges have been deleted.
-        For each new transitive relatum, checks whether the target can already
-        reach the source via transitive edges. Raises CyclicRelationshipError
-        on the first cycle found.
-        """
         type_union = "|".join(transitive_types)
 
         for rp in relata_params:
@@ -287,10 +245,11 @@ class PrimitiveRepository:
                     f"{rp['target_id']} would create a cycle"
                 )
 
+    # ------------------------------------------------------------------
+    # Abstract method implementations
+    # ------------------------------------------------------------------
+
     def save_primitive(self, primitive: Primitive) -> None:
-        """
-        Persist a Primitive — full replace of depths and relata.
-        """
         primitive.validate_provenance()
         depths_json = self._depths_to_json(primitive.depths)
 
@@ -343,7 +302,7 @@ class PrimitiveRepository:
                     id=str(primitive.id),
                 )
 
-            PrimitiveRepository._check_transitive_cycles(
+            Neo4jRepository._check_transitive_cycles(
                 tx, str(primitive.id), relata_params, _TRANSITIVE_RELS,
             )
 
@@ -379,31 +338,7 @@ class PrimitiveRepository:
             logger.error("Neo4j error saving primitive %r: %s", primitive.name, exc)
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
 
-    def upsert_primitive(self, primitive: Primitive) -> Primitive:
-        """
-        Save `primitive`, preserving the id of any existing primitive with the
-        same name. Returns the reconciled primitive so callers can cite its
-        canonical id in downstream relata.
-
-        Within-domain idempotency only: depths and relata are full-replaced
-        (per save_primitive). Cross-domain merging is not handled here.
-        """
-        existing = self.find_by_name(primitive.name)
-        if existing is None:
-            canonical = primitive
-        else:
-            logger.info(
-                "Upserting %r: overwriting existing primitive (id=%s)",
-                primitive.name, existing.id,
-            )
-            canonical = primitive.model_copy(update={"id": existing.id})
-        self.save_primitive(canonical)
-        return canonical
-
     def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
-        """
-        Update only the metrics JSON on an existing primitive node.
-        """
         metrics_json = json.dumps(metrics.model_dump(mode="json"))
         try:
             with self._driver.session(database=self._database) as session:
@@ -421,9 +356,6 @@ class PrimitiveRepository:
             raise PersistenceError(f"Failed to update metrics for '{primitive_id}': {exc}") from exc
 
     def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
-        """
-        Read current metrics for multiple primitives in a single query.
-        """
         result: dict[UUID, PrimitiveMetrics | None] = {}
         if primitive_ids:
             cypher = cast(
@@ -454,9 +386,6 @@ class PrimitiveRepository:
         return result
 
     def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
-        """
-        Persist metrics for multiple primitives in a single query.
-        """
         if not updates:
             return
         params = [
@@ -476,9 +405,6 @@ class PrimitiveRepository:
             raise PersistenceError(f"Failed to batch-update metrics: {exc}") from exc
 
     def list_names(self) -> list[str]:
-        """
-        Return the names of all primitives in the graph, sorted alphabetically.
-        """
         try:
             with self._driver.session(database=self._database) as session:
                 result = session.run(
@@ -489,9 +415,6 @@ class PrimitiveRepository:
             raise GraphError(f"Failed to list primitive names: {exc}") from exc
 
     def find_by_id(self, id: UUID) -> Primitive | None:
-        """
-        Look up a primitive by its UUID, returning None if not found.
-        """
         cypher = cast(
             LiteralString,
             """
@@ -534,9 +457,6 @@ class PrimitiveRepository:
         return primitive
 
     def find_by_name(self, name: str) -> Primitive | None:
-        """
-        Look up a primitive by name (case-insensitive), returning None if not found.
-        """
         cypher = cast(
             LiteralString,
             """
@@ -580,9 +500,6 @@ class PrimitiveRepository:
         return primitive
 
     def delete_primitive(self, id: UUID) -> bool:
-        """
-        Delete the primitive with the given UUID and all its relationships. Returns True if deleted.
-        """
         try:
             with self._driver.session(database=self._database) as session:
                 result = session.run(
@@ -596,13 +513,23 @@ class PrimitiveRepository:
         except Neo4jError as exc:
             raise PersistenceError(f"Failed to delete primitive '{id}': {exc}") from exc
 
+    def clear(self) -> int:
+        try:
+            with self._driver.session(database=self._database) as session:
+                result = session.run(
+                    cast(
+                        LiteralString,
+                        "MATCH (p:Primitive) DETACH DELETE p RETURN count(p) AS deleted",
+                    ),
+                ).single()
+                return result["deleted"] if result else 0
+        except Neo4jError as exc:
+            raise PersistenceError(f"Failed to clear graph: {exc}") from exc
+
     def resolve_subgraph(
         self,
         names: list[str],
     ) -> ResolvedSubgraph:
-        """
-        Single-query Cypher traversal that resolves a subgraph for the given names.
-        """
         logger.debug("Resolving subgraph for names=%s", names)
         lowered = [n.lower() for n in names]
 

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -218,7 +218,14 @@ class Neo4jRepository(Repository):
         relata_params: list[dict[str, Any]],
         transitive_types: list[str],
     ) -> None:
-        """Verify that no new transitive edge would create a cycle."""
+        """
+        Verify that no new transitive edge would create a cycle.
+
+        Called inside the write transaction after old edges have been deleted.
+        For each new transitive relatum, checks whether the target can already
+        reach the source via transitive edges. Raises CyclicRelationshipError
+        on the first cycle found.
+        """
         type_union = "|".join(transitive_types)
 
         for rp in relata_params:
@@ -259,6 +266,7 @@ class Neo4jRepository(Repository):
     # ------------------------------------------------------------------
 
     def save_primitive(self, primitive: Primitive) -> None:
+        """Persist a Primitive — full replace of depths and relata."""
         primitive.validate_provenance()
         depths_json = self._depths_to_json(primitive.depths)
 
@@ -348,6 +356,7 @@ class Neo4jRepository(Repository):
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
 
     def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        """Update only the metrics JSON on an existing primitive node."""
         metrics_json = json.dumps(metrics.model_dump(mode="json"))
         try:
             with self._driver.session(database=self._database) as session:
@@ -365,6 +374,7 @@ class Neo4jRepository(Repository):
             raise PersistenceError(f"Failed to update metrics for '{primitive_id}': {exc}") from exc
 
     def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        """Read current metrics for multiple primitives in a single query."""
         result: dict[UUID, PrimitiveMetrics | None] = {}
         if primitive_ids:
             cypher = cast(
@@ -395,6 +405,7 @@ class Neo4jRepository(Repository):
         return result
 
     def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        """Persist metrics for multiple primitives in a single query."""
         if not updates:
             return
         params = [
@@ -414,6 +425,7 @@ class Neo4jRepository(Repository):
             raise PersistenceError(f"Failed to batch-update metrics: {exc}") from exc
 
     def list_names(self) -> list[str]:
+        """Return the names of all primitives in the graph, sorted alphabetically."""
         try:
             with self._driver.session(database=self._database) as session:
                 result = session.run(
@@ -424,6 +436,7 @@ class Neo4jRepository(Repository):
             raise GraphError(f"Failed to list primitive names: {exc}") from exc
 
     def find_by_id(self, id: UUID) -> Primitive | None:
+        """Look up a primitive by its UUID, returning None if not found."""
         cypher = cast(
             LiteralString,
             """
@@ -466,6 +479,7 @@ class Neo4jRepository(Repository):
         return primitive
 
     def find_by_name(self, name: str) -> Primitive | None:
+        """Look up a primitive by name (case-insensitive), returning None if not found."""
         cypher = cast(
             LiteralString,
             """
@@ -509,6 +523,7 @@ class Neo4jRepository(Repository):
         return primitive
 
     def delete_primitive(self, id: UUID) -> bool:
+        """Delete the primitive with the given UUID and all its relationships. Returns True if deleted."""
         try:
             with self._driver.session(database=self._database) as session:
                 result = session.run(
@@ -523,6 +538,7 @@ class Neo4jRepository(Repository):
             raise PersistenceError(f"Failed to delete primitive '{id}': {exc}") from exc
 
     def clear(self) -> int:
+        """Delete every Primitive node and its relationships. Returns the count deleted."""
         try:
             with self._driver.session(database=self._database) as session:
                 result = session.run(
@@ -539,6 +555,7 @@ class Neo4jRepository(Repository):
         self,
         names: list[str],
     ) -> ResolvedSubgraph:
+        """Single-query Cypher traversal that resolves a subgraph for the given names."""
         logger.debug("Resolving subgraph for names=%s", names)
         lowered = [n.lower() for n in names]
 

--- a/src/vre/core/backends/repository.py
+++ b/src/vre/core/backends/repository.py
@@ -74,39 +74,59 @@ class Repository(ABC):
     # ------------------------------------------------------------------
 
     @abstractmethod
-    def find_by_id(self, id: UUID) -> Primitive | None: ...
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        """Look up a primitive by UUID. Returns `None` if not found."""
+        ...
 
     @abstractmethod
-    def find_by_name(self, name: str) -> Primitive | None: ...
+    def find_by_name(self, name: str) -> Primitive | None:
+        """Look up a primitive by name (case-insensitive). Returns `None` if not found."""
+        ...
 
     @abstractmethod
-    def save_primitive(self, primitive: Primitive) -> None: ...
+    def save_primitive(self, primitive: Primitive) -> None:
+        """Persist a primitive — full replace of depths and relata."""
+        ...
 
     @abstractmethod
-    def list_names(self) -> list[str]: ...
+    def list_names(self) -> list[str]:
+        """Return the names of all primitives, sorted alphabetically."""
+        ...
 
     @abstractmethod
-    def delete_primitive(self, id: UUID) -> bool: ...
+    def delete_primitive(self, id: UUID) -> bool:
+        """Delete the primitive with the given UUID and all its relationships. Returns `True` if deleted."""
+        ...
 
     @abstractmethod
-    def clear(self) -> int: ...
+    def clear(self) -> int:
+        """Delete every primitive and its relationships. Returns the count deleted."""
+        ...
 
     # ------------------------------------------------------------------
     # Abstract: metrics
     # ------------------------------------------------------------------
 
     @abstractmethod
-    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None: ...
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        """Update only the metrics on an existing primitive."""
+        ...
 
     @abstractmethod
-    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]: ...
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        """Read current metrics for multiple primitives in a single query."""
+        ...
 
     @abstractmethod
-    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None: ...
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        """Persist metrics for multiple primitives in a single query."""
+        ...
 
     # ------------------------------------------------------------------
     # Abstract: graph traversal
     # ------------------------------------------------------------------
 
     @abstractmethod
-    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph: ...
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        """Single-query traversal that resolves a subgraph for the given concept names."""
+        ...

--- a/src/vre/core/backends/repository.py
+++ b/src/vre/core/backends/repository.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Abstract repository contract for the Volute Reasoning Engine.
+
+Defines the persistence interface that all backends must implement.
+Engine modules depend on this contract, never on a concrete backend.
+"""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Self
+from uuid import UUID
+
+from vre.core.models import (
+    Primitive,
+    PrimitiveMetrics,
+    ResolvedSubgraph,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class Repository(ABC):
+    """
+    Abstract persistence contract for epistemic primitives.
+
+    Concrete backends (Neo4j, SQLite, in-memory) implement the abstract
+    methods; shared logic like upsert and context-manager support lives here.
+    """
+
+    # ------------------------------------------------------------------
+    # Concrete: lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        pass
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Concrete: composite operations
+    # ------------------------------------------------------------------
+
+    def upsert_primitive(self, primitive: Primitive) -> Primitive:
+        """
+        Save `primitive`, preserving the id of any existing primitive with the
+        same name. Returns the reconciled primitive so callers can cite its
+        canonical id in downstream relata.
+
+        Within-domain idempotency only: depths and relata are full-replaced
+        (per save_primitive). Cross-domain merging is not handled here.
+        """
+        existing = self.find_by_name(primitive.name)
+        if existing is None:
+            canonical = primitive
+        else:
+            logger.info(
+                "Upserting %r: overwriting existing primitive (id=%s)",
+                primitive.name, existing.id,
+            )
+            canonical = primitive.model_copy(update={"id": existing.id})
+        self.save_primitive(canonical)
+        return canonical
+
+    # ------------------------------------------------------------------
+    # Abstract: CRUD
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def find_by_id(self, id: UUID) -> Primitive | None: ...
+
+    @abstractmethod
+    def find_by_name(self, name: str) -> Primitive | None: ...
+
+    @abstractmethod
+    def save_primitive(self, primitive: Primitive) -> None: ...
+
+    @abstractmethod
+    def list_names(self) -> list[str]: ...
+
+    @abstractmethod
+    def delete_primitive(self, id: UUID) -> bool: ...
+
+    @abstractmethod
+    def clear(self) -> int: ...
+
+    # ------------------------------------------------------------------
+    # Abstract: metrics
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None: ...
+
+    @abstractmethod
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]: ...
+
+    @abstractmethod
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None: ...
+
+    # ------------------------------------------------------------------
+    # Abstract: graph traversal
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph: ...

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import logging
 from uuid import UUID
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Repository
 from vre.core.grounding.models import GroundingResult
 from vre.core.grounding.resolver import ConceptResolver
 from vre.core.models import (
@@ -58,7 +58,7 @@ class GroundingEngine:
     visibility, and returns a fully closed epistemic response.
     """
 
-    def __init__(self, repository: PrimitiveRepository) -> None:
+    def __init__(self, repository: Repository) -> None:
         """
         Initialize the grounding engine with a primitive repository.
         """

--- a/src/vre/core/grounding/resolver.py
+++ b/src/vre/core/grounding/resolver.py
@@ -15,7 +15,7 @@ import logging
 from functools import lru_cache
 
 from vre.core.errors import ResolutionError
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Repository
 
 
 logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class ConceptResolver:
     3. Return None if no match found — the caller decides how to handle unknowns.
     """
 
-    def __init__(self, repository: PrimitiveRepository) -> None:
+    def __init__(self, repository: Repository) -> None:
         """
         Initialize the resolver with a primitive repository.
         """

--- a/src/vre/core/policy/wizard.py
+++ b/src/vre/core/policy/wizard.py
@@ -13,7 +13,7 @@ import argparse
 import importlib
 from uuid import UUID
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Neo4jRepository, Repository
 from vre.core.models import DepthLevel, RelationType, Relatum, format_depth_label
 from vre.core.policy.models import Cardinality, Policy
 
@@ -76,7 +76,7 @@ def _validate_callback(path: str) -> bool:
 def _display_relata_table(
     primitive,
     name_cache: dict[UUID, str],
-    repo: PrimitiveRepository,
+    repo: Repository,
 ) -> None:
     """
     Print a formatted table of all relata on the primitive, highlighting APPLIES_TO edges.
@@ -181,7 +181,7 @@ def _print_policy_summary(policy: Policy) -> None:
     print()
 
 
-def run_wizard(repo: PrimitiveRepository) -> None:
+def run_wizard(repo: Repository) -> None:
     """
     Run the interactive policy wizard against the given repository.
     """
@@ -273,7 +273,7 @@ def main() -> None:
     parser.add_argument("--neo4j-password", default="password")
     args = parser.parse_args()
 
-    with PrimitiveRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password) as repo:
+    with Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password) as repo:
         run_wizard(repo)
 
 

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -14,7 +14,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from vre.core.errors import CandidateValidationError, CyclicRelationshipError
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Repository
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -66,7 +66,7 @@ class LearningEngine:
     and persists it to the graph.
     """
 
-    def __init__(self, repository: PrimitiveRepository) -> None:
+    def __init__(self, repository: Repository) -> None:
         self._repo = repository
 
     def reachability_prerequisites(

--- a/src/vre/metrics.py
+++ b/src/vre/metrics.py
@@ -11,7 +11,7 @@ import logging
 from datetime import datetime, timezone
 from uuid import UUID
 
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends import Repository
 from vre.core.grounding.models import GroundingResult
 from vre.core.models import (
     PrimitiveMetrics,
@@ -27,7 +27,7 @@ class MetricsManager:
     Internal coordinator for primitive-level grounding metrics.
     """
 
-    def __init__(self, repository: PrimitiveRepository) -> None:
+    def __init__(self, repository: Repository) -> None:
         self._repo = repository
 
     def update_grounding(self, result: GroundingResult) -> None:

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -7,12 +7,14 @@ Uses a StubRepository to avoid Neo4j dependency.
 from collections import deque
 from uuid import UUID, uuid4
 
+from vre.core.backends import Repository
 from vre.core.grounding import GroundingEngine
 from vre.core.models import (
     Depth,
     DepthLevel,
     EpistemicStep,
     Primitive,
+    PrimitiveMetrics,
     Relatum,
     RelationType,
     ResolvedSubgraph,
@@ -26,9 +28,9 @@ from vre.core.models import (
 _TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
 
 
-class StubRepository:
+class StubRepository(Repository):
     """
-    In-memory stand-in for PrimitiveRepository.
+    In-memory stand-in for Repository.
     Supports lookup by name (case-insensitive) and by UUID.
     Implements resolve_subgraph with BFS and relationship type filtering.
     """
@@ -89,6 +91,30 @@ class StubRepository:
                     ))
 
         return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        raise NotImplementedError
+
+    def find_by_name(self, name: str) -> Primitive | None:
+        raise NotImplementedError
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        raise NotImplementedError
+
+    def delete_primitive(self, id: UUID) -> bool:
+        raise NotImplementedError
+
+    def clear(self) -> int:
+        raise NotImplementedError
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        raise NotImplementedError
+
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        raise NotImplementedError
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_graph.py
+++ b/tests/vre/test_graph.py
@@ -1,15 +1,24 @@
 """
-Unit tests for PrimitiveRepository methods that have pure Python logic
-on top of the Neo4j calls. We bypass __init__ (which would require a
-live driver) and substitute the lower-level methods we need.
+Unit tests for Repository.upsert_primitive — the concrete method on the
+abstract base class. _FakeRepo implements the minimum abstract surface
+needed by upsert_primitive.
 """
 
 import logging
+from uuid import UUID
 
 import pytest
 
-from vre.core.graph import PrimitiveRepository
-from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource
+from vre.core.backends import Repository
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    Primitive,
+    PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
+    ResolvedSubgraph,
+)
 
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
@@ -23,8 +32,8 @@ def _make_primitive(name: str) -> Primitive:
     )
 
 
-class _FakeRepo(PrimitiveRepository):
-    """PrimitiveRepository with find_by_name and save_primitive stubbed."""
+class _FakeRepo(Repository):
+    """Repository with find_by_name and save_primitive stubbed."""
 
     def __init__(self) -> None:
         self._existing: Primitive | None = None
@@ -35,6 +44,15 @@ class _FakeRepo(PrimitiveRepository):
 
     def save_primitive(self, primitive: Primitive) -> None:
         self._saved.append(primitive)
+
+    def find_by_id(self, id: UUID) -> Primitive | None: raise NotImplementedError
+    def list_names(self) -> list[str]: raise NotImplementedError
+    def delete_primitive(self, id: UUID) -> bool: raise NotImplementedError
+    def clear(self) -> int: raise NotImplementedError
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None: raise NotImplementedError
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]: raise NotImplementedError
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None: raise NotImplementedError
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph: raise NotImplementedError
 
 
 def test_upsert_creates_when_no_existing() -> None:
@@ -66,7 +84,7 @@ def test_upsert_logs_on_overwrite(caplog: pytest.LogCaptureFixture) -> None:
     repo._existing = _make_primitive("file")
     incoming = _make_primitive("file")
 
-    with caplog.at_level(logging.INFO, logger="vre.core.graph"):
+    with caplog.at_level(logging.INFO, logger="vre.core.backends.repository"):
         repo.upsert_primitive(incoming)
 
     assert any("Upserting 'file'" in r.message for r in caplog.records)
@@ -76,7 +94,7 @@ def test_upsert_does_not_log_when_new(caplog: pytest.LogCaptureFixture) -> None:
     repo = _FakeRepo()
     incoming = _make_primitive("file")
 
-    with caplog.at_level(logging.INFO, logger="vre.core.graph"):
+    with caplog.at_level(logging.INFO, logger="vre.core.backends.repository"):
         repo.upsert_primitive(incoming)
 
     assert not any("Upserting" in r.message for r in caplog.records)

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -10,6 +10,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from vre.core.backends import Repository
 from vre.core.errors import CandidateValidationError, CyclicRelationshipError
 from vre.core.models import (
     Depth,
@@ -17,9 +18,11 @@ from vre.core.models import (
     DepthLevel,
     ExistenceGap,
     Primitive,
+    PrimitiveMetrics,
     Provenance,
     ProvenanceSource,
     ReachabilityGap,
+    ResolvedSubgraph,
     Relatum,
     RelationalGap,
     RelationType,
@@ -68,7 +71,7 @@ def _depth(
     )
 
 
-class StubRepository:
+class StubRepository(Repository):
     """
     In-memory repository for learning engine tests.
     """
@@ -119,6 +122,27 @@ class StubRepository:
         self._by_id[primitive.id] = primitive
         self._by_name[primitive.name.lower()] = primitive
         self.saved.append(primitive)
+
+    def list_names(self) -> list[str]:
+        raise NotImplementedError
+
+    def delete_primitive(self, id: UUID) -> bool:
+        raise NotImplementedError
+
+    def clear(self) -> int:
+        raise NotImplementedError
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        raise NotImplementedError
+
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        raise NotImplementedError
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        raise NotImplementedError
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from uuid import UUID
 
 from vre import VRE
+from vre.core.backends import Repository
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -29,7 +30,7 @@ from vre.core.grounding import GroundingResult
 _TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
 
 
-class StubRepository:
+class StubRepository(Repository):
     def __init__(self, primitives: list[Primitive] | None = None) -> None:
         self._by_id: dict[UUID, Primitive] = {}
         self._by_name: dict[str, Primitive] = {}
@@ -98,6 +99,9 @@ class StubRepository:
                         target_depth=rel.target_depth,
                     ))
         return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+    def delete_primitive(self, id: UUID) -> bool: raise NotImplementedError
+    def clear(self) -> int: raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_provenance.py
+++ b/tests/vre/test_provenance.py
@@ -18,7 +18,7 @@ from vre.core.models import (
     Relatum,
     RelationType,
 )
-from vre.core.graph import PrimitiveRepository
+from vre.core.backends.neo4j import Neo4jRepository
 from vre.core.grounding.models import _fmt_depth, _fmt_primitive, _fmt_relatum
 
 
@@ -214,7 +214,7 @@ def test_depths_to_json_includes_provenance():
     """
     prov = Provenance(source=ProvenanceSource.AUTHORED)
     depths = [Depth(level=DepthLevel.EXISTENCE, provenance=prov)]
-    result = json.loads(PrimitiveRepository._depths_to_json(depths))
+    result = json.loads(Neo4jRepository._depths_to_json(depths))
     assert len(result) == 1
     assert "provenance" in result[0]
     assert result[0]["provenance"]["source"] == "authored"
@@ -225,7 +225,7 @@ def test_depths_to_json_omits_provenance_when_none():
     _depths_to_json omits the provenance key entirely when provenance is None.
     """
     depths = [Depth(level=DepthLevel.EXISTENCE)]
-    result = json.loads(PrimitiveRepository._depths_to_json(depths))
+    result = json.loads(Neo4jRepository._depths_to_json(depths))
     assert "provenance" not in result[0]
 
 
@@ -259,7 +259,7 @@ def test_hydrate_primitive_with_provenance():
     )
 
     # Serialize
-    depths_json = PrimitiveRepository._depths_to_json(primitive.depths)
+    depths_json = Neo4jRepository._depths_to_json(primitive.depths)
     node_prov_json = json.dumps(prov.model_dump(mode="json"))
     rel_prov = Provenance(source=ProvenanceSource.CONVERSATIONAL)
     rel_prov_json = json.dumps(rel_prov.model_dump(mode="json"))
@@ -285,7 +285,7 @@ def test_hydrate_primitive_with_provenance():
     ]
 
     # Deserialize
-    hydrated = PrimitiveRepository._hydrate_primitive(node_data, relationships)
+    hydrated = Neo4jRepository._hydrate_primitive(node_data, relationships)
 
     # Node provenance
     assert hydrated.provenance is not None
@@ -316,7 +316,7 @@ def test_hydrate_primitive_without_provenance():
         "name": "legacy",
         "depths_json": json.dumps([{"level": 0, "properties": {}}]),
     }
-    hydrated = PrimitiveRepository._hydrate_primitive(node_data, [])
+    hydrated = Neo4jRepository._hydrate_primitive(node_data, [])
     assert hydrated.provenance is None
     assert hydrated.depths[0].provenance is None
 

--- a/tests/vre/test_tracing.py
+++ b/tests/vre/test_tracing.py
@@ -9,6 +9,7 @@ from collections import deque
 from uuid import UUID, uuid4
 
 from vre import VRE
+from vre.core.backends import Repository
 from vre.core.grounding import GroundingResult
 from vre.core.models import (
     Depth,
@@ -33,7 +34,7 @@ from vre.tracing import TraceWriter, build_trace_entry
 _TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
 
 
-class StubRepository:
+class StubRepository(Repository):
     def __init__(self, primitives: list[Primitive] | None = None) -> None:
         self._by_id: dict[UUID, Primitive] = {}
         self._by_name: dict[str, Primitive] = {}
@@ -100,6 +101,9 @@ class StubRepository:
                         target_depth=rel.target_depth,
                     ))
         return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+    def delete_primitive(self, id: UUID) -> bool: raise NotImplementedError
+    def clear(self) -> int: raise NotImplementedError
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -8,6 +8,7 @@ from collections import deque
 from uuid import UUID
 
 from vre import VRE
+from vre.core.backends import Repository
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -30,7 +31,7 @@ from vre.learning import LearningEngine
 _TRANSITIVE_RELS = {RelationType.REQUIRES, RelationType.DEPENDS_ON, RelationType.CONSTRAINED_BY}
 
 
-class StubRepository:
+class StubRepository(Repository):
     def __init__(self, primitives: list[Primitive] | None = None) -> None:
         self._by_id: dict[UUID, Primitive] = {}
         self._by_name: dict[str, Primitive] = {}
@@ -99,6 +100,9 @@ class StubRepository:
                         target_depth=rel.target_depth,
                     ))
         return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)
+
+    def delete_primitive(self, id: UUID) -> bool: raise NotImplementedError
+    def clear(self) -> int: raise NotImplementedError
 
 
 def _make_fully_grounded(name: str) -> Primitive:


### PR DESCRIPTION
## Summary

- Extract abstract `Repository` base class (`abc.ABC`) into new `core/backends/` package with 10 abstract methods and 4 concrete methods (upsert, close, context manager)
- Rename `PrimitiveRepository` to `Neo4jRepository` and move from `core/graph.py` to `core/backends/neo4j.py`
- Add `clear() -> int` to the abstract surface — `Neo4jRepository` absorbs the Cypher from `clear_graph.py`
- Engine modules (`GroundingEngine`, `ConceptResolver`, `LearningEngine`, `MetricsManager`) now depend on the ABC, not the concrete class
- Scripts and seeders use `Repository` type hints for backend-agnostic signatures; only entry points instantiate `Neo4jRepository`
- All test stubs subclass `Repository` to validate the ABC contract
- Clean break — no backward-compat alias (pre-v1.0.0)

Closes #69

## Test plan

- [x] All 251 existing tests pass (`poetry run pytest`)
- [x] Zero remaining references to `PrimitiveRepository` or `from vre.core.graph`
- [x] Import verification: `from vre import VRE, Repository, Neo4jRepository`

🤖 Generated with [Claude Code](https://claude.com/claude-code)