### PR TITLE
fix: SQLite-only install crashes + learning silent no-op (0.9.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,10 +669,15 @@ filesystem state.
 
 ### Policy Wizard
 
-The wizard provides an interactive CLI to attach policies to `APPLIES_TO` relata without manually editing seed scripts:
+`run_wizard(repo)` is an interactive helper for attaching policies to `APPLIES_TO` relata without manually editing seed
+scripts. Construct a repository and pass it in:
 
-```bash
-poetry run python -m vre.core.policy.wizard
+```python
+from vre.core.backends import SQLiteRepository
+from vre.core.policy.wizard import run_wizard
+
+with SQLiteRepository() as repo:
+    run_wizard(repo)
 ```
 
 It walks you through selecting source and target primitives, viewing the relata table, defining policy fields, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.9.0"
+version = "0.9.1"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,6 +1,11 @@
 import argparse
 
-from vre.core.backends import Neo4jRepository, Repository, SQLiteRepository
+from vre.core.backends import Repository, SQLiteRepository
+
+try:
+    from vre.core.backends import Neo4jRepository
+except ImportError:
+    Neo4jRepository = None
 
 
 def add_backend_args(parser: argparse.ArgumentParser) -> None:
@@ -27,4 +32,6 @@ def add_backend_args(parser: argparse.ArgumentParser) -> None:
 def make_repository(args: argparse.Namespace) -> Repository:
     if args.backend == "sqlite":
         return SQLiteRepository(args.sqlite_path)
+    if Neo4jRepository is None:
+        raise SystemExit("The neo4j backend requires the optional 'neo4j' extra: pip install 'vre[neo4j]'")
     return Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password)

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -209,16 +209,19 @@ class GroundingEngine:
     @staticmethod
     def _reachable_undirected(root_id: UUID, neighbors: dict[UUID, set[UUID]]) -> set[UUID]:
         """
-        BFS from root_id over the undirected neighbor graph; returns all reachable node IDs.
+        DFS from root_id over the undirected neighbor graph; returns all reachable node IDs.
+
+        Traversal order does not affect the result — the full connected component
+        is returned regardless — so a stack (DFS) is used.
         """
         visited: set[UUID] = {root_id}
-        queue: list[UUID] = [root_id]
-        while queue:
-            current = queue.pop()
+        stack: list[UUID] = [root_id]
+        while stack:
+            current = stack.pop()
             for neighbor in neighbors.get(current, set()):
                 if neighbor not in visited:
                     visited.add(neighbor)
-                    queue.append(neighbor)
+                    stack.append(neighbor)
         return visited
 
     @staticmethod

--- a/src/vre/core/policy/wizard.py
+++ b/src/vre/core/policy/wizard.py
@@ -4,16 +4,21 @@
 """
 Policy Wizard — interactive tool for attaching policies to APPLIES_TO relata.
 
-Run: python -m vre.core.policy.wizard
+`run_wizard` is a helper: construct a repository and pass it in.
+
+    from vre.core.backends import SQLiteRepository
+    from vre.core.policy.wizard import run_wizard
+
+    with SQLiteRepository() as repo:
+        run_wizard(repo)
 """
 
 from __future__ import annotations
 
-import argparse
 import importlib
 from uuid import UUID
 
-from vre.core.backends import Neo4jRepository, Repository
+from vre.core.backends import Repository
 from vre.core.models import DepthLevel, RelationType, Relatum, format_depth_label
 from vre.core.policy.models import Cardinality, Policy
 
@@ -261,21 +266,3 @@ def run_wizard(repo: Repository) -> None:
                 f"\n  Saved policy '{policy.name}' on "
                 f"{source.name} --[APPLIES_TO @ {format_depth_label(chosen_depth_level)}]--> {target.name}\n"
             )
-
-
-def main() -> None:
-    """
-    Entry point: parse CLI arguments and launch the policy wizard.
-    """
-    parser = argparse.ArgumentParser(description="VRE Policy Wizard")
-    parser.add_argument("--neo4j-uri", default="neo4j://localhost:7687")
-    parser.add_argument("--neo4j-user", default="neo4j")
-    parser.add_argument("--neo4j-password", default="password")
-    args = parser.parse_args()
-
-    with Neo4jRepository(args.neo4j_uri, args.neo4j_user, args.neo4j_password) as repo:
-        run_wizard(repo)
-
-
-if __name__ == "__main__":
-    main()

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -282,6 +282,10 @@ class LearningEngine:
                 self._persist_relational(gap, candidate, provenance)
             case (ReachabilityGap(), ReachabilityCandidate()):
                 self._persist_reachability(gap, candidate, provenance)
+            case _:
+                raise CandidateValidationError(
+                    f"No persistence path for gap '{gap.kind}' with candidate '{candidate.kind}'"
+                )
 
     def learn_gap(
         self,
@@ -295,6 +299,10 @@ class LearningEngine:
         Raises CandidateValidationError if the candidate is invalid.
         """
         logger.info("Learning gap: %s", gap.kind)
+        if gap.kind != candidate.kind:
+            raise CandidateValidationError(
+                f"Candidate kind '{candidate.kind}' does not match gap kind '{gap.kind}'"
+            )
         candidate.validate_for_gap(gap)
         provenance = _make_provenance(source)
         self._persist(gap, candidate, provenance)

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -556,6 +556,34 @@ class TestLearnGap:
         saved = repo.saved[0]
         assert saved.provenance.source == ProvenanceSource.CONVERSATIONAL
 
+    def test_rejects_mismatched_gap_candidate_kind(self):
+        # ExistenceGap fed a well-formed DepthCandidate: the kind guard must
+        # reject the pair before any persistence is attempted.
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Widget"))
+        filled = DepthCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.IDENTITY, properties={"description": "x"})],
+        )
+
+        with pytest.raises(CandidateValidationError, match="does not match gap kind"):
+            engine.learn_gap(gap, filled)
+        assert repo.saved == []
+
+    def test_persist_rejects_unhandled_pair(self):
+        # Direct _persist bypasses the learn_gap kind guard; the match's case _
+        # backstop must still raise instead of silently persisting nothing.
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Widget"))
+        filled = DepthCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.IDENTITY, properties={"description": "x"})],
+        )
+
+        with pytest.raises(CandidateValidationError, match="No persistence path"):
+            engine._persist(gap, filled, _make_provenance(ProvenanceSource.LEARNED))
+        assert repo.saved == []
+
 
 # ---------------------------------------------------------------------------
 # Reachability prerequisites tests


### PR DESCRIPTION
Fixes a set of latent bugs surfaced during review. All changes are bug fixes; version bumped `0.9.0` → `0.9.1`.

## Fixes

### 1. Seeders & policy wizard crashed on SQLite-only installs
`neo4j` is an optional extra, but two entry points imported `Neo4jRepository` unconditionally:
- `scripts/__init__.py` — crashed both seeders (`clear_graph.py`, `seed_gaps.py`) on import. Now guarded, with a clear `SystemExit` if `--backend neo4j` is requested without the extra.
- `src/vre/core/policy/wizard.py` — same latent import crash plus a hardcoded-Neo4j CLI `main()`. The CLI shim is removed; `run_wizard(repo)` is now a pure helper that operates on any `Repository` the caller constructs (no backend coupling, no `library → scripts` dependency). README updated to show the helper usage.

### 2. Silent no-op on a mismatched gap/candidate pair
`LearningEngine._persist` matched on `(gap, candidate)` type pairs with no fallback, and `validate_for_gap` only checked payload non-emptiness — never that the candidate kind matched the gap kind. A mismatched pair (e.g. `ExistenceGap` + `DepthCandidate`) passed validation, fell through every case, and persisted nothing with no error. Added:
- an early `gap.kind != candidate.kind` guard in `learn_gap` (clear, early error), and
- a total-match `case _:` backstop in `_persist`.

Two regression tests added to `TestLearnGap`, each isolating one guard via its distinct error message.

### 3. Cosmetic: reachability traversal comment
`_reachable_undirected` uses `list.pop()` (LIFO → DFS) but was documented as BFS with a `queue`. The reachable set is order-independent, so this is purely a comment/naming fix (`queue` → `stack`, labelled DFS).

## Testing
- `293 passed` (291 + 2 new), coverage 74.46% (gate: 70%)
- `ruff` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)