### PR TITLE
Implement SQLiteRepository backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,20 @@ After installation, download the spaCy language model:
 python -m spacy download en_core_web_sm
 ```
 
+VRE ships with a **SQLite backend** that works out of the box — no external services required.
+The database defaults to `~/.vre/graph.db` and is created automatically on first use.
+
+For production deployments or larger graphs, an optional **Neo4j backend** is available:
+
+```bash
+pip install vre[neo4j]
+```
+
 ### Infrastructure
 
-VRE requires a running Neo4j instance for the epistemic graph:
+**SQLite (default)** — no setup needed. The database file is created automatically.
+
+**Neo4j (optional)** — requires a running Neo4j instance:
 
 ```bash
 docker run -d \
@@ -201,9 +212,6 @@ docker run -d \
 -e NEO4J_AUTH=neo4j/password \
 neo4j:latest
 ```
-
-If you already have neo4j installed locally, ensure it is running and note the connection details
-(URI, username, password) for use in the next steps.
 
 ### Seeding the Graph
 
@@ -214,14 +222,19 @@ produce its deterministic output. Use `scripts/clear_graph.py` if you want
 a clean slate before seeding. See [`scripts/README.md`](scripts/README.md)
 for details.
 
+All scripts default to the SQLite backend. Pass `--backend neo4j` with
+connection flags to use Neo4j instead.
+
 ```bash
 # Fully grounded filesystem domain — 20 primitives, all at D3+ with complete relata
-python seeders/seed_filesystem.py \
---neo4j-uri neo4j://localhost:7687 --neo4j-user neo4j --neo4j-password password
+python seeders/seed_filesystem.py
 
 # Gap demonstration graph — 10 primitives, deliberately shaped to produce each gap type
-python scripts/seed_gaps.py \
---neo4j-uri neo4j://localhost:7687 --neo4j-user neo4j --neo4j-password password
+python scripts/seed_gaps.py
+
+# Same commands with Neo4j:
+python seeders/seed_filesystem.py \
+    --backend neo4j --neo4j-uri neo4j://localhost:7687 --neo4j-user neo4j --neo4j-password password
 ```
 
 ---
@@ -229,6 +242,15 @@ python scripts/seed_gaps.py \
 ## Core API
 
 ### Connecting to VRE
+
+```python
+from vre import VRE, SQLiteRepository
+
+repo = SQLiteRepository()  # defaults to ~/.vre/graph.db
+vre = VRE(repo)
+```
+
+Or with Neo4j:
 
 ```python
 from vre import VRE
@@ -679,7 +701,7 @@ against a sandboxed filesystem.
 
 #### Prerequisites
 
-In addition to Neo4j, this example requires [Ollama](https://ollama.com/) running locally:
+This example requires [Ollama](https://ollama.com/) running locally:
 
 ```bash
 brew install ollama
@@ -695,7 +717,15 @@ poetry install --extras examples
 #### Running
 
 ```bash
+# SQLite (default — no setup needed)
 poetry run python -m examples.langchain_ollama.main \
+    --model qwen3:8b \
+    --concepts-model qwen2.5-coder:7b \
+    --sandbox examples/langchain_ollama/workspace
+
+# Neo4j
+poetry run python -m examples.langchain_ollama.main \
+    --backend neo4j \
     --neo4j-uri neo4j://localhost:7687 \
     --neo4j-user neo4j \
     --neo4j-password password \
@@ -764,11 +794,15 @@ lets Claude itself propose the conceptual primitives, using a two-pass protocol.
 #### Install
 
 ```bash
+# SQLite (default — zero config)
+poetry run python examples/claude-code/claude_code.py install
+
+# Neo4j
 poetry run python examples/claude-code/claude_code.py install \
-    --uri neo4j://localhost:7687 --user neo4j --password password
+    --backend neo4j --uri neo4j://localhost:7687 --user neo4j --password password
 ```
 
-This writes your Neo4j connection details to `~/.vre/config.json` and injects a `PreToolUse` hook entry into
+This writes your backend configuration to `~/.vre/config.json` and injects a `PreToolUse` hook entry into
 `~/.claude/settings.json` that matches all `Bash` tool calls. Safe to call multiple times —
 existing VRE hook entries are replaced, not duplicated.
 
@@ -836,13 +870,13 @@ grounding history, and affect the agent's confidence in related concepts.
 
 ## Tech Stack
 
-| Concern            | Technology               |
-|--------------------|--------------------------|
-| Language           | Python 3.12+             |
-| Epistemic graph    | Neo4j                    |
-| Concept resolution | spaCy (`en_core_web_sm`) |
-| Data models        | Pydantic v2              |
-| Package management | Poetry                   |
+| Concern            | Technology                                    |
+|--------------------|-----------------------------------------------|
+| Language           | Python 3.12+                                  |
+| Epistemic graph    | SQLite (default) or Neo4j (`pip install vre[neo4j]`) |
+| Concept resolution | spaCy (`en_core_web_sm`)                      |
+| Data models        | Pydantic v2                                   |
+| Package management | Poetry                                        |
 
 
 ---
@@ -865,7 +899,8 @@ src/vre/
 │   ├── errors.py                # VREError hierarchy — typed exceptions for all failure modes
 │   ├── backends/
 │   │   ├── repository.py        # Repository ABC — abstract persistence contract
-│   │   └── neo4j.py             # Neo4jRepository — Neo4j backend
+│   │   ├── sqlite.py            # SQLiteRepository — SQLite backend (default)
+│   │   └── neo4j.py             # Neo4jRepository — Neo4j backend (optional)
 │   ├── grounding/
 │   │   ├── resolver.py          # ConceptResolver — spaCy lemmatization + name lookup
 │   │   ├── engine.py            # GroundingEngine — depth-gated query, gap detection
@@ -882,7 +917,7 @@ src/vre/
     └── engine.py                # LearningEngine — learn_gap, reachability_prerequisites
 
 scripts/
-├── clear_graph.py               # Clear all primitives from the Neo4j graph
+├── clear_graph.py               # Clear all primitives from the graph
 └── seed_gaps.py                 # Seed gap-demonstration graph (10 primitives)
 
 seeders/

--- a/examples/claude-code/claude_code.py
+++ b/examples/claude-code/claude_code.py
@@ -246,11 +246,18 @@ def _run_hook() -> None:
         config = json.loads(_VRE_CONFIG_PATH.read_text())
 
         from vre import VRE, PolicyAction
-        from vre.core.backends import Neo4jRepository
 
-        with Neo4jRepository(
-            config["uri"], config["user"], config["password"], config.get("database", "neo4j")
-        ) as repo:
+        backend = config.get("backend", "neo4j")
+        if backend == "sqlite":
+            from vre.core.backends import SQLiteRepository
+            repo_ctx = SQLiteRepository(config.get("path"))
+        else:
+            from vre.core.backends import Neo4jRepository
+            repo_ctx = Neo4jRepository(
+                config["uri"], config["user"], config["password"],
+                config.get("database", "neo4j"),
+            )
+        with repo_ctx as repo:
             vre = VRE(repo)
             grounding = vre.check(concepts)
 

--- a/examples/claude-code/claude_code.py
+++ b/examples/claude-code/claude_code.py
@@ -44,6 +44,10 @@ import shlex
 import sys
 from pathlib import Path
 
+from vre import VRE, PolicyAction
+from vre.core.backends import Neo4jRepository, SQLiteRepository
+
+
 _SETTINGS_PATH = Path.home() / ".claude" / "settings.json"
 _VRE_CONFIG_PATH = Path.home() / ".vre" / "config.json"
 
@@ -265,14 +269,10 @@ def _run_hook() -> None:
 
         config = json.loads(_VRE_CONFIG_PATH.read_text())
 
-        from vre import VRE, PolicyAction
-
         backend = config.get("backend", "sqlite")
         if backend == "sqlite":
-            from vre.core.backends import SQLiteRepository
             repo_ctx = SQLiteRepository(config.get("path"))
         else:
-            from vre.core.backends import Neo4jRepository
             repo_ctx = Neo4jRepository(
                 config["uri"], config["user"], config["password"],
                 config.get("database", "neo4j"),

--- a/examples/claude-code/claude_code.py
+++ b/examples/claude-code/claude_code.py
@@ -17,10 +17,14 @@ VRE grounding and policy evaluation using a two-pass protocol:
 This lets Claude — the LLM — propose the concepts itself rather than
 relying on a static command-to-concept map.
 
-Setup::
+Setup (SQLite — default, zero config)::
+
+    python examples/claude-code/claude_code.py install
+
+Setup (Neo4j)::
 
     python examples/claude-code/claude_code.py install \
-        --uri neo4j://localhost:7687 --user neo4j --password password
+        --backend neo4j --uri neo4j://localhost:7687 --user neo4j --password password
 
 Removal::
 
@@ -122,19 +126,35 @@ def _block(message: str) -> None:
     sys.exit(_EXIT_BLOCK)
 
 
-def install(uri: str, user: str, password: str, database: str = "neo4j") -> None:
+def install(
+    backend: str = "sqlite",
+    uri: str | None = None,
+    user: str | None = None,
+    password: str | None = None,
+    database: str = "neo4j",
+    path: str | None = None,
+) -> None:
     """
     Install the VRE PreToolUse hook into Claude Code's settings.
 
-    Writes Neo4j connection details to ~/.vre/config.json and injects
+    Writes backend configuration to ~/.vre/config.json and injects
     the hook entry into ~/.claude/settings.json. Safe to call multiple
     times — existing VRE hook entries are replaced, not duplicated.
     """
     _VRE_CONFIG_PATH.parent.mkdir(parents=True, exist_ok=True)
-    _VRE_CONFIG_PATH.write_text(json.dumps(
-        {"uri": uri, "user": user, "password": password, "database": database},
-        indent=2,
-    ))
+    if backend == "sqlite":
+        config: dict = {"backend": "sqlite"}
+        if path is not None:
+            config["path"] = path
+    else:
+        config = {
+            "backend": "neo4j",
+            "uri": uri,
+            "user": user,
+            "password": password,
+            "database": database,
+        }
+    _VRE_CONFIG_PATH.write_text(json.dumps(config, indent=2))
     _VRE_CONFIG_PATH.chmod(0o600)
 
     _SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
@@ -292,17 +312,34 @@ if __name__ == "__main__":
     sub = parser.add_subparsers(dest="command")
 
     inst = sub.add_parser("install", help="Install the VRE PreToolUse hook")
-    inst.add_argument("--uri", required=True)
-    inst.add_argument("--user", required=True)
-    inst.add_argument("--password", required=True)
-    inst.add_argument("--database", default="neo4j")
+    inst.add_argument("--backend", choices=["neo4j", "sqlite"], default="sqlite",
+                      help="Persistence backend (default: sqlite)")
+
+    neo4j = inst.add_argument_group("neo4j", "Options for --backend neo4j")
+    neo4j.add_argument("--uri", default=None)
+    neo4j.add_argument("--user", default=None)
+    neo4j.add_argument("--password", default=None)
+    neo4j.add_argument("--database", default="neo4j")
+
+    sqlite = inst.add_argument_group("sqlite", "Options for --backend sqlite")
+    sqlite.add_argument("--path", default=None,
+                        help="Database path (default: ~/.vre/graph.db)")
 
     sub.add_parser("uninstall", help="Remove the VRE PreToolUse hook")
 
     args = parser.parse_args()
 
     if args.command == "install":
-        install(args.uri, args.user, args.password, args.database)
+        if args.backend == "neo4j" and not all([args.uri, args.user, args.password]):
+            parser.error("--backend neo4j requires --uri, --user, and --password")
+        install(
+            backend=args.backend,
+            uri=args.uri,
+            user=args.user,
+            password=args.password,
+            database=args.database,
+            path=args.path,
+        )
     elif args.command == "uninstall":
         uninstall()
     else:

--- a/examples/claude-code/claude_code.py
+++ b/examples/claude-code/claude_code.py
@@ -247,7 +247,7 @@ def _run_hook() -> None:
 
         from vre import VRE, PolicyAction
 
-        backend = config.get("backend", "neo4j")
+        backend = config.get("backend", "sqlite")
         if backend == "sqlite":
             from vre.core.backends import SQLiteRepository
             repo_ctx = SQLiteRepository(config.get("path"))

--- a/examples/langchain_ollama/main.py
+++ b/examples/langchain_ollama/main.py
@@ -13,6 +13,7 @@ import os
 from langchain_core.tools import StructuredTool
 
 from vre import VRE
+from vre.core.backends import Neo4jRepository, SQLiteRepository
 
 from examples.langchain_ollama.agent import make_agent
 from examples.langchain_ollama.callbacks import ConceptExtractor, get_cardinality, on_policy, on_trace
@@ -42,10 +43,8 @@ def main() -> None:
     os.makedirs(args.sandbox, exist_ok=True)
 
     if args.backend == "sqlite":
-        from vre.core.backends import SQLiteRepository
         repo = SQLiteRepository(args.sqlite_path)
     else:
-        from vre.core.backends import Neo4jRepository
         repo = Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
     vre = VRE(repo, agent_key="langchain-ollama-demo-agent", agent_name="Langchain Ollama Demo Agent")
 

--- a/examples/langchain_ollama/main.py
+++ b/examples/langchain_ollama/main.py
@@ -23,14 +23,20 @@ from examples.langchain_ollama.tools import init_tools, init_learn_tool
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="VRE Demo Agent")
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
     parser.add_argument("--model", default="gemma4:26b")
     parser.add_argument("--sandbox", default="examples/langchain_ollama/workspace")
     parser.add_argument("--concepts-model", default="qwen2.5-coder:7b")
-    parser.add_argument("--backend", choices=["neo4j", "sqlite"], default="neo4j")
-    parser.add_argument("--sqlite-path", default=None)
+    parser.add_argument("--backend", choices=["neo4j", "sqlite"], default="sqlite",
+                        help="Persistence backend (default: sqlite)")
+
+    neo4j = parser.add_argument_group("neo4j", "Options for --backend neo4j")
+    neo4j.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
+    neo4j.add_argument("--neo4j-user", default="neo4j")
+    neo4j.add_argument("--neo4j-password", default="password")
+
+    sqlite = parser.add_argument_group("sqlite", "Options for --backend sqlite")
+    sqlite.add_argument("--sqlite-path", default=None,
+                        help="Database path (default: ~/.vre/graph.db)")
     args = parser.parse_args()
 
     os.makedirs(args.sandbox, exist_ok=True)

--- a/examples/langchain_ollama/main.py
+++ b/examples/langchain_ollama/main.py
@@ -13,7 +13,6 @@ import os
 from langchain_core.tools import StructuredTool
 
 from vre import VRE
-from vre.core.backends import Neo4jRepository
 
 from examples.langchain_ollama.agent import make_agent
 from examples.langchain_ollama.callbacks import ConceptExtractor, get_cardinality, on_policy, on_trace
@@ -30,11 +29,18 @@ def main() -> None:
     parser.add_argument("--model", default="gemma4:26b")
     parser.add_argument("--sandbox", default="examples/langchain_ollama/workspace")
     parser.add_argument("--concepts-model", default="qwen2.5-coder:7b")
+    parser.add_argument("--backend", choices=["neo4j", "sqlite"], default="neo4j")
+    parser.add_argument("--sqlite-path", default=None)
     args = parser.parse_args()
 
     os.makedirs(args.sandbox, exist_ok=True)
 
-    repo = Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
+    if args.backend == "sqlite":
+        from vre.core.backends import SQLiteRepository
+        repo = SQLiteRepository(args.sqlite_path)
+    else:
+        from vre.core.backends import Neo4jRepository
+        repo = Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)
     vre = VRE(repo, agent_key="langchain-ollama-demo-agent", agent_name="Langchain Ollama Demo Agent")
 
     concepts = ConceptExtractor(model=args.concepts_model)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ requires-python = ">=3.12,<4.0"
 dependencies = [
     "pydantic>=2.0",
     "spacy>=3.8",
+    "click>=8.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,13 @@ readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
     "pydantic>=2.0",
-    "neo4j>=5.0,<7.0",
     "spacy>=3.8",
 ]
 
 [project.optional-dependencies]
+neo4j = ["neo4j>=5.0,<7.0"]
 examples = [
+    "neo4j>=5.0,<7.0",
     "rich>=14.3.2",
     "langchain-core>=1.2.16",
     "langchain-ollama>=1.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.7.0"
+version = "0.8.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,6 +1,6 @@
 import argparse
 
-from vre.core.backends import Repository
+from vre.core.backends import Neo4jRepository, Repository, SQLiteRepository
 
 
 def add_backend_args(parser: argparse.ArgumentParser) -> None:
@@ -26,7 +26,5 @@ def add_backend_args(parser: argparse.ArgumentParser) -> None:
 
 def make_repository(args: argparse.Namespace) -> Repository:
     if args.backend == "sqlite":
-        from vre.core.backends import SQLiteRepository
         return SQLiteRepository(args.sqlite_path)
-    from vre.core.backends import Neo4jRepository
     return Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,28 @@
+import argparse
+
+from vre.core.backends import Repository
+
+
+def add_backend_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--backend",
+        choices=["neo4j", "sqlite"],
+        default="neo4j",
+        help="Persistence backend (default: neo4j)",
+    )
+    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
+    parser.add_argument("--neo4j-user", default="neo4j")
+    parser.add_argument("--neo4j-password", default="password")
+    parser.add_argument(
+        "--sqlite-path",
+        default=None,
+        help="SQLite database path (default: ~/.vre/graph.db, use ':memory:' for in-memory)",
+    )
+
+
+def make_repository(args: argparse.Namespace) -> Repository:
+    if args.backend == "sqlite":
+        from vre.core.backends import SQLiteRepository
+        return SQLiteRepository(args.sqlite_path)
+    from vre.core.backends import Neo4jRepository
+    return Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -7,16 +7,20 @@ def add_backend_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--backend",
         choices=["neo4j", "sqlite"],
-        default="neo4j",
-        help="Persistence backend (default: neo4j)",
+        default="sqlite",
+        help="Persistence backend (default: sqlite)",
     )
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
-    parser.add_argument(
+
+    neo4j = parser.add_argument_group("neo4j", "Options for --backend neo4j")
+    neo4j.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
+    neo4j.add_argument("--neo4j-user", default="neo4j")
+    neo4j.add_argument("--neo4j-password", default="password")
+
+    sqlite = parser.add_argument_group("sqlite", "Options for --backend sqlite")
+    sqlite.add_argument(
         "--sqlite-path",
         default=None,
-        help="SQLite database path (default: ~/.vre/graph.db, use ':memory:' for in-memory)",
+        help="Database path (default: ~/.vre/graph.db, use ':memory:' for in-memory)",
     )
 
 

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -8,6 +8,7 @@ Run: python scripts/clear_graph.py
 import argparse
 
 from vre.core.backends import Repository
+from scripts import add_backend_args, make_repository
 
 
 def clear_graph(repo: Repository) -> int:
@@ -18,8 +19,6 @@ def clear_graph(repo: Repository) -> int:
 
 
 if __name__ == "__main__":
-    import argparse
-    from scripts import add_backend_args, make_repository
 
     parser = argparse.ArgumentParser(description="Clear all VRE graph data")
     add_backend_args(parser)

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -1,30 +1,19 @@
 """
-Clear all primitives and relationships from a VRE repository.
-
-Can be run standalone or imported by seed scripts to ensure a clean slate.
+Clear all primitives and relata from a VRE repository.
 
 Run: python scripts/clear_graph.py
 """
 import argparse
 
 from scripts import add_backend_args, make_repository
-from vre.core.backends import Repository
-
-
-def clear_graph(repo: Repository) -> int:
-    """
-    Delete every Primitive and its relationships. Returns the count deleted.
-    """
-    return repo.clear()
 
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser(description="Clear all VRE graph data")
     add_backend_args(parser)
     args = parser.parse_args()
 
     repo = make_repository(args)
     with repo:
-        deleted = clear_graph(repo)
+        deleted = repo.clear()
         print(f"Cleared {deleted} primitive(s) from the graph.")

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -7,7 +7,7 @@ Run: python scripts/clear_graph.py
 """
 import argparse
 
-from vre.core.backends import Neo4jRepository, Repository
+from vre.core.backends import Repository
 
 
 def clear_graph(repo: Repository) -> int:
@@ -18,18 +18,14 @@ def clear_graph(repo: Repository) -> int:
 
 
 if __name__ == "__main__":
+    import argparse
+    from scripts import add_backend_args, make_repository
+
     parser = argparse.ArgumentParser(description="Clear all VRE graph data")
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
+    add_backend_args(parser)
     args = parser.parse_args()
 
-    repo = Neo4jRepository(
-        uri=args.neo4j_uri,
-        user=args.neo4j_user,
-        password=args.neo4j_password,
-    )
-
+    repo = make_repository(args)
     with repo:
         deleted = clear_graph(repo)
         print(f"Cleared {deleted} primitive(s) from the graph.")

--- a/scripts/clear_graph.py
+++ b/scripts/clear_graph.py
@@ -7,8 +7,8 @@ Run: python scripts/clear_graph.py
 """
 import argparse
 
-from vre.core.backends import Repository
 from scripts import add_backend_args, make_repository
+from vre.core.backends import Repository
 
 
 def clear_graph(repo: Repository) -> int:

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -12,7 +12,7 @@ Run: python scripts/seed_gaps.py
 import argparse
 
 from scripts.clear_graph import clear_graph
-from vre.core.backends import Neo4jRepository, Repository
+from vre.core.backends import Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
@@ -682,16 +682,11 @@ Expected gap scenarios:
 
 
 if __name__ == "__main__":
+    from scripts import add_backend_args, make_repository
+
     parser = argparse.ArgumentParser(description="Depth-Gated Gap Demonstration Seeder")
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
+    add_backend_args(parser)
     args = parser.parse_args()
 
-    repo = Neo4jRepository(
-        uri=args.neo4j_uri,
-        user=args.neo4j_user,
-        password=args.neo4j_password,
-    )
-
+    repo = make_repository(args)
     main(repository=repo)

--- a/scripts/seed_gaps.py
+++ b/scripts/seed_gaps.py
@@ -11,7 +11,7 @@ Run: python scripts/seed_gaps.py
 """
 import argparse
 
-from scripts.clear_graph import clear_graph
+from scripts import add_backend_args, make_repository
 from vre.core.backends import Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
@@ -628,7 +628,7 @@ def seed_create(repo: Repository, file: Primitive, directory: Primitive) -> Prim
 
 def main(repository: Repository) -> None:
     with repository as repo:
-        deleted = clear_graph(repo)
+        deleted = repo.clear()
 
         print(f"Cleared {deleted} existing primitive(s).")
         print("Seeding gap-demonstration graph (10 primitives):\n")
@@ -682,8 +682,6 @@ Expected gap scenarios:
 
 
 if __name__ == "__main__":
-    from scripts import add_backend_args, make_repository
-
     parser = argparse.ArgumentParser(description="Depth-Gated Gap Demonstration Seeder")
     add_backend_args(parser)
     args = parser.parse_args()

--- a/seeders/seed_filesystem.py
+++ b/seeders/seed_filesystem.py
@@ -12,6 +12,7 @@ Run: python seeders/seed_filesystem.py
 """
 import argparse
 
+from scripts import add_backend_args, make_repository
 from vre.core.backends import Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
@@ -2104,8 +2105,6 @@ def main(repository: Repository) -> None:
 
 
 if __name__ == "__main__":
-    from scripts import add_backend_args, make_repository
-
     parser = argparse.ArgumentParser(description="Fully Grounded Graph Seeder")
     add_backend_args(parser)
     args = parser.parse_args()

--- a/seeders/seed_filesystem.py
+++ b/seeders/seed_filesystem.py
@@ -12,7 +12,7 @@ Run: python seeders/seed_filesystem.py
 """
 import argparse
 
-from vre.core.backends import Neo4jRepository, Repository
+from vre.core.backends import Repository
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource, Relatum, RelationType
 
 SEED_PROVENANCE = Provenance(source=ProvenanceSource.AUTHORED)
@@ -2104,16 +2104,11 @@ def main(repository: Repository) -> None:
 
 
 if __name__ == "__main__":
+    from scripts import add_backend_args, make_repository
+
     parser = argparse.ArgumentParser(description="Fully Grounded Graph Seeder")
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
+    add_backend_args(parser)
     args = parser.parse_args()
 
-    repo = Neo4jRepository(
-        uri=args.neo4j_uri,
-        user=args.neo4j_user,
-        password=args.neo4j_password,
-    )
-
+    repo = make_repository(args)
     main(repository=repo)

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -6,10 +6,9 @@ Volute Reasoning Engine — decorator-based epistemic enforcement.
 
 Usage::
 
-    from vre import VRE
-    from vre.core.backends import Neo4jRepository
+    from vre import VRE, SQLiteRepository
 
-    repo = Neo4jRepository("neo4j://localhost:7687", "neo4j", "password")
+    repo = SQLiteRepository()  # defaults to ~/.vre/graph.db; pass ":memory:" for testing
     vre = VRE(repo)
     result = vre.check(["file", "write"])
     print(result.grounded, result.resolved)
@@ -30,7 +29,12 @@ from vre.core.errors import (
     ResolutionError,
     VREError,
 )
-from vre.core.backends import Neo4jRepository, Repository
+from vre.core.backends import Repository, SQLiteRepository
+
+try:
+    from vre.core.backends import Neo4jRepository
+except ImportError:
+    pass
 from vre.core.grounding import ConceptResolver, GroundingEngine, GroundingResult
 from vre.core.models import (
     DepthLevel,
@@ -65,6 +69,7 @@ __all__ = [
     "VREError",
     "Neo4jRepository",
     "Repository",
+    "SQLiteRepository",
     "ConceptResolver",
     "GroundingEngine",
     "GroundingResult",

--- a/src/vre/core/backends/__init__.py
+++ b/src/vre/core/backends/__init__.py
@@ -10,7 +10,7 @@ __all__ = [
 ]
 
 try:
-    from vre.core.backends.neo4j import Neo4jRepository
+    from vre.core.backends.neo4j import Neo4jRepository  # noqa: F401
     __all__.append("Neo4jRepository")
 except ImportError:
     pass

--- a/src/vre/core/backends/__init__.py
+++ b/src/vre/core/backends/__init__.py
@@ -1,10 +1,16 @@
 # Copyright 2026 Andrew Greene
 # Licensed under the Apache License, Version 2.0
 
-from vre.core.backends.neo4j import Neo4jRepository
 from vre.core.backends.repository import Repository
+from vre.core.backends.sqlite import SQLiteRepository
 
 __all__ = [
-    "Neo4jRepository",
     "Repository",
+    "SQLiteRepository",
 ]
+
+try:
+    from vre.core.backends.neo4j import Neo4jRepository
+    __all__.append("Neo4jRepository")
+except ImportError:
+    pass

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -23,8 +23,8 @@ Schema
 
     CREATE TABLE IF NOT EXISTS relata (
         id            INTEGER PRIMARY KEY AUTOINCREMENT,
-        source_id     TEXT NOT NULL REFERENCES primitives(id),
-        target_id     TEXT NOT NULL REFERENCES primitives(id),
+        source_id     TEXT NOT NULL REFERENCES primitives(id) ON DELETE CASCADE,
+        target_id     TEXT NOT NULL REFERENCES primitives(id) ON DELETE CASCADE,
         rel_type      TEXT NOT NULL,
         source_depth  INTEGER NOT NULL,
         target_depth  INTEGER NOT NULL,
@@ -84,8 +84,8 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
 
 CREATE TABLE IF NOT EXISTS relata (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
-    source_id     TEXT NOT NULL REFERENCES primitives(id),
-    target_id     TEXT NOT NULL REFERENCES primitives(id),
+    source_id     TEXT NOT NULL REFERENCES primitives(id) ON DELETE CASCADE,
+    target_id     TEXT NOT NULL REFERENCES primitives(id) ON DELETE CASCADE,
     rel_type      TEXT NOT NULL,
     source_depth  INTEGER NOT NULL,
     target_depth  INTEGER NOT NULL,
@@ -429,41 +429,29 @@ class SQLiteRepository(Repository):
     def list_names(self) -> list[str]:
         """Return the names of all primitives, sorted alphabetically."""
         rows = self._conn.execute(
-            "SELECT name FROM primitives ORDER BY name"
+            "SELECT name FROM primitives ORDER BY name COLLATE NOCASE"
         ).fetchall()
         return [r["name"] for r in rows]
 
     def delete_primitive(self, id: UUID) -> bool:
-        """Delete the primitive with the given UUID and all its relata. Returns True if deleted."""
-        sid = str(id)
+        """Delete the primitive with the given UUID. Relata are cascade-deleted by the FK constraint."""
         try:
-            self._conn.execute("BEGIN")
-            self._conn.execute(
-                "DELETE FROM relata WHERE source_id = ? OR target_id = ?",
-                (sid, sid),
-            )
             cursor = self._conn.execute(
                 "DELETE FROM primitives WHERE id = ?",
-                (sid,),
+                (str(id),),
             )
-            self._conn.commit()
             return cursor.rowcount > 0
         except sqlite3.Error as exc:
-            self._conn.rollback()
             raise PersistenceError(
                 f"Failed to delete primitive '{id}': {exc}"
             ) from exc
 
     def clear(self) -> int:
-        """Delete every primitive and its relata. Returns the count deleted."""
+        """Delete every primitive. Relata are cascade-deleted by the FK constraint."""
         try:
-            self._conn.execute("BEGIN")
-            self._conn.execute("DELETE FROM relata")
             cursor = self._conn.execute("DELETE FROM primitives")
-            self._conn.commit()
             return cursor.rowcount
         except sqlite3.Error as exc:
-            self._conn.rollback()
             raise PersistenceError(f"Failed to clear graph: {exc}") from exc
 
     # ------------------------------------------------------------------

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -1,0 +1,623 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+SQLite persistence backend for the Volute Reasoning Engine.
+
+Provides SQLiteRepository -- a zero-external-dependency backend that
+implements the Repository ABC using a local SQLite database.
+
+Schema
+------
+::
+
+    CREATE TABLE IF NOT EXISTS primitives (
+        id              TEXT PRIMARY KEY,
+        name            TEXT NOT NULL,
+        depths_json     TEXT NOT NULL,
+        provenance      TEXT,
+        metrics_json    TEXT
+    );
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
+        ON primitives(name COLLATE NOCASE);
+
+    CREATE TABLE IF NOT EXISTS relationships (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        source_id     TEXT NOT NULL REFERENCES primitives(id),
+        target_id     TEXT NOT NULL REFERENCES primitives(id),
+        rel_type      TEXT NOT NULL,
+        source_depth  INTEGER NOT NULL,
+        target_depth  INTEGER NOT NULL,
+        metadata_json TEXT NOT NULL DEFAULT '{}',
+        policies      TEXT NOT NULL DEFAULT '[]',
+        provenance    TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_rel_source ON relationships(source_id);
+    CREATE INDEX IF NOT EXISTS idx_rel_target ON relationships(target_id);
+    CREATE INDEX IF NOT EXISTS idx_rel_type   ON relationships(rel_type);
+"""
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Any
+from uuid import UUID
+
+from vre.core.backends.repository import Repository
+from vre.core.errors import (
+    CyclicRelationshipError,
+    HydrationError,
+    PersistenceError,
+)
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    EpistemicStep,
+    Primitive,
+    PrimitiveMetrics,
+    Provenance,
+    Relatum,
+    RelationType,
+    ResolvedSubgraph,
+    TRANSITIVE_RELATION_TYPES,
+)
+from vre.core.policy.models import parse_policy
+
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PATH = Path.home() / ".vre" / "graph.db"
+
+_TRANSITIVE_RELS = [rt.value for rt in TRANSITIVE_RELATION_TYPES]
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS primitives (
+    id              TEXT PRIMARY KEY,
+    name            TEXT NOT NULL,
+    depths_json     TEXT NOT NULL,
+    provenance      TEXT,
+    metrics_json    TEXT
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
+    ON primitives(name COLLATE NOCASE);
+
+CREATE TABLE IF NOT EXISTS relationships (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    source_id     TEXT NOT NULL REFERENCES primitives(id),
+    target_id     TEXT NOT NULL REFERENCES primitives(id),
+    rel_type      TEXT NOT NULL,
+    source_depth  INTEGER NOT NULL,
+    target_depth  INTEGER NOT NULL,
+    metadata_json TEXT NOT NULL DEFAULT '{}',
+    policies      TEXT NOT NULL DEFAULT '[]',
+    provenance    TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_rel_source ON relationships(source_id);
+CREATE INDEX IF NOT EXISTS idx_rel_target ON relationships(target_id);
+CREATE INDEX IF NOT EXISTS idx_rel_type   ON relationships(rel_type);
+"""
+
+
+class SQLiteRepository(Repository):
+    """
+    SQLite persistence backend for epistemic primitives.
+
+    Stores primitives in a local SQLite database with depths serialized as
+    JSON and relata stored in a separate ``relationships`` table. Provides
+    transitive cycle detection via recursive CTEs and subgraph resolution
+    for the grounding engine.
+    """
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        if path is None:
+            path = _DEFAULT_PATH
+        resolved = Path(path)
+        if str(resolved) != ":memory:":
+            resolved.parent.mkdir(parents=True, exist_ok=True)
+        self._path = str(resolved)
+        self._conn = sqlite3.connect(self._path)
+        self._conn.row_factory = sqlite3.Row
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.executescript(_SCHEMA)
+
+    def close(self) -> None:
+        """Close the underlying SQLite connection."""
+        self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _depths_to_json(depths: list[Depth]) -> str:
+        """Serialize depth levels and their properties to a JSON string."""
+        stripped = []
+        for depth in depths:
+            entry: dict[str, Any] = {
+                "level": int(depth.level),
+                "properties": depth.properties,
+            }
+            if depth.provenance:
+                entry["provenance"] = depth.provenance.model_dump(mode="json")
+            stripped.append(entry)
+        return json.dumps(stripped)
+
+    @staticmethod
+    def _dump_model_json(model: Any) -> str | None:
+        """Serialize an optional Pydantic model to a JSON string, or None when absent."""
+        return json.dumps(model.model_dump(mode="json")) if model is not None else None
+
+    @staticmethod
+    def _hydrate_primitive(
+        node_data: dict[str, Any],
+        relationships: list[dict[str, Any]],
+    ) -> Primitive:
+        """Reconstruct a Primitive from raw SQLite row data and its relationship records."""
+        try:
+            raw_depths = json.loads(node_data["depths_json"])
+            depths_by_level: dict[int, Depth] = {}
+            for rd in raw_depths:
+                depth = Depth(
+                    level=DepthLevel(rd["level"]),
+                    properties=rd.get("properties", {}),
+                    provenance=Provenance(**rd["provenance"]) if rd.get("provenance") else None,
+                )
+                depths_by_level[int(depth.level)] = depth
+
+            for rel in relationships:
+                source_depth = rel["source_depth"]
+                target_depth_val = rel["target_depth"]
+                metadata_raw = rel.get("metadata_json", "{}")
+                metadata = json.loads(metadata_raw) if metadata_raw else {}
+
+                policies_raw = rel.get("policies", "[]")
+                policies_data = json.loads(policies_raw) if policies_raw else []
+                policies = [parse_policy(p) for p in policies_data]
+
+                rel_prov_raw = rel.get("provenance")
+                rel_prov = None
+                if rel_prov_raw:
+                    rel_prov = Provenance(**json.loads(rel_prov_raw))
+
+                relatum = Relatum(
+                    relation_type=RelationType(rel["rel_type"]),
+                    target_id=UUID(rel["target_id"]),
+                    target_depth=DepthLevel(target_depth_val),
+                    metadata=metadata,
+                    policies=policies,
+                    provenance=rel_prov,
+                )
+
+                if source_depth is not None and source_depth in depths_by_level:
+                    depths_by_level[source_depth].relata.append(relatum)
+
+            sorted_depths = sorted(depths_by_level.values(), key=lambda d: int(d.level))
+
+            node_prov_raw = node_data.get("provenance")
+            node_prov = None
+            if node_prov_raw:
+                node_prov = Provenance(**json.loads(node_prov_raw))
+
+            node_metrics_raw = node_data.get("metrics_json")
+            node_metrics = None
+            if node_metrics_raw:
+                node_metrics = PrimitiveMetrics(**json.loads(node_metrics_raw))
+
+            return Primitive(
+                id=UUID(node_data["id"]),
+                name=node_data["name"],
+                depths=sorted_depths,
+                provenance=node_prov,
+                metrics=node_metrics,
+            )
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            logger.error("Hydration failed for primitive %r: %s", node_data.get("name", "?"), exc)
+            raise HydrationError(
+                f"Failed to hydrate primitive '{node_data.get('name', '?')}': {exc}"
+            ) from exc
+
+    # ------------------------------------------------------------------
+    # Cycle detection
+    # ------------------------------------------------------------------
+
+    def _check_transitive_cycles(
+        self,
+        cursor: sqlite3.Cursor,
+        source_id: str,
+        relata_params: list[dict[str, Any]],
+    ) -> None:
+        """
+        Verify that no new transitive edge would create a cycle.
+
+        Called inside a transaction after old edges have been deleted.
+        For each new transitive relatum, checks whether the target can
+        already reach the source via transitive edges. Raises
+        CyclicRelationshipError on the first cycle found.
+        """
+        placeholders = ",".join("?" for _ in _TRANSITIVE_RELS)
+
+        for rp in relata_params:
+            if rp["rel_type"] not in _TRANSITIVE_RELS:
+                continue
+
+            if rp["target_id"] == source_id:
+                logger.warning(
+                    "Self-referential %s detected on primitive %s",
+                    rp["rel_type"],
+                    source_id,
+                )
+                raise CyclicRelationshipError(
+                    f"Self-referential {rp['rel_type']} on {source_id}"
+                )
+
+            row = cursor.execute(
+                f"""
+                WITH RECURSIVE reachable(id) AS (
+                    SELECT ?
+                    UNION
+                    SELECT r.target_id
+                    FROM relationships r
+                    INNER JOIN reachable rc ON r.source_id = rc.id
+                    WHERE r.rel_type IN ({placeholders})
+                )
+                SELECT EXISTS(SELECT 1 FROM reachable WHERE id = ?) AS would_cycle
+                """,
+                [rp["target_id"]] + _TRANSITIVE_RELS + [source_id],
+            ).fetchone()
+
+            if row and row["would_cycle"]:
+                logger.warning(
+                    "Cycle detected: %s from %s to %s would create a cycle",
+                    rp["rel_type"],
+                    source_id,
+                    rp["target_id"],
+                )
+                raise CyclicRelationshipError(
+                    f"{rp['rel_type']} from {source_id} to "
+                    f"{rp['target_id']} would create a cycle"
+                )
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations: CRUD
+    # ------------------------------------------------------------------
+
+    def save_primitive(self, primitive: Primitive) -> None:
+        """Persist a Primitive -- full replace of depths and relata."""
+        primitive.validate_provenance()
+        depths_json = self._depths_to_json(primitive.depths)
+
+        relata_params: list[dict[str, Any]] = []
+        for depth in primitive.depths:
+            for relatum in depth.relata:
+                relata_params.append(
+                    {
+                        "target_id": str(relatum.target_id),
+                        "rel_type": relatum.relation_type.value,
+                        "source_depth": int(depth.level),
+                        "target_depth": int(relatum.target_depth),
+                        "metadata_json": json.dumps(relatum.metadata) if relatum.metadata else "{}",
+                        "policies": json.dumps(
+                            [p.model_dump() for p in relatum.policies]
+                        ) if relatum.policies else "[]",
+                        "provenance": self._dump_model_json(relatum.provenance),
+                    }
+                )
+
+        node_provenance = self._dump_model_json(primitive.provenance)
+        node_metrics = self._dump_model_json(primitive.metrics)
+
+        logger.debug(
+            "Saving primitive %r (id=%s, depths=%d, relata=%d)",
+            primitive.name,
+            primitive.id,
+            len(primitive.depths),
+            len(relata_params),
+        )
+
+        try:
+            cursor = self._conn.cursor()
+            cursor.execute("BEGIN")
+
+            # UPSERT primitive row
+            cursor.execute(
+                """
+                INSERT INTO primitives (id, name, depths_json, provenance, metrics_json)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    name = excluded.name,
+                    depths_json = excluded.depths_json,
+                    provenance = excluded.provenance,
+                    metrics_json = excluded.metrics_json
+                """,
+                (
+                    str(primitive.id),
+                    primitive.name,
+                    depths_json,
+                    node_provenance,
+                    node_metrics,
+                ),
+            )
+
+            # Delete old outgoing relationships
+            cursor.execute(
+                "DELETE FROM relationships WHERE source_id = ?",
+                (str(primitive.id),),
+            )
+
+            # Check for transitive cycles
+            self._check_transitive_cycles(cursor, str(primitive.id), relata_params)
+
+            # Insert new relationships
+            for rp in relata_params:
+                cursor.execute(
+                    """
+                    INSERT INTO relationships
+                        (source_id, target_id, rel_type, source_depth,
+                         target_depth, metadata_json, policies, provenance)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        str(primitive.id),
+                        rp["target_id"],
+                        rp["rel_type"],
+                        rp["source_depth"],
+                        rp["target_depth"],
+                        rp["metadata_json"],
+                        rp["policies"],
+                        rp["provenance"],
+                    ),
+                )
+
+            self._conn.commit()
+        except CyclicRelationshipError:
+            self._conn.rollback()
+            raise
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            logger.error("SQLite error saving primitive %r: %s", primitive.name, exc)
+            raise PersistenceError(
+                f"Failed to save primitive '{primitive.name}': {exc}"
+            ) from exc
+
+    def find_by_id(self, id: UUID) -> Primitive | None:
+        """Look up a primitive by UUID. Returns None if not found."""
+        row = self._conn.execute(
+            "SELECT id, name, depths_json, provenance, metrics_json "
+            "FROM primitives WHERE id = ?",
+            (str(id),),
+        ).fetchone()
+
+        if row is None:
+            logger.debug("Primitive not found by id=%s", id)
+            return None
+
+        node_data = dict(row)
+        relationships = self._fetch_outgoing_relationships(str(id))
+        return self._hydrate_primitive(node_data, relationships)
+
+    def find_by_name(self, name: str) -> Primitive | None:
+        """Look up a primitive by name (case-insensitive). Returns None if not found."""
+        row = self._conn.execute(
+            "SELECT id, name, depths_json, provenance, metrics_json "
+            "FROM primitives WHERE name = ? COLLATE NOCASE",
+            (name,),
+        ).fetchone()
+
+        if row is None:
+            logger.debug("Primitive not found by name=%r", name)
+            return None
+
+        node_data = dict(row)
+        relationships = self._fetch_outgoing_relationships(node_data["id"])
+        return self._hydrate_primitive(node_data, relationships)
+
+    def _fetch_outgoing_relationships(self, primitive_id: str) -> list[dict[str, Any]]:
+        """Fetch all outgoing relationships for a primitive as dicts."""
+        rows = self._conn.execute(
+            """
+            SELECT rel_type, target_id, source_depth, target_depth,
+                   metadata_json, policies, provenance
+            FROM relationships
+            WHERE source_id = ?
+            """,
+            (primitive_id,),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def list_names(self) -> list[str]:
+        """Return the names of all primitives, sorted alphabetically."""
+        rows = self._conn.execute(
+            "SELECT name FROM primitives ORDER BY name"
+        ).fetchall()
+        return [r["name"] for r in rows]
+
+    def delete_primitive(self, id: UUID) -> bool:
+        """Delete the primitive with the given UUID and all its relationships. Returns True if deleted."""
+        sid = str(id)
+        # Delete relationships first (both directions)
+        self._conn.execute(
+            "DELETE FROM relationships WHERE source_id = ? OR target_id = ?",
+            (sid, sid),
+        )
+        cursor = self._conn.execute(
+            "DELETE FROM primitives WHERE id = ?",
+            (sid,),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def clear(self) -> int:
+        """Delete every primitive and its relationships. Returns the count deleted."""
+        self._conn.execute("DELETE FROM relationships")
+        cursor = self._conn.execute("DELETE FROM primitives")
+        self._conn.commit()
+        return cursor.rowcount
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations: metrics
+    # ------------------------------------------------------------------
+
+    def update_metrics(self, primitive_id: UUID, metrics: PrimitiveMetrics) -> None:
+        """Update only the metrics JSON on an existing primitive."""
+        metrics_json = json.dumps(metrics.model_dump(mode="json"))
+        try:
+            self._conn.execute(
+                "UPDATE primitives SET metrics_json = ? WHERE id = ?",
+                (metrics_json, str(primitive_id)),
+            )
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            logger.error("Failed to update metrics for primitive %s: %s", primitive_id, exc)
+            raise PersistenceError(
+                f"Failed to update metrics for '{primitive_id}': {exc}"
+            ) from exc
+
+    def batch_read_metrics(self, primitive_ids: list[UUID]) -> dict[UUID, PrimitiveMetrics | None]:
+        """Read current metrics for multiple primitives in a single query."""
+        result: dict[UUID, PrimitiveMetrics | None] = {}
+        if not primitive_ids:
+            return result
+
+        placeholders = ",".join("?" for _ in primitive_ids)
+        try:
+            rows = self._conn.execute(
+                f"SELECT id, metrics_json FROM primitives WHERE id IN ({placeholders})",
+                [str(pid) for pid in primitive_ids],
+            ).fetchall()
+
+            for row in rows:
+                pid = UUID(row["id"])
+                raw = row["metrics_json"]
+                if raw:
+                    try:
+                        result[pid] = PrimitiveMetrics(**json.loads(raw))
+                    except Exception as exc:
+                        raise HydrationError(
+                            f"Failed to hydrate metrics for primitive '{pid}': {exc}"
+                        ) from exc
+                else:
+                    result[pid] = None
+        except HydrationError:
+            raise
+        except sqlite3.Error as exc:
+            raise PersistenceError(f"Failed to batch-read metrics: {exc}") from exc
+
+        return result
+
+    def batch_update_metrics(self, updates: dict[UUID, PrimitiveMetrics]) -> None:
+        """Persist metrics for multiple primitives in a single batch."""
+        if not updates:
+            return
+
+        try:
+            for pid, metrics in updates.items():
+                metrics_json = json.dumps(metrics.model_dump(mode="json"))
+                self._conn.execute(
+                    "UPDATE primitives SET metrics_json = ? WHERE id = ?",
+                    (metrics_json, str(pid)),
+                )
+            self._conn.commit()
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            raise PersistenceError(f"Failed to batch-update metrics: {exc}") from exc
+
+    # ------------------------------------------------------------------
+    # Abstract method implementations: graph traversal
+    # ------------------------------------------------------------------
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        """Single-query traversal that resolves a subgraph for the given concept names."""
+        logger.debug("Resolving subgraph for names=%s", names)
+
+        if not names:
+            return ResolvedSubgraph(roots=[], nodes=[], edges=[])
+
+        lowered = [n.lower() for n in names]
+        name_placeholders = ",".join("?" for _ in lowered)
+        transitive_placeholders = ",".join("?" for _ in _TRANSITIVE_RELS)
+
+        # Phase 1: Find all transitively reachable node IDs from roots
+        reachable_ids_rows = self._conn.execute(
+            f"""
+            WITH RECURSIVE reachable(id) AS (
+                SELECT id FROM primitives WHERE LOWER(name) IN ({name_placeholders})
+                UNION
+                SELECT r.target_id
+                FROM relationships r
+                INNER JOIN reachable rc ON r.source_id = rc.id
+                WHERE r.rel_type IN ({transitive_placeholders})
+            )
+            SELECT id FROM reachable
+            """,
+            lowered + _TRANSITIVE_RELS,
+        ).fetchall()
+
+        reachable_ids = [row["id"] for row in reachable_ids_rows]
+
+        if not reachable_ids:
+            return ResolvedSubgraph(roots=[], nodes=[], edges=[])
+
+        # Phase 2: Fetch all node rows
+        node_placeholders = ",".join("?" for _ in reachable_ids)
+        node_rows = self._conn.execute(
+            f"""
+            SELECT id, name, depths_json, provenance, metrics_json
+            FROM primitives WHERE id IN ({node_placeholders})
+            """,
+            reachable_ids,
+        ).fetchall()
+
+        # Phase 3: Fetch all edges between reachable nodes
+        edge_rows = self._conn.execute(
+            f"""
+            SELECT source_id, target_id, rel_type, source_depth, target_depth,
+                   metadata_json, policies, provenance
+            FROM relationships
+            WHERE source_id IN ({node_placeholders})
+              AND target_id IN ({node_placeholders})
+            """,
+            reachable_ids + reachable_ids,
+        ).fetchall()
+
+        # Build edges-by-source for hydration
+        edges_by_source: dict[str, list[dict[str, Any]]] = {}
+        for e in edge_rows:
+            ed = dict(e)
+            sid = ed["source_id"]
+            edges_by_source.setdefault(sid, []).append(ed)
+
+        # Identify root names (lowered) for root filtering
+        lowered_set = set(lowered)
+
+        # Hydrate all nodes
+        nodes: list[Primitive] = []
+        roots: list[Primitive] = []
+        for nr in node_rows:
+            nd = dict(nr)
+            prim = self._hydrate_primitive(nd, edges_by_source.get(nd["id"], []))
+            nodes.append(prim)
+            if prim.name.lower() in lowered_set:
+                roots.append(prim)
+
+        # Build EpistemicStep edges
+        edges: list[EpistemicStep] = []
+        for e in edge_rows:
+            edges.append(
+                EpistemicStep(
+                    source_id=UUID(e["source_id"]),
+                    target_id=UUID(e["target_id"]),
+                    relation_type=RelationType(e["rel_type"]),
+                    source_depth=DepthLevel(e["source_depth"]),
+                    target_depth=DepthLevel(e["target_depth"]),
+                )
+            )
+
+        logger.debug(
+            "Subgraph resolved: %d roots, %d nodes, %d edges",
+            len(roots),
+            len(nodes),
+            len(edges),
+        )
+        return ResolvedSubgraph(roots=roots, nodes=nodes, edges=edges)

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -512,9 +512,11 @@ class SQLiteRepository(Repository):
             return
 
         try:
+            cursor = self._conn.cursor()
+            cursor.execute("BEGIN")
             for pid, metrics in updates.items():
                 metrics_json = json.dumps(metrics.model_dump(mode="json"))
-                self._conn.execute(
+                cursor.execute(
                     "UPDATE primitives SET metrics_json = ? WHERE id = ?",
                     (metrics_json, str(pid)),
                 )

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -116,7 +116,7 @@ class SQLiteRepository(Repository):
         if str(resolved) != ":memory:":
             resolved.parent.mkdir(parents=True, exist_ok=True)
         self._path = str(resolved)
-        self._conn = sqlite3.connect(self._path)
+        self._conn = sqlite3.connect(self._path, isolation_level=None)
         self._conn.row_factory = sqlite3.Row
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._conn.execute("PRAGMA journal_mode = WAL")
@@ -436,24 +436,35 @@ class SQLiteRepository(Repository):
     def delete_primitive(self, id: UUID) -> bool:
         """Delete the primitive with the given UUID and all its relationships. Returns True if deleted."""
         sid = str(id)
-        # Delete relationships first (both directions)
-        self._conn.execute(
-            "DELETE FROM relationships WHERE source_id = ? OR target_id = ?",
-            (sid, sid),
-        )
-        cursor = self._conn.execute(
-            "DELETE FROM primitives WHERE id = ?",
-            (sid,),
-        )
-        self._conn.commit()
-        return cursor.rowcount > 0
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute(
+                "DELETE FROM relationships WHERE source_id = ? OR target_id = ?",
+                (sid, sid),
+            )
+            cursor = self._conn.execute(
+                "DELETE FROM primitives WHERE id = ?",
+                (sid,),
+            )
+            self._conn.commit()
+            return cursor.rowcount > 0
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            raise PersistenceError(
+                f"Failed to delete primitive '{id}': {exc}"
+            ) from exc
 
     def clear(self) -> int:
         """Delete every primitive and its relationships. Returns the count deleted."""
-        self._conn.execute("DELETE FROM relationships")
-        cursor = self._conn.execute("DELETE FROM primitives")
-        self._conn.commit()
-        return cursor.rowcount
+        try:
+            self._conn.execute("BEGIN")
+            self._conn.execute("DELETE FROM relationships")
+            cursor = self._conn.execute("DELETE FROM primitives")
+            self._conn.commit()
+            return cursor.rowcount
+        except sqlite3.Error as exc:
+            self._conn.rollback()
+            raise PersistenceError(f"Failed to clear graph: {exc}") from exc
 
     # ------------------------------------------------------------------
     # Abstract method implementations: metrics
@@ -463,12 +474,14 @@ class SQLiteRepository(Repository):
         """Update only the metrics JSON on an existing primitive."""
         metrics_json = json.dumps(metrics.model_dump(mode="json"))
         try:
+            self._conn.execute("BEGIN")
             self._conn.execute(
                 "UPDATE primitives SET metrics_json = ? WHERE id = ?",
                 (metrics_json, str(primitive_id)),
             )
             self._conn.commit()
         except sqlite3.Error as exc:
+            self._conn.rollback()
             logger.error("Failed to update metrics for primitive %s: %s", primitive_id, exc)
             raise PersistenceError(
                 f"Failed to update metrics for '{primitive_id}': {exc}"

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -21,7 +21,7 @@ Schema
     CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
         ON primitives(name COLLATE NOCASE);
 
-    CREATE TABLE IF NOT EXISTS relationships (
+    CREATE TABLE IF NOT EXISTS relata (
         id            INTEGER PRIMARY KEY AUTOINCREMENT,
         source_id     TEXT NOT NULL REFERENCES primitives(id),
         target_id     TEXT NOT NULL REFERENCES primitives(id),
@@ -32,9 +32,9 @@ Schema
         policies      TEXT NOT NULL DEFAULT '[]',
         provenance    TEXT
     );
-    CREATE INDEX IF NOT EXISTS idx_rel_source ON relationships(source_id);
-    CREATE INDEX IF NOT EXISTS idx_rel_target ON relationships(target_id);
-    CREATE INDEX IF NOT EXISTS idx_rel_type   ON relationships(rel_type);
+    CREATE INDEX IF NOT EXISTS idx_rel_source ON relata(source_id);
+    CREATE INDEX IF NOT EXISTS idx_rel_target ON relata(target_id);
+    CREATE INDEX IF NOT EXISTS idx_rel_type   ON relata(rel_type);
 """
 
 import json
@@ -82,7 +82,7 @@ CREATE TABLE IF NOT EXISTS primitives (
 CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
     ON primitives(name COLLATE NOCASE);
 
-CREATE TABLE IF NOT EXISTS relationships (
+CREATE TABLE IF NOT EXISTS relata (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
     source_id     TEXT NOT NULL REFERENCES primitives(id),
     target_id     TEXT NOT NULL REFERENCES primitives(id),
@@ -93,9 +93,9 @@ CREATE TABLE IF NOT EXISTS relationships (
     policies      TEXT NOT NULL DEFAULT '[]',
     provenance    TEXT
 );
-CREATE INDEX IF NOT EXISTS idx_rel_source ON relationships(source_id);
-CREATE INDEX IF NOT EXISTS idx_rel_target ON relationships(target_id);
-CREATE INDEX IF NOT EXISTS idx_rel_type   ON relationships(rel_type);
+CREATE INDEX IF NOT EXISTS idx_rel_source ON relata(source_id);
+CREATE INDEX IF NOT EXISTS idx_rel_target ON relata(target_id);
+CREATE INDEX IF NOT EXISTS idx_rel_type   ON relata(rel_type);
 """
 
 
@@ -104,7 +104,7 @@ class SQLiteRepository(Repository):
     SQLite persistence backend for epistemic primitives.
 
     Stores primitives in a local SQLite database with depths serialized as
-    JSON and relata stored in a separate ``relationships`` table. Provides
+    JSON and relata stored in a separate ``relata`` table. Provides
     transitive cycle detection via recursive CTEs and subgraph resolution
     for the grounding engine.
     """
@@ -152,9 +152,9 @@ class SQLiteRepository(Repository):
     @staticmethod
     def _hydrate_primitive(
         node_data: dict[str, Any],
-        relationships: list[dict[str, Any]],
+        relata: list[dict[str, Any]],
     ) -> Primitive:
-        """Reconstruct a Primitive from raw SQLite row data and its relationship records."""
+        """Reconstruct a Primitive from raw SQLite row data and its relata records."""
         try:
             raw_depths = json.loads(node_data["depths_json"])
             depths_by_level: dict[int, Depth] = {}
@@ -166,7 +166,7 @@ class SQLiteRepository(Repository):
                 )
                 depths_by_level[int(depth.level)] = depth
 
-            for rel in relationships:
+            for rel in relata:
                 source_depth = rel["source_depth"]
                 target_depth_val = rel["target_depth"]
                 metadata_raw = rel.get("metadata_json", "{}")
@@ -258,7 +258,7 @@ class SQLiteRepository(Repository):
                     SELECT ?
                     UNION
                     SELECT r.target_id
-                    FROM relationships r
+                    FROM relata r
                     INNER JOIN reachable rc ON r.source_id = rc.id
                     WHERE r.rel_type IN ({placeholders})
                 )
@@ -340,20 +340,20 @@ class SQLiteRepository(Repository):
                 ),
             )
 
-            # Delete old outgoing relationships
+            # Delete old outgoing relata
             cursor.execute(
-                "DELETE FROM relationships WHERE source_id = ?",
+                "DELETE FROM relata WHERE source_id = ?",
                 (str(primitive.id),),
             )
 
             # Check for transitive cycles
             self._check_transitive_cycles(cursor, str(primitive.id), relata_params)
 
-            # Insert new relationships
+            # Insert new relata
             for rp in relata_params:
                 cursor.execute(
                     """
-                    INSERT INTO relationships
+                    INSERT INTO relata
                         (source_id, target_id, rel_type, source_depth,
                          target_depth, metadata_json, policies, provenance)
                     VALUES (?, ?, ?, ?, ?, ?, ?, ?)
@@ -394,8 +394,8 @@ class SQLiteRepository(Repository):
             return None
 
         node_data = dict(row)
-        relationships = self._fetch_outgoing_relationships(str(id))
-        return self._hydrate_primitive(node_data, relationships)
+        relata = self._fetch_outgoing_relata(str(id))
+        return self._hydrate_primitive(node_data, relata)
 
     def find_by_name(self, name: str) -> Primitive | None:
         """Look up a primitive by name (case-insensitive). Returns None if not found."""
@@ -410,16 +410,16 @@ class SQLiteRepository(Repository):
             return None
 
         node_data = dict(row)
-        relationships = self._fetch_outgoing_relationships(node_data["id"])
-        return self._hydrate_primitive(node_data, relationships)
+        relata = self._fetch_outgoing_relata(node_data["id"])
+        return self._hydrate_primitive(node_data, relata)
 
-    def _fetch_outgoing_relationships(self, primitive_id: str) -> list[dict[str, Any]]:
-        """Fetch all outgoing relationships for a primitive as dicts."""
+    def _fetch_outgoing_relata(self, primitive_id: str) -> list[dict[str, Any]]:
+        """Fetch all outgoing relata for a primitive as dicts."""
         rows = self._conn.execute(
             """
             SELECT rel_type, target_id, source_depth, target_depth,
                    metadata_json, policies, provenance
-            FROM relationships
+            FROM relata
             WHERE source_id = ?
             """,
             (primitive_id,),
@@ -434,12 +434,12 @@ class SQLiteRepository(Repository):
         return [r["name"] for r in rows]
 
     def delete_primitive(self, id: UUID) -> bool:
-        """Delete the primitive with the given UUID and all its relationships. Returns True if deleted."""
+        """Delete the primitive with the given UUID and all its relata. Returns True if deleted."""
         sid = str(id)
         try:
             self._conn.execute("BEGIN")
             self._conn.execute(
-                "DELETE FROM relationships WHERE source_id = ? OR target_id = ?",
+                "DELETE FROM relata WHERE source_id = ? OR target_id = ?",
                 (sid, sid),
             )
             cursor = self._conn.execute(
@@ -455,10 +455,10 @@ class SQLiteRepository(Repository):
             ) from exc
 
     def clear(self) -> int:
-        """Delete every primitive and its relationships. Returns the count deleted."""
+        """Delete every primitive and its relata. Returns the count deleted."""
         try:
             self._conn.execute("BEGIN")
-            self._conn.execute("DELETE FROM relationships")
+            self._conn.execute("DELETE FROM relata")
             cursor = self._conn.execute("DELETE FROM primitives")
             self._conn.commit()
             return cursor.rowcount
@@ -560,7 +560,7 @@ class SQLiteRepository(Repository):
                 SELECT id FROM primitives WHERE LOWER(name) IN ({name_placeholders})
                 UNION
                 SELECT r.target_id
-                FROM relationships r
+                FROM relata r
                 INNER JOIN reachable rc ON r.source_id = rc.id
                 WHERE r.rel_type IN ({transitive_placeholders})
             )
@@ -589,7 +589,7 @@ class SQLiteRepository(Repository):
             f"""
             SELECT source_id, target_id, rel_type, source_depth, target_depth,
                    metadata_json, policies, provenance
-            FROM relationships
+            FROM relata
             WHERE source_id IN ({node_placeholders})
               AND target_id IN ({node_placeholders})
             """,

--- a/tests/vre/test_provenance.py
+++ b/tests/vre/test_provenance.py
@@ -18,7 +18,7 @@ from vre.core.models import (
     Relatum,
     RelationType,
 )
-from vre.core.backends.neo4j import Neo4jRepository
+from vre.core.backends.sqlite import SQLiteRepository
 from vre.core.grounding.models import _fmt_depth, _fmt_primitive, _fmt_relatum
 
 
@@ -214,7 +214,7 @@ def test_depths_to_json_includes_provenance():
     """
     prov = Provenance(source=ProvenanceSource.AUTHORED)
     depths = [Depth(level=DepthLevel.EXISTENCE, provenance=prov)]
-    result = json.loads(Neo4jRepository._depths_to_json(depths))
+    result = json.loads(SQLiteRepository._depths_to_json(depths))
     assert len(result) == 1
     assert "provenance" in result[0]
     assert result[0]["provenance"]["source"] == "authored"
@@ -225,7 +225,7 @@ def test_depths_to_json_omits_provenance_when_none():
     _depths_to_json omits the provenance key entirely when provenance is None.
     """
     depths = [Depth(level=DepthLevel.EXISTENCE)]
-    result = json.loads(Neo4jRepository._depths_to_json(depths))
+    result = json.loads(SQLiteRepository._depths_to_json(depths))
     assert "provenance" not in result[0]
 
 
@@ -259,7 +259,7 @@ def test_hydrate_primitive_with_provenance():
     )
 
     # Serialize
-    depths_json = Neo4jRepository._depths_to_json(primitive.depths)
+    depths_json = SQLiteRepository._depths_to_json(primitive.depths)
     node_prov_json = json.dumps(prov.model_dump(mode="json"))
     rel_prov = Provenance(source=ProvenanceSource.CONVERSATIONAL)
     rel_prov_json = json.dumps(rel_prov.model_dump(mode="json"))
@@ -269,23 +269,22 @@ def test_hydrate_primitive_with_provenance():
         "name": "file",
         "depths_json": depths_json,
         "provenance": node_prov_json,
+        "metrics_json": None,
     }
     relationships = [
         {
             "rel_type": "APPLIES_TO",
             "target_id": str(target_id),
-            "rel_props": {
-                "source_depth": 2,
-                "target_depth": 2,
-                "metadata_json": "{}",
-                "policies": "[]",
-                "provenance": rel_prov_json,
-            },
+            "source_depth": 2,
+            "target_depth": 2,
+            "metadata_json": "{}",
+            "policies": "[]",
+            "provenance": rel_prov_json,
         },
     ]
 
     # Deserialize
-    hydrated = Neo4jRepository._hydrate_primitive(node_data, relationships)
+    hydrated = SQLiteRepository._hydrate_primitive(node_data, relationships)
 
     # Node provenance
     assert hydrated.provenance is not None
@@ -315,8 +314,10 @@ def test_hydrate_primitive_without_provenance():
         "id": str(uuid4()),
         "name": "legacy",
         "depths_json": json.dumps([{"level": 0, "properties": {}}]),
+        "provenance": None,
+        "metrics_json": None,
     }
-    hydrated = Neo4jRepository._hydrate_primitive(node_data, [])
+    hydrated = SQLiteRepository._hydrate_primitive(node_data, [])
     assert hydrated.provenance is None
     assert hydrated.depths[0].provenance is None
 

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -1008,3 +1008,18 @@ class TestGroundingEngineWithSQLite:
             response = engine.query(["read", "file"])
             gap_kinds = [g.kind for g in response.result.gaps]
             assert "RELATIONAL" in gap_kinds
+
+
+# ------------------------------------------------------------------
+# TestExports
+# ------------------------------------------------------------------
+
+
+class TestExports:
+    def test_importable_from_backends(self) -> None:
+        from vre.core.backends import SQLiteRepository as S
+        assert S is SQLiteRepository
+
+    def test_importable_from_vre(self) -> None:
+        from vre import SQLiteRepository as S
+        assert S is SQLiteRepository

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -469,7 +469,7 @@ class TestListDeleteClear:
             for name in ["Zebra", "Alpha", "middle"]:
                 repo.save_primitive(_make_primitive(name))
             names = repo.list_names()
-            assert names == ["Alpha", "Zebra", "middle"]
+            assert names == ["Alpha", "middle", "Zebra"]
 
     def test_list_names_empty(self) -> None:
         with SQLiteRepository(":memory:") as repo:

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -151,7 +151,7 @@ class TestSQLiteLifecycle:
             )
             tables = [row["name"] for row in cursor.fetchall()]
             assert "primitives" in tables
-            assert "relationships" in tables
+            assert "relata" in tables
 
     def test_context_manager_closes_connection(self) -> None:
         repo = SQLiteRepository(":memory:")
@@ -488,7 +488,7 @@ class TestListDeleteClear:
 
             assert repo.delete_primitive(uuid4()) is False
 
-    def test_delete_removes_outgoing_relationships(self) -> None:
+    def test_delete_removes_outgoing_relata(self) -> None:
         with SQLiteRepository(":memory:") as repo:
             target = _make_primitive("Target")
             repo.save_primitive(target)
@@ -516,11 +516,11 @@ class TestListDeleteClear:
             repo.delete_primitive(source.id)
             # Relationships should be gone
             count = repo._conn.execute(
-                "SELECT COUNT(*) FROM relationships"
+                "SELECT COUNT(*) FROM relata"
             ).fetchone()[0]
             assert count == 0
 
-    def test_delete_removes_incoming_relationships(self) -> None:
+    def test_delete_removes_incoming_relata(self) -> None:
         with SQLiteRepository(":memory:") as repo:
             target = _make_primitive("Target")
             repo.save_primitive(target)
@@ -548,7 +548,7 @@ class TestListDeleteClear:
             repo.delete_primitive(target.id)
             # Relationship row should be gone (deleted as incoming)
             count = repo._conn.execute(
-                "SELECT COUNT(*) FROM relationships"
+                "SELECT COUNT(*) FROM relata"
             ).fetchone()[0]
             assert count == 0
 

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -1,0 +1,953 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Comprehensive test suite for SQLiteRepository.
+"""
+
+import sqlite3
+
+import pytest
+
+from vre.core.backends.sqlite import SQLiteRepository
+from vre.core.errors import CyclicRelationshipError, HydrationError, PersistenceError
+from vre.core.models import (
+    Depth,
+    DepthLevel,
+    EpistemicStep,
+    Primitive,
+    PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
+    Relatum,
+    RelationType,
+    ResolvedSubgraph,
+)
+from vre.core.policy.models import Cardinality, Policy
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+
+
+def _prov() -> Provenance:
+    return Provenance(source=ProvenanceSource.AUTHORED)
+
+
+def _make_primitive(
+    name: str,
+    max_depth: DepthLevel = DepthLevel.EXISTENCE,
+) -> Primitive:
+    depths = [
+        Depth(level=DepthLevel(i), provenance=_prov())
+        for i in range(max_depth + 1)
+    ]
+    return Primitive(name=name, depths=depths, provenance=_prov())
+
+
+def _seed_filesystem_graph(repo: SQLiteRepository) -> dict[str, Primitive]:
+    """Seed a small filesystem-domain graph and return primitives by name."""
+    operating_system = _make_primitive("operating_system", DepthLevel.CONSTRAINTS)
+    filesystem = _make_primitive("filesystem", DepthLevel.CONSTRAINTS)
+    path = _make_primitive("path", DepthLevel.CONSTRAINTS)
+    directory = _make_primitive("directory", DepthLevel.CONSTRAINTS)
+    file = _make_primitive("file", DepthLevel.IDENTITY)
+    list_prim = _make_primitive("list", DepthLevel.CAPABILITIES)
+    read = _make_primitive("read", DepthLevel.CAPABILITIES)
+
+    # filesystem DEPENDS_ON operating_system @ D2
+    filesystem.depths[2].relata.append(
+        Relatum(
+            relation_type=RelationType.DEPENDS_ON,
+            target_id=operating_system.id,
+            target_depth=DepthLevel.CAPABILITIES,
+            provenance=_prov(),
+        )
+    )
+
+    # path DEPENDS_ON filesystem @ D2
+    path.depths[2].relata.append(
+        Relatum(
+            relation_type=RelationType.DEPENDS_ON,
+            target_id=filesystem.id,
+            target_depth=DepthLevel.CAPABILITIES,
+            provenance=_prov(),
+        )
+    )
+
+    # directory REQUIRES path @ D1
+    directory.depths[1].relata.append(
+        Relatum(
+            relation_type=RelationType.REQUIRES,
+            target_id=path.id,
+            target_depth=DepthLevel.IDENTITY,
+            provenance=_prov(),
+        )
+    )
+    # directory DEPENDS_ON filesystem @ D2
+    directory.depths[2].relata.append(
+        Relatum(
+            relation_type=RelationType.DEPENDS_ON,
+            target_id=filesystem.id,
+            target_depth=DepthLevel.CAPABILITIES,
+            provenance=_prov(),
+        )
+    )
+
+    # file REQUIRES path @ D1
+    file.depths[1].relata.append(
+        Relatum(
+            relation_type=RelationType.REQUIRES,
+            target_id=path.id,
+            target_depth=DepthLevel.IDENTITY,
+            provenance=_prov(),
+        )
+    )
+
+    # list APPLIES_TO directory @ D2
+    list_prim.depths[2].relata.append(
+        Relatum(
+            relation_type=RelationType.APPLIES_TO,
+            target_id=directory.id,
+            target_depth=DepthLevel.CAPABILITIES,
+            provenance=_prov(),
+        )
+    )
+
+    # read APPLIES_TO file @ D2
+    read.depths[2].relata.append(
+        Relatum(
+            relation_type=RelationType.APPLIES_TO,
+            target_id=file.id,
+            target_depth=DepthLevel.CAPABILITIES,
+            provenance=_prov(),
+        )
+    )
+
+    # Save order matters: targets before sources for FK constraints
+    for p in [operating_system, filesystem, path, directory, file, list_prim, read]:
+        repo.save_primitive(p)
+
+    return {
+        "operating_system": operating_system,
+        "filesystem": filesystem,
+        "path": path,
+        "directory": directory,
+        "file": file,
+        "list": list_prim,
+        "read": read,
+    }
+
+
+# ------------------------------------------------------------------
+# TestSQLiteLifecycle
+# ------------------------------------------------------------------
+
+
+class TestSQLiteLifecycle:
+    def test_constructor_creates_tables(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            cursor = repo._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+            )
+            tables = [row["name"] for row in cursor.fetchall()]
+            assert "primitives" in tables
+            assert "relationships" in tables
+
+    def test_context_manager_closes_connection(self) -> None:
+        repo = SQLiteRepository(":memory:")
+        repo.__enter__()
+        repo.__exit__(None, None, None)
+        with pytest.raises(Exception):
+            repo._conn.execute("SELECT 1")
+
+    def test_foreign_keys_enabled(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            row = repo._conn.execute("PRAGMA foreign_keys").fetchone()
+            assert row[0] == 1
+
+    def test_wal_mode(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            row = repo._conn.execute("PRAGMA journal_mode").fetchone()
+            # :memory: databases may report "memory" instead of "wal"
+            assert row[0] in ("wal", "memory")
+
+    def test_default_path(self, tmp_path: object) -> None:
+        """Constructor with None path uses the default (not tested for real path, just not :memory:)."""
+        # Just verify the attribute exists and is a string
+        repo = SQLiteRepository(":memory:")
+        assert repo._path == ":memory:"
+        repo.close()
+
+    def test_file_based_db(self, tmp_path: object) -> None:
+        import pathlib
+
+        db_path = pathlib.Path(str(tmp_path)) / "sub" / "test.db"
+        with SQLiteRepository(db_path) as repo:
+            repo.save_primitive(_make_primitive("alpha"))
+        # Reopen to verify persistence
+        with SQLiteRepository(db_path) as repo:
+            assert repo.find_by_name("alpha") is not None
+
+
+# ------------------------------------------------------------------
+# TestSaveFindPrimitive
+# ------------------------------------------------------------------
+
+
+class TestSaveFindPrimitive:
+    def test_save_and_find_by_id(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File", DepthLevel.IDENTITY)
+            repo.save_primitive(prim)
+            found = repo.find_by_id(prim.id)
+            assert found is not None
+            assert found.id == prim.id
+            assert found.name == "File"
+            assert len(found.depths) == 2
+
+    def test_save_and_find_by_name(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("Directory")
+            repo.save_primitive(prim)
+            found = repo.find_by_name("Directory")
+            assert found is not None
+            assert found.name == "Directory"
+
+    def test_find_by_name_case_insensitive(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File")
+            repo.save_primitive(prim)
+            assert repo.find_by_name("file") is not None
+            assert repo.find_by_name("FILE") is not None
+            assert repo.find_by_name("FiLe") is not None
+
+    def test_find_by_id_not_found(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            from uuid import uuid4
+
+            assert repo.find_by_id(uuid4()) is None
+
+    def test_find_by_name_not_found(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            assert repo.find_by_name("nonexistent") is None
+
+    def test_overwrite_primitive(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File", DepthLevel.EXISTENCE)
+            repo.save_primitive(prim)
+            # Overwrite with more depths
+            updated = prim.model_copy(
+                update={
+                    "depths": [
+                        Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                        Depth(level=DepthLevel.IDENTITY, provenance=_prov()),
+                        Depth(level=DepthLevel.CAPABILITIES, provenance=_prov()),
+                    ]
+                }
+            )
+            repo.save_primitive(updated)
+            found = repo.find_by_id(prim.id)
+            assert found is not None
+            assert len(found.depths) == 3
+
+    def test_multiple_depths_with_properties(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = Primitive(
+                name="File",
+                depths=[
+                    Depth(
+                        level=DepthLevel.EXISTENCE,
+                        properties={"exists": True},
+                        provenance=_prov(),
+                    ),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        properties={"type": "regular", "extensions": [".txt", ".py"]},
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(prim)
+            found = repo.find_by_id(prim.id)
+            assert found is not None
+            assert found.depths[0].properties == {"exists": True}
+            assert found.depths[1].properties == {
+                "type": "regular",
+                "extensions": [".txt", ".py"],
+            }
+
+    def test_relata_round_trip(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target = _make_primitive("Path", DepthLevel.IDENTITY)
+            repo.save_primitive(target)
+
+            source = Primitive(
+                name="File",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.REQUIRES,
+                                target_id=target.id,
+                                target_depth=DepthLevel.IDENTITY,
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+            found = repo.find_by_id(source.id)
+            assert found is not None
+            assert len(found.depths[1].relata) == 1
+            rel = found.depths[1].relata[0]
+            assert rel.relation_type == RelationType.REQUIRES
+            assert rel.target_id == target.id
+            assert rel.target_depth == DepthLevel.IDENTITY
+
+    def test_metadata_and_policies_round_trip(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target = _make_primitive("Directory", DepthLevel.CAPABILITIES)
+            repo.save_primitive(target)
+
+            policy = Policy(
+                name="confirm_delete",
+                requires_confirmation=True,
+                trigger_cardinality=Cardinality.MULTIPLE,
+                confirmation_message="Are you sure?",
+                metadata={"severity": "high"},
+            )
+            source = Primitive(
+                name="Delete",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(level=DepthLevel.IDENTITY, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.CAPABILITIES,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.APPLIES_TO,
+                                target_id=target.id,
+                                target_depth=DepthLevel.CAPABILITIES,
+                                metadata={"destructive": True, "tags": ["danger"]},
+                                policies=[policy],
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+            found = repo.find_by_id(source.id)
+            assert found is not None
+            rel = found.depths[2].relata[0]
+            assert rel.metadata == {"destructive": True, "tags": ["danger"]}
+            assert len(rel.policies) == 1
+            assert rel.policies[0].name == "confirm_delete"
+            assert rel.policies[0].trigger_cardinality == Cardinality.MULTIPLE
+            assert rel.policies[0].metadata == {"severity": "high"}
+
+    def test_provenance_round_trip(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File")
+            repo.save_primitive(prim)
+            found = repo.find_by_id(prim.id)
+            assert found is not None
+            assert found.provenance is not None
+            assert found.provenance.source == ProvenanceSource.AUTHORED
+            assert found.depths[0].provenance is not None
+            assert found.depths[0].provenance.source == ProvenanceSource.AUTHORED
+
+    def test_relata_provenance_round_trip(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target = _make_primitive("Path")
+            repo.save_primitive(target)
+
+            rel_prov = Provenance(
+                source=ProvenanceSource.LEARNED,
+                detail="Discovered via execution failure",
+            )
+            source = Primitive(
+                name="File",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.REQUIRES,
+                                target_id=target.id,
+                                target_depth=DepthLevel.EXISTENCE,
+                                provenance=rel_prov,
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+            found = repo.find_by_id(source.id)
+            assert found is not None
+            rel = found.depths[1].relata[0]
+            assert rel.provenance is not None
+            assert rel.provenance.source == ProvenanceSource.LEARNED
+            assert rel.provenance.detail == "Discovered via execution failure"
+
+    def test_overwrite_replaces_relata(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target_a = _make_primitive("TargetA")
+            target_b = _make_primitive("TargetB")
+            repo.save_primitive(target_a)
+            repo.save_primitive(target_b)
+
+            source = Primitive(
+                name="Source",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.APPLIES_TO,
+                                target_id=target_a.id,
+                                target_depth=DepthLevel.EXISTENCE,
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+
+            # Overwrite with different relata
+            updated = Primitive(
+                id=source.id,
+                name="Source",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.APPLIES_TO,
+                                target_id=target_b.id,
+                                target_depth=DepthLevel.EXISTENCE,
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(updated)
+
+            found = repo.find_by_id(source.id)
+            assert found is not None
+            assert len(found.depths[1].relata) == 1
+            assert found.depths[1].relata[0].target_id == target_b.id
+
+
+# ------------------------------------------------------------------
+# TestListDeleteClear
+# ------------------------------------------------------------------
+
+
+class TestListDeleteClear:
+    def test_list_names_sorted(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            for name in ["Zebra", "Alpha", "middle"]:
+                repo.save_primitive(_make_primitive(name))
+            names = repo.list_names()
+            assert names == ["Alpha", "Zebra", "middle"]
+
+    def test_list_names_empty(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            assert repo.list_names() == []
+
+    def test_delete_returns_true(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File")
+            repo.save_primitive(prim)
+            assert repo.delete_primitive(prim.id) is True
+            assert repo.find_by_id(prim.id) is None
+
+    def test_delete_returns_false_not_found(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            from uuid import uuid4
+
+            assert repo.delete_primitive(uuid4()) is False
+
+    def test_delete_removes_outgoing_relationships(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target = _make_primitive("Target")
+            repo.save_primitive(target)
+
+            source = Primitive(
+                name="Source",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.APPLIES_TO,
+                                target_id=target.id,
+                                target_depth=DepthLevel.EXISTENCE,
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+            repo.delete_primitive(source.id)
+            # Relationships should be gone
+            count = repo._conn.execute(
+                "SELECT COUNT(*) FROM relationships"
+            ).fetchone()[0]
+            assert count == 0
+
+    def test_delete_removes_incoming_relationships(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            target = _make_primitive("Target")
+            repo.save_primitive(target)
+
+            source = Primitive(
+                name="Source",
+                depths=[
+                    Depth(level=DepthLevel.EXISTENCE, provenance=_prov()),
+                    Depth(
+                        level=DepthLevel.IDENTITY,
+                        relata=[
+                            Relatum(
+                                relation_type=RelationType.APPLIES_TO,
+                                target_id=target.id,
+                                target_depth=DepthLevel.EXISTENCE,
+                                provenance=_prov(),
+                            )
+                        ],
+                        provenance=_prov(),
+                    ),
+                ],
+                provenance=_prov(),
+            )
+            repo.save_primitive(source)
+            repo.delete_primitive(target.id)
+            # Relationship row should be gone (deleted as incoming)
+            count = repo._conn.execute(
+                "SELECT COUNT(*) FROM relationships"
+            ).fetchone()[0]
+            assert count == 0
+
+    def test_clear(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            for name in ["A", "B", "C"]:
+                repo.save_primitive(_make_primitive(name))
+            deleted = repo.clear()
+            assert deleted == 3
+            assert repo.list_names() == []
+
+    def test_clear_empty(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            assert repo.clear() == 0
+
+
+# ------------------------------------------------------------------
+# TestMetrics
+# ------------------------------------------------------------------
+
+
+class TestMetrics:
+    def test_update_metrics(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File")
+            repo.save_primitive(prim)
+            from datetime import datetime, timezone
+
+            metrics = PrimitiveMetrics(
+                grounding_count=5,
+                last_grounded=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+            repo.update_metrics(prim.id, metrics)
+            found = repo.find_by_id(prim.id)
+            assert found is not None
+            assert found.metrics is not None
+            assert found.metrics.grounding_count == 5
+
+    def test_batch_read_metrics(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            from datetime import datetime, timezone
+
+            p1 = _make_primitive("A")
+            p2 = _make_primitive("B")
+            repo.save_primitive(p1)
+            repo.save_primitive(p2)
+            metrics = PrimitiveMetrics(
+                grounding_count=3,
+                last_grounded=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            )
+            repo.update_metrics(p1.id, metrics)
+
+            result = repo.batch_read_metrics([p1.id, p2.id])
+            assert p1.id in result
+            assert result[p1.id] is not None
+            assert result[p1.id].grounding_count == 3
+            assert p2.id in result
+            assert result[p2.id] is None
+
+    def test_batch_read_metrics_empty(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            assert repo.batch_read_metrics([]) == {}
+
+    def test_batch_update_metrics(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            from datetime import datetime, timezone
+
+            p1 = _make_primitive("A")
+            p2 = _make_primitive("B")
+            repo.save_primitive(p1)
+            repo.save_primitive(p2)
+
+            m1 = PrimitiveMetrics(grounding_count=10)
+            m2 = PrimitiveMetrics(
+                failure_count=2,
+                last_failed=datetime(2026, 6, 1, tzinfo=timezone.utc),
+            )
+            repo.batch_update_metrics({p1.id: m1, p2.id: m2})
+
+            result = repo.batch_read_metrics([p1.id, p2.id])
+            assert result[p1.id].grounding_count == 10
+            assert result[p2.id].failure_count == 2
+
+    def test_batch_update_metrics_empty(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            repo.batch_update_metrics({})  # should not raise
+
+    def test_metrics_preserved_on_save(self) -> None:
+        """Metrics set via update_metrics survive a save_primitive overwrite when included."""
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File")
+            repo.save_primitive(prim)
+            metrics = PrimitiveMetrics(grounding_count=7)
+            repo.update_metrics(prim.id, metrics)
+
+            # Re-save with metrics attached
+            found = repo.find_by_id(prim.id)
+            repo.save_primitive(found)
+            refound = repo.find_by_id(prim.id)
+            assert refound.metrics is not None
+            assert refound.metrics.grounding_count == 7
+
+
+# ------------------------------------------------------------------
+# TestCycleDetection
+# ------------------------------------------------------------------
+
+
+class TestCycleDetection:
+    def test_self_referential_raises(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("A", DepthLevel.IDENTITY)
+            repo.save_primitive(prim)
+
+            prim.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=prim.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            with pytest.raises(CyclicRelationshipError):
+                repo.save_primitive(prim)
+
+    def test_direct_cycle_raises(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            a = _make_primitive("A", DepthLevel.IDENTITY)
+            b = _make_primitive("B", DepthLevel.IDENTITY)
+            repo.save_primitive(a)
+            repo.save_primitive(b)
+
+            # A -> B
+            a.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.DEPENDS_ON,
+                    target_id=b.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(a)
+
+            # B -> A would cycle
+            b.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.DEPENDS_ON,
+                    target_id=a.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            with pytest.raises(CyclicRelationshipError):
+                repo.save_primitive(b)
+
+    def test_transitive_cycle_raises(self) -> None:
+        """A->B via REQUIRES, B->C via CONSTRAINED_BY, C->A via DEPENDS_ON = cycle."""
+        with SQLiteRepository(":memory:") as repo:
+            a = _make_primitive("A", DepthLevel.IDENTITY)
+            b = _make_primitive("B", DepthLevel.IDENTITY)
+            c = _make_primitive("C", DepthLevel.IDENTITY)
+            repo.save_primitive(a)
+            repo.save_primitive(b)
+            repo.save_primitive(c)
+
+            a.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=b.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(a)
+
+            b.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.CONSTRAINED_BY,
+                    target_id=c.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(b)
+
+            # C -> A would create A->B->C->A cycle
+            c.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.DEPENDS_ON,
+                    target_id=a.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            with pytest.raises(CyclicRelationshipError):
+                repo.save_primitive(c)
+
+    def test_non_transitive_allows_cycle(self) -> None:
+        """APPLIES_TO and INCLUDES should not trigger cycle detection."""
+        with SQLiteRepository(":memory:") as repo:
+            a = _make_primitive("A", DepthLevel.IDENTITY)
+            b = _make_primitive("B", DepthLevel.IDENTITY)
+            repo.save_primitive(a)
+            repo.save_primitive(b)
+
+            a.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.APPLIES_TO,
+                    target_id=b.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(a)
+
+            b.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.APPLIES_TO,
+                    target_id=a.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            # Should not raise
+            repo.save_primitive(b)
+
+    def test_edge_replacement_allows_formerly_cyclic(self) -> None:
+        """After replacing A->B with A->C, B->A should no longer cycle."""
+        with SQLiteRepository(":memory:") as repo:
+            a = _make_primitive("A", DepthLevel.IDENTITY)
+            b = _make_primitive("B", DepthLevel.IDENTITY)
+            c = _make_primitive("C", DepthLevel.IDENTITY)
+            repo.save_primitive(a)
+            repo.save_primitive(b)
+            repo.save_primitive(c)
+
+            # A -> B
+            a.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=b.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(a)
+
+            # Replace A->B with A->C
+            a.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=c.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(a)
+
+            # Now B -> A should be fine
+            b.depths[1].relata = [
+                Relatum(
+                    relation_type=RelationType.REQUIRES,
+                    target_id=a.id,
+                    target_depth=DepthLevel.EXISTENCE,
+                    provenance=_prov(),
+                )
+            ]
+            repo.save_primitive(b)  # Should not raise
+
+
+# ------------------------------------------------------------------
+# TestResolveSubgraph
+# ------------------------------------------------------------------
+
+
+class TestResolveSubgraph:
+    def test_empty_names(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            result = repo.resolve_subgraph([])
+            assert result.roots == []
+            assert result.nodes == []
+            assert result.edges == []
+
+    def test_unknown_name(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            result = repo.resolve_subgraph(["nonexistent"])
+            assert result.roots == []
+            assert result.nodes == []
+            assert result.edges == []
+
+    def test_single_root_no_edges(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("Standalone", DepthLevel.CAPABILITIES)
+            repo.save_primitive(prim)
+            result = repo.resolve_subgraph(["Standalone"])
+            assert len(result.roots) == 1
+            assert result.roots[0].id == prim.id
+            assert len(result.nodes) == 1
+            assert result.edges == []
+
+    def test_case_insensitive_resolution(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prim = _make_primitive("File", DepthLevel.EXISTENCE)
+            repo.save_primitive(prim)
+            result = repo.resolve_subgraph(["file"])
+            assert len(result.roots) == 1
+            assert result.roots[0].name == "File"
+
+    def test_transitive_traversal(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            # directory -> (REQUIRES) path -> (DEPENDS_ON) filesystem -> (DEPENDS_ON) os
+            result = repo.resolve_subgraph(["directory"])
+            node_names = {n.name for n in result.nodes}
+            assert "directory" in node_names
+            assert "path" in node_names
+            assert "filesystem" in node_names
+            assert "operating_system" in node_names
+
+    def test_non_transitive_edges_not_traversed(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            # list has APPLIES_TO directory. Starting from list, should NOT
+            # traverse into directory's transitive subgraph.
+            result = repo.resolve_subgraph(["list"])
+            node_names = {n.name for n in result.nodes}
+            assert "list" in node_names
+            # APPLIES_TO is non-transitive, so directory should not be reached
+            assert "directory" not in node_names
+
+    def test_non_transitive_edges_included_between_reachable_nodes(self) -> None:
+        """Even though APPLIES_TO is not traversed, if both ends are in the subgraph,
+        the edge should be included."""
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            # Resolve both list and directory
+            result = repo.resolve_subgraph(["list", "directory"])
+            node_names = {n.name for n in result.nodes}
+            assert "list" in node_names
+            assert "directory" in node_names
+            # The APPLIES_TO edge between list and directory should be present
+            applies_to_edges = [
+                e
+                for e in result.edges
+                if e.relation_type == RelationType.APPLIES_TO
+                and e.source_id == prims["list"].id
+                and e.target_id == prims["directory"].id
+            ]
+            assert len(applies_to_edges) == 1
+
+    def test_roots_are_only_matched_names(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            result = repo.resolve_subgraph(["directory"])
+            root_names = {r.name for r in result.roots}
+            assert root_names == {"directory"}
+            # path, filesystem, os should be in nodes but not roots
+            node_names = {n.name for n in result.nodes}
+            assert "path" in node_names
+
+    def test_multiple_roots(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            result = repo.resolve_subgraph(["file", "directory"])
+            root_names = {r.name for r in result.roots}
+            assert root_names == {"file", "directory"}
+
+    def test_hydrated_nodes_have_relata(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            result = repo.resolve_subgraph(["directory"])
+            # Find directory node
+            dir_nodes = [n for n in result.nodes if n.name == "directory"]
+            assert len(dir_nodes) == 1
+            dir_node = dir_nodes[0]
+            # directory has relata on D1 (REQUIRES path) and D2 (DEPENDS_ON filesystem)
+            all_relata = [r for d in dir_node.depths for r in d.relata]
+            assert len(all_relata) >= 2
+
+    def test_all_edges_between_nodes(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            result = repo.resolve_subgraph(["directory"])
+            # Should have edges: directory->path (REQUIRES), directory->filesystem (DEPENDS_ON),
+            # path->filesystem (DEPENDS_ON), filesystem->os (DEPENDS_ON)
+            edge_pairs = {(e.source_id, e.target_id) for e in result.edges}
+            assert (prims["directory"].id, prims["path"].id) in edge_pairs
+            assert (prims["directory"].id, prims["filesystem"].id) in edge_pairs
+            assert (prims["path"].id, prims["filesystem"].id) in edge_pairs
+            assert (prims["filesystem"].id, prims["operating_system"].id) in edge_pairs
+
+    def test_edges_are_epistemic_steps(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            prims = _seed_filesystem_graph(repo)
+            result = repo.resolve_subgraph(["directory"])
+            for edge in result.edges:
+                assert isinstance(edge, EpistemicStep)
+                assert isinstance(edge.relation_type, RelationType)
+                assert isinstance(edge.source_depth, DepthLevel)
+                assert isinstance(edge.target_depth, DepthLevel)

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -5,12 +5,10 @@
 Comprehensive test suite for SQLiteRepository.
 """
 
-import sqlite3
-
 import pytest
 
 from vre.core.backends.sqlite import SQLiteRepository
-from vre.core.errors import CyclicRelationshipError, HydrationError, PersistenceError
+from vre.core.errors import CyclicRelationshipError
 from vre.core.grounding import GroundingEngine
 from vre.core.models import (
     Depth,
@@ -22,7 +20,6 @@ from vre.core.models import (
     ProvenanceSource,
     Relatum,
     RelationType,
-    ResolvedSubgraph,
 )
 from vre.core.policy.models import Cardinality, Policy
 
@@ -862,7 +859,7 @@ class TestResolveSubgraph:
 
     def test_transitive_traversal(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             # directory -> (REQUIRES) path -> (DEPENDS_ON) filesystem -> (DEPENDS_ON) os
             result = repo.resolve_subgraph(["directory"])
             node_names = {n.name for n in result.nodes}
@@ -873,7 +870,7 @@ class TestResolveSubgraph:
 
     def test_non_transitive_edges_not_traversed(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             # list has APPLIES_TO directory. Starting from list, should NOT
             # traverse into directory's transitive subgraph.
             result = repo.resolve_subgraph(["list"])
@@ -904,7 +901,7 @@ class TestResolveSubgraph:
 
     def test_roots_are_only_matched_names(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             result = repo.resolve_subgraph(["directory"])
             root_names = {r.name for r in result.roots}
             assert root_names == {"directory"}
@@ -914,14 +911,14 @@ class TestResolveSubgraph:
 
     def test_multiple_roots(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             result = repo.resolve_subgraph(["file", "directory"])
             root_names = {r.name for r in result.roots}
             assert root_names == {"file", "directory"}
 
     def test_hydrated_nodes_have_relata(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             result = repo.resolve_subgraph(["directory"])
             # Find directory node
             dir_nodes = [n for n in result.nodes if n.name == "directory"]
@@ -945,7 +942,7 @@ class TestResolveSubgraph:
 
     def test_edges_are_epistemic_steps(self) -> None:
         with SQLiteRepository(":memory:") as repo:
-            prims = _seed_filesystem_graph(repo)
+            _seed_filesystem_graph(repo)
             result = repo.resolve_subgraph(["directory"])
             for edge in result.edges:
                 assert isinstance(edge, EpistemicStep)

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -11,6 +11,7 @@ import pytest
 
 from vre.core.backends.sqlite import SQLiteRepository
 from vre.core.errors import CyclicRelationshipError, HydrationError, PersistenceError
+from vre.core.grounding import GroundingEngine
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -951,3 +952,59 @@ class TestResolveSubgraph:
                 assert isinstance(edge.relation_type, RelationType)
                 assert isinstance(edge.source_depth, DepthLevel)
                 assert isinstance(edge.target_depth, DepthLevel)
+
+
+# ------------------------------------------------------------------
+# TestUpsertPrimitive
+# ------------------------------------------------------------------
+
+
+class TestUpsertPrimitive:
+    def test_upsert_creates_new(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            p = _make_primitive("file")
+            result = repo.upsert_primitive(p)
+            assert result.id == p.id
+            assert repo.find_by_name("file") is not None
+
+    def test_upsert_preserves_existing_id(self) -> None:
+        with SQLiteRepository(":memory:") as repo:
+            existing = _make_primitive("file")
+            repo.save_primitive(existing)
+            incoming = _make_primitive("file")
+            result = repo.upsert_primitive(incoming)
+            assert result.id == existing.id
+            assert result.id != incoming.id
+
+
+# ------------------------------------------------------------------
+# TestGroundingEngineWithSQLite
+# ------------------------------------------------------------------
+
+
+class TestGroundingEngineWithSQLite:
+    def test_clean_pass(self) -> None:
+        """list + directory with full grounding -> no gaps."""
+        with SQLiteRepository(":memory:") as repo:
+            _seed_filesystem_graph(repo)
+            engine = GroundingEngine(repo)
+            response = engine.query(["list", "directory"])
+            assert response.result.gaps == []
+
+    def test_existence_gap(self) -> None:
+        """Unknown concept -> ExistenceGap."""
+        with SQLiteRepository(":memory:") as repo:
+            _seed_filesystem_graph(repo)
+            engine = GroundingEngine(repo)
+            response = engine.query(["unknown_concept"])
+            assert len(response.result.gaps) == 1
+            assert response.result.gaps[0].kind == "EXISTENCE"
+
+    def test_relational_gap(self) -> None:
+        """read targets file at D2 but file is only D1 -> RelationalGap."""
+        with SQLiteRepository(":memory:") as repo:
+            _seed_filesystem_graph(repo)
+            engine = GroundingEngine(repo)
+            response = engine.query(["read", "file"])
+            gap_kinds = [g.kind for g in response.result.gaps]
+            assert "RELATIONAL" in gap_kinds


### PR DESCRIPTION
## Summary

- **New `SQLiteRepository(Repository)` backend** — full implementation of the Repository ABC using SQLite, with recursive CTEs for transitive traversal and cycle detection. Zero external dependencies; database defaults to `~/.vre/graph.db` and is created automatically on first use.
- **Neo4j is now an optional dependency** — `pip install vre` works with SQLite only; `pip install vre[neo4j]` adds Neo4j support. Conditional imports with clear error handling.
- **All scripts and examples default to SQLite** — `--backend neo4j` flag available everywhere for Neo4j users. Backend-specific flags grouped in `--help` output.
- **56 new tests** covering the full Repository contract: CRUD, metrics, cycle detection, `resolve_subgraph`, upsert, grounding engine integration, and export verification.

Closes #70

## Test plan

- [ ] `pytest tests/vre/test_sqlite.py -v` — 56 SQLite-specific tests pass
- [ ] `pytest tests/ -v` — full suite (307 tests) passes at 77% coverage
- [ ] `python -m scripts.seed_gaps` — seeds 10 primitives to `~/.vre/graph.db`
- [ ] `python -m seeders.seed_filesystem --sqlite-path :memory:` — seeds 20 primitives
- [ ] `python examples/claude-code/claude_code.py install --help` — shows backend arg groups
- [ ] End-to-end: seed → `VRE.check(["list", "directory"])` returns grounded; `VRE.check(["read", "file"])` returns RelationalGap

🤖 Generated with [Claude Code](https://claude.com/claude-code)