### PR TITLE
feat(policy): redesign callback context — composed PolicyCallContext + per-edge identity (#58)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Claude Code
 .claude/
+docs/superpowers/
 CLAUDE.md
 
 # Python

--- a/README.md
+++ b/README.md
@@ -608,8 +608,11 @@ A `PolicyCallback` is a callable attached to a `Policy` that runs *during* evalu
 decisions. This is distinct from `on_policy`, which handles human confirmation
 *after* violations are collected. A policy callback determines whether a violation fires at all.
 
-The callback receives a `PolicyCallContext` containing the tool name, the full grounding result, and the original
-function arguments. It returns a `PolicyCallbackResult` — `passed=True` suppresses the
+The callback receives a `PolicyCallContext` composed of four parts: `tool_call` (the invocation —
+`tool_name`, `call_args`, `call_kwargs`), `grounding` (a bounded facade — `agent_id` and the
+`resolved_concepts` grounded in this call), `triggering_edge` (the specific edge that fired the
+callback — source/target concept and the source/target depths), and `policy` (the `Policy` that
+fired, including its `metadata`). It returns a `PolicyCallbackResult` — `passed=True` suppresses the
 violation, `passed=False` fires it.
 
 ```python
@@ -621,7 +624,7 @@ class BlockProtectedFiles:
     """Block deletion of files matching 'protected*'."""
 
     def __call__(self, context: PolicyCallContext) -> PolicyCallbackResult:
-        command = context.call_args[0] if context.call_args else ""
+        command = context.tool_call.call_args[0] if context.tool_call.call_args else ""
         targets = [t for t in command.split()[1:] if not t.startswith("-")]
 
         for target in targets:

--- a/examples/langchain_ollama/policies.py
+++ b/examples/langchain_ollama/policies.py
@@ -26,10 +26,10 @@ def _extract_command(context: PolicyCallContext) -> str:
     """
     Pull the command string from call_args or call_kwargs.
     """
-    if context.call_args:
-        command = str(context.call_args[0])
+    if context.tool_call.call_args:
+        command = str(context.tool_call.call_args[0])
     else:
-        command = str(context.call_kwargs.get("command", ""))
+        command = str(context.tool_call.call_kwargs.get("command", ""))
     return command
 
 
@@ -116,7 +116,7 @@ def protected_file_delete(context: PolicyCallContext) -> PolicyCallbackResult:
     `passed=False` (violation fires) when protected files are at risk.
     """
     command: str = _extract_command(context)
-    cwd: str = context.call_kwargs.get("cwd", ".")
+    cwd: str = context.tool_call.call_kwargs.get("cwd", ".")
 
     if not command:
         callback_result = PolicyCallbackResult(passed=True)

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -209,12 +209,9 @@ class VRE:
                     card_enum = None  # unknown -> fire all policies
 
             gate = PolicyGate()
-            grounding_ctx = GroundingContext(
-                agent_id=grounding.agent_id,
-                resolved_concepts=grounding.resolved,
-            )
             violations = gate.evaluate(
-                grounding.trace, card_enum, tool_call=tool_call, grounding=grounding_ctx,
+                grounding.trace, card_enum, tool_call=tool_call,
+                grounding=GroundingContext.from_grounding(grounding),
             )
 
             if not violations:

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -42,7 +42,12 @@ from vre.core.models import (
     ProvenanceSource,
 )
 from vre.core.policy import Cardinality, PolicyAction, PolicyCallbackResult, PolicyResult, PolicyViolation
-from vre.core.policy.callback import PolicyCallContext
+from vre.core.policy.callback import (
+    GroundingContext,
+    PolicyCallContext,
+    ToolCallContext,
+    TriggeringEdge,
+)
 from vre.core.policy.gate import PolicyGate
 from vre.identity import AgentIdentity, AgentRegistry
 from vre.learning import LearningEngine, template_for_gap
@@ -80,6 +85,9 @@ __all__ = [
     "PolicyResult",
     "PolicyViolation",
     "PolicyCallContext",
+    "ToolCallContext",
+    "GroundingContext",
+    "TriggeringEdge",
     "PolicyGate",
     "LearningEngine",
     "template_for_gap",
@@ -165,7 +173,7 @@ class VRE:
         self,
         concepts: list[str] | GroundingResult,
         cardinality: str | None = None,
-        call_context: PolicyCallContext | None = None,
+        tool_call: ToolCallContext | None = None,
         on_policy: Callable[[list[PolicyViolation]], bool] | None = None,
     ) -> PolicyResult:
         """
@@ -174,9 +182,9 @@ class VRE:
         `concepts` may be a list of concept names (grounding is run) or a
         pre-computed `GroundingResult` (grounding is skipped).
 
-        `call_context` carries the tool name, grounding result, and the args/
-        kwargs of the decorated function so that policy callbacks can make
-        domain-specific decisions. Omit when calling outside a guarded context.
+        `tool_call` carries the tool name and the args/kwargs of the decorated
+        function so that policy callbacks can make domain-specific decisions.
+        Omit when calling outside a guarded context.
 
         `on_policy` is an optional handler consulted when any violation has
         `requires_confirmation=True`. It receives all violations and returns
@@ -201,7 +209,13 @@ class VRE:
                     card_enum = None  # unknown -> fire all policies
 
             gate = PolicyGate()
-            violations = gate.evaluate(grounding.trace, card_enum, call_context)
+            grounding_ctx = GroundingContext(
+                agent_id=grounding.agent_id,
+                resolved_concepts=grounding.resolved,
+            )
+            violations = gate.evaluate(
+                grounding.trace, card_enum, tool_call=tool_call, grounding=grounding_ctx,
+            )
 
             if not violations:
                 policy_result = PolicyResult(action=PolicyAction.PASS)

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -225,7 +225,9 @@ class VRE:
 
                 # Hard blocks do not consult on_policy — they are immediate BLOCKs with their own messages
                 if hard_blocks:
-                    messages = "; ".join(v.message for v in hard_blocks)
+                    # Violation messages are multi-line (callback reason + confirmation);
+                    # separate distinct hard blocks with a blank line to keep them readable.
+                    messages = "\n\n".join(v.message for v in hard_blocks)
                     policy_result = PolicyResult(
                         action=PolicyAction.BLOCK,
                         reason=messages,

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -346,6 +346,7 @@ class GroundingEngine:
         """
         if not concepts:
             logger.debug("Ground called with empty concepts")
+            # TODO: Why not use the _empty_response for the trace here?
             result = GroundingResult(grounded=False, resolved=[], gaps=[], trace=None)
         else:
             logger.info("Grounding %d concept(s)", len(concepts))

--- a/src/vre/core/policy/callback.py
+++ b/src/vre/core/policy/callback.py
@@ -23,13 +23,16 @@ Example::
             return PolicyCallbackResult(passed=False)
 """
 
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 from uuid import UUID
 
 from pydantic import BaseModel, Field
 
 from vre.core.models import DepthLevel
 from vre.core.policy.models import Policy, PolicyCallbackResult
+
+if TYPE_CHECKING:
+    from vre.core.grounding import GroundingResult
 
 
 class ToolCallContext(BaseModel):
@@ -59,6 +62,14 @@ class GroundingContext(BaseModel):
 
     agent_id: UUID | None = None
     resolved_concepts: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_grounding(cls, grounding: "GroundingResult") -> "GroundingContext":
+        """
+        Project the bounded, callback-facing facade from a full GroundingResult —
+        only `agent_id` and the resolved concept names cross this boundary.
+        """
+        return cls(agent_id=grounding.agent_id, resolved_concepts=grounding.resolved)
 
 
 class TriggeringEdge(BaseModel):

--- a/src/vre/core/policy/callback.py
+++ b/src/vre/core/policy/callback.py
@@ -21,11 +21,56 @@ Example::
 """
 
 from typing import Any, Protocol
+from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from vre.core.grounding import GroundingResult
+from vre.core.models import DepthLevel
 from vre.core.policy.models import PolicyCallbackResult
+
+
+class ToolCallContext(BaseModel):
+    """
+    The tool invocation being gated — only what the caller knows.
+
+    Built by `vre_guard` (or an integrator calling `check_policy` directly).
+    The grounding facade and the per-edge identity are not here: VRE derives
+    the former and the gate builds the latter.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}  # call args may be arbitrary objects
+
+    tool_name: str
+    call_args: tuple[Any, ...] = ()
+    call_kwargs: dict[str, Any] = Field(default_factory=dict)
+
+
+class GroundingContext(BaseModel):
+    """
+    Minimal, VRE-authored view of the grounding that occurred in this call.
+
+    Replaces the leaky full `GroundingResult`. Callbacks may branch on which
+    other root concepts were grounded alongside the triggering edge. `agent_id`
+    is callback pass-through — policy firing is agent-agnostic.
+    """
+
+    agent_id: UUID | None = None
+    resolved_concepts: list[str] = Field(default_factory=list)
+
+
+class TriggeringEdge(BaseModel):
+    """
+    The specific APPLIES_TO edge whose policy invoked this callback.
+
+    Lets one callback registered on several edges tell them apart — by
+    source/target concept and by the depth the edge lives at (D2 vs D3).
+    """
+
+    source_name: str
+    target_name: str
+    source_depth: DepthLevel
+    target_depth: DepthLevel
 
 
 class PolicyCallContext(BaseModel):

--- a/src/vre/core/policy/callback.py
+++ b/src/vre/core/policy/callback.py
@@ -5,7 +5,10 @@
 PolicyCallback Protocol and PolicyCallContext — the user-facing callback contract.
 
 Users implementing custom policy logic should type-annotate against
-PolicyCallback and accept a PolicyCallContext argument.
+PolicyCallback and accept a PolicyCallContext argument. PolicyCallContext is a
+composition of four orthogonal pieces — the tool call (`tool_call`), a bounded
+grounding facade (`grounding`), the edge that fired (`triggering_edge`), and the
+policy itself (`policy`).
 
 Example::
 
@@ -14,7 +17,7 @@ Example::
 
     class AllowTempWrites:
         def __call__(self, context: PolicyCallContext) -> PolicyCallbackResult:
-            path = context.call_kwargs.get("path", "")
+            path = context.tool_call.call_kwargs.get("path", "")
             if path.startswith("/tmp"):
                 return PolicyCallbackResult(passed=True, message="Temp writes allowed")
             return PolicyCallbackResult(passed=False)
@@ -25,9 +28,8 @@ from uuid import UUID
 
 from pydantic import BaseModel, Field
 
-from vre.core.grounding import GroundingResult
 from vre.core.models import DepthLevel
-from vre.core.policy.models import PolicyCallbackResult
+from vre.core.policy.models import Policy, PolicyCallbackResult
 
 
 class ToolCallContext(BaseModel):
@@ -75,26 +77,17 @@ class TriggeringEdge(BaseModel):
 
 class PolicyCallContext(BaseModel):
     """
-    Context passed to a policy callback at evaluation time.
+    Complete, per-edge context passed to a policy callback.
 
-    Attributes
-    ----------
-    tool_name:
-        Name of the decorated function that triggered the policy check.
-    grounding:
-        The GroundingResult from grounding, including the full epistemic trace.
-    call_args:
-        Positional arguments the decorated function was called with.
-    call_kwargs:
-        Keyword arguments the decorated function was called with.
+    A composition of four orthogonal pieces: the tool call, the grounding
+    facade, the edge that fired, and the policy that fired. All are populated
+    by the gate before the callback runs.
     """
 
-    model_config = {"arbitrary_types_allowed": True}
-
-    tool_name: str
-    grounding: GroundingResult
-    call_args: tuple[Any, ...]
-    call_kwargs: dict[str, Any]
+    tool_call: ToolCallContext
+    grounding: GroundingContext
+    triggering_edge: TriggeringEdge
+    policy: Policy
 
 
 class PolicyCallback(Protocol):

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -8,7 +8,12 @@ PolicyGate — evaluates policy violations against an epistemic trace.
 import logging
 
 from vre.core.models import EpistemicResponse, RelationType
-from vre.core.policy.callback import PolicyCallContext
+from vre.core.policy.callback import (
+    GroundingContext,
+    PolicyCallContext,
+    ToolCallContext,
+    TriggeringEdge,
+)
 from vre.core.policy.models import Cardinality, PolicyCallbackResult, PolicyViolation
 
 logger = logging.getLogger(__name__)
@@ -22,15 +27,19 @@ class PolicyGate:
     def _collect_violations(
         response: EpistemicResponse,
         cardinality: Cardinality | None = None,
-        call_context: PolicyCallContext | None = None,
+        tool_call: ToolCallContext | None = None,
+        grounding: GroundingContext | None = None,
     ) -> list[PolicyViolation]:
         """
         Walk all APPLIES_TO relata in the trace and collect triggered policy violations.
 
         When cardinality is None (unknown), all policies fire — we cannot justify
-        skipping any policy without knowing the cardinality.
+        skipping any policy without knowing the cardinality. A `PolicyCallContext`
+        is built per edge, but only when the policy has a callback and a `tool_call`
+        is present; otherwise no context is allocated and the policy simply fires.
         """
         violations: list[PolicyViolation] = []
+        id_to_name = {p.id: p.name for p in response.result.primitives}
         for primitive in response.result.primitives:
             for depth in primitive.depths:
                 for relatum in depth.relata:
@@ -47,8 +56,21 @@ class PolicyGate:
                             continue
                         cb = policy.resolve_callback()
                         cb_result: PolicyCallbackResult | None = None
-                        if cb is not None and call_context is not None:
-                            cb_result = cb(call_context)
+                        if cb is not None and tool_call is not None:
+                            context = PolicyCallContext(
+                                tool_call=tool_call,
+                                grounding=grounding or GroundingContext(),
+                                triggering_edge=TriggeringEdge(
+                                    source_name=primitive.name,
+                                    target_name=id_to_name.get(
+                                        relatum.target_id, str(relatum.target_id)
+                                    ),
+                                    source_depth=depth.level,
+                                    target_depth=relatum.target_depth,
+                                ),
+                                policy=policy,
+                            )
+                            cb_result = cb(context)
                             if cb_result.passed:
                                 logger.debug("Policy %r passed by callback", policy.name)
                                 continue  # action passed the policy — no violation
@@ -71,13 +93,17 @@ class PolicyGate:
         self,
         response: EpistemicResponse,
         cardinality: Cardinality | None = None,
-        call_context: PolicyCallContext | None = None,
+        tool_call: ToolCallContext | None = None,
+        grounding: GroundingContext | None = None,
     ) -> list[PolicyViolation]:
         """
         Evaluate all policies in the trace and return triggered violations.
         """
-        logger.debug("Evaluating policies (cardinality=%s, has_context=%s)", cardinality, call_context is not None)
-        violations = self._collect_violations(response, cardinality, call_context)
+        logger.debug(
+            "Evaluating policies (cardinality=%s, has_tool_call=%s)",
+            cardinality, tool_call is not None,
+        )
+        violations = self._collect_violations(response, cardinality, tool_call, grounding)
         if violations:
             logger.info("Policy evaluation: %d violation(s)", len(violations))
         else:

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -34,9 +34,9 @@ class PolicyGate:
         Walk all APPLIES_TO relata in the trace and collect triggered policy violations.
 
         When cardinality is None (unknown), all policies fire — we cannot justify
-        skipping any policy without knowing the cardinality. A `PolicyCallContext`
-        is built per edge, but only when the policy has a callback and a `tool_call`
-        is present; otherwise no context is allocated and the policy simply fires.
+        skipping any policy without knowing the cardinality. A callback is consulted
+        only when a `tool_call` is present; without one it cannot be evaluated, so the
+        policy fires conservatively with an explicit reason (see the else branch).
         """
         violations: list[PolicyViolation] = []
         id_to_name = {p.id: p.name for p in response.result.primitives}
@@ -56,32 +56,41 @@ class PolicyGate:
                             continue
                         cb = policy.resolve_callback()
                         cb_result: PolicyCallbackResult | None = None
-                        # Without a tool_call we cannot justify that the action is safe (a
-                        # callback may require the call args). Fail closed by construction:
-                        # skip the callback and fire the policy. Do NOT relax to
-                        # `if cb is not None` — that delegates safety to integrator discipline
-                        # (callbacks remembering to guard against a None tool_call), which a
-                        # safety-by-construction framework must not rely on.
-                        if cb is not None and tool_call is not None:
-                            context = PolicyCallContext(
-                                tool_call=tool_call,
-                                grounding=grounding or GroundingContext(),
-                                triggering_edge=TriggeringEdge(
-                                    source_name=primitive.name,
-                                    target_name=id_to_name.get(
-                                        relatum.target_id, str(relatum.target_id)
+                        if cb is not None:
+                            if tool_call is not None:
+                                context = PolicyCallContext(
+                                    tool_call=tool_call,
+                                    grounding=grounding or GroundingContext(),
+                                    triggering_edge=TriggeringEdge(
+                                        source_name=primitive.name,
+                                        target_name=id_to_name.get(
+                                            relatum.target_id, str(relatum.target_id)
+                                        ),
+                                        source_depth=depth.level,
+                                        target_depth=relatum.target_depth,
                                     ),
-                                    source_depth=depth.level,
-                                    target_depth=relatum.target_depth,
-                                ),
-                                policy=policy,
-                            )
-                            cb_result = cb(context)
-                            if cb_result.passed:
-                                logger.debug("Policy %r passed by callback", policy.name)
-                                continue  # action passed the policy — no violation
+                                    policy=policy,
+                                )
+                                cb_result = cb(context)
+                                if cb_result.passed:
+                                    logger.debug("Policy %r passed by callback", policy.name)
+                                    continue  # action passed the policy — no violation
+                            else:
+                                # Callback present but unevaluable without a tool call. Fail closed
+                                # by construction — do not trust the callback to have what it needs —
+                                # and record an explicit reason so the conservative fire does not
+                                # masquerade as a plain trigger.
+                                cb_result = PolicyCallbackResult(
+                                    passed=False,
+                                    message="Policy callback could not be evaluated (no tool call in this context); firing conservatively.",
+                                )
 
-                        message = policy.confirmation_message
+                        # Most specific reason first (the callback's, when it fired or could not be
+                        # evaluated), always followed by the integrator's confirmation message.
+                        if cb_result is not None and cb_result.message:
+                            message = f"{cb_result.message}\n{policy.confirmation_message}"
+                        else:
+                            message = policy.confirmation_message
 
                         logger.info(
                             "Policy violation: %r — %s (requires_confirmation=%s)",

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -53,12 +53,7 @@ class PolicyGate:
                                 logger.debug("Policy %r passed by callback", policy.name)
                                 continue  # action passed the policy — no violation
 
-                        try:
-                            message = policy.confirmation_message.format(
-                                action=primitive.name
-                            )
-                        except (KeyError, ValueError):
-                            message = policy.confirmation_message
+                        message = policy.confirmation_message
 
                         logger.info(
                             "Policy violation: %r — %s (requires_confirmation=%s)",

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -79,7 +79,10 @@ class PolicyGate:
                             else:
                                 # No tool_call ⇒ the callback cannot be evaluated. Fail closed
                                 # by construction rather than trusting it to handle a missing call.
-                                cb_result = PolicyCallbackResult.unevaluable()
+                                cb_result = PolicyCallbackResult.unevaluable(
+                                    "Policy callback could not be evaluated (no tool call "
+                                    "in this context); firing conservatively."
+                                )
 
                         violation = PolicyViolation(policy=policy, callback_result=cb_result)
                         logger.info(

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -56,6 +56,12 @@ class PolicyGate:
                             continue
                         cb = policy.resolve_callback()
                         cb_result: PolicyCallbackResult | None = None
+                        # Without a tool_call we cannot justify that the action is safe (a
+                        # callback may require the call args). Fail closed by construction:
+                        # skip the callback and fire the policy. Do NOT relax to
+                        # `if cb is not None` — that delegates safety to integrator discipline
+                        # (callbacks remembering to guard against a None tool_call), which a
+                        # safety-by-construction framework must not rely on.
                         if cb is not None and tool_call is not None:
                             context = PolicyCallContext(
                                 tool_call=tool_call,

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -40,6 +40,7 @@ class PolicyGate:
         """
         violations: list[PolicyViolation] = []
         id_to_name = {p.id: p.name for p in response.result.primitives}
+        grounding = grounding or GroundingContext()
         for primitive in response.result.primitives:
             for depth in primitive.depths:
                 for relatum in depth.relata:
@@ -60,7 +61,7 @@ class PolicyGate:
                             if tool_call is not None:
                                 context = PolicyCallContext(
                                     tool_call=tool_call,
-                                    grounding=grounding or GroundingContext(),
+                                    grounding=grounding,
                                     triggering_edge=TriggeringEdge(
                                         source_name=primitive.name,
                                         target_name=id_to_name.get(
@@ -76,31 +77,16 @@ class PolicyGate:
                                     logger.debug("Policy %r passed by callback", policy.name)
                                     continue  # action passed the policy — no violation
                             else:
-                                # Callback present but unevaluable without a tool call. Fail closed
-                                # by construction — do not trust the callback to have what it needs —
-                                # and record an explicit reason so the conservative fire does not
-                                # masquerade as a plain trigger.
-                                cb_result = PolicyCallbackResult(
-                                    passed=False,
-                                    message="Policy callback could not be evaluated (no tool call in this context); firing conservatively.",
-                                )
+                                # No tool_call ⇒ the callback cannot be evaluated. Fail closed
+                                # by construction rather than trusting it to handle a missing call.
+                                cb_result = PolicyCallbackResult.unevaluable()
 
-                        # Most specific reason first (the callback's, when it fired or could not be
-                        # evaluated), always followed by the integrator's confirmation message.
-                        if cb_result is not None and cb_result.message:
-                            message = f"{cb_result.message}\n{policy.confirmation_message}"
-                        else:
-                            message = policy.confirmation_message
-
+                        violation = PolicyViolation(policy=policy, callback_result=cb_result)
                         logger.info(
                             "Policy violation: %r — %s (requires_confirmation=%s)",
-                            policy.name, message, policy.requires_confirmation,
+                            policy.name, violation.message, policy.requires_confirmation,
                         )
-                        violations.append(PolicyViolation(
-                            policy=policy,
-                            message=message,
-                            callback_result=cb_result,
-                        ))
+                        violations.append(violation)
 
         return violations
 

--- a/src/vre/core/policy/models.py
+++ b/src/vre/core/policy/models.py
@@ -34,6 +34,20 @@ class PolicyCallbackResult(BaseModel):
     passed: bool
     message: str | None = None
 
+    @classmethod
+    def unevaluable(cls) -> "PolicyCallbackResult":
+        """
+        Result for a callback that could not be evaluated because no tool call was
+        available to it. Fails closed with an explicit reason.
+        """
+        return cls(
+            passed=False,
+            message=(
+                "Policy callback could not be evaluated (no tool call in this "
+                "context); firing conservatively."
+            ),
+        )
+
 
 class PolicyAction(str, Enum):
     """
@@ -102,8 +116,19 @@ class PolicyViolation(BaseModel):
     """
 
     policy: Policy
-    message: str
     callback_result: PolicyCallbackResult | None = None
+
+    @property
+    def message(self) -> str:
+        """
+        Human-readable reason the violation fired. The callback's message (when it
+        fired or could not be evaluated) leads, followed by the policy's
+        confirmation message; the confirmation message alone when there is no
+        callback reason.
+        """
+        if self.callback_result is not None and self.callback_result.message:
+            return f"{self.callback_result.message}\n{self.policy.confirmation_message}"
+        return self.policy.confirmation_message
 
     @property
     def requires_confirmation(self) -> bool:

--- a/src/vre/core/policy/models.py
+++ b/src/vre/core/policy/models.py
@@ -35,18 +35,13 @@ class PolicyCallbackResult(BaseModel):
     message: str | None = None
 
     @classmethod
-    def unevaluable(cls) -> "PolicyCallbackResult":
+    def unevaluable(cls, message: str) -> "PolicyCallbackResult":
         """
-        Result for a callback that could not be evaluated because no tool call was
-        available to it. Fails closed with an explicit reason.
+        Result for a callback that could not be evaluated — fails closed, carrying
+        the caller-supplied reason it could not run (a missing tool call is one
+        such reason, but not the only one).
         """
-        return cls(
-            passed=False,
-            message=(
-                "Policy callback could not be evaluated (no tool call in this "
-                "context); firing conservatively."
-            ),
-        )
+        return cls(passed=False, message=message)
 
 
 class PolicyAction(str, Enum):
@@ -125,10 +120,17 @@ class PolicyViolation(BaseModel):
         fired or could not be evaluated) leads, followed by the policy's
         confirmation message; the confirmation message alone when there is no
         callback reason.
+
+        Deliberately a derived property — NOT a stored field or `@computed_field`.
+        Keeping it out of the serialized form means it can never drift from its
+        inputs (`callback_result.message` + `policy.confirmation_message`), which
+        are themselves serialized and so fully reconstruct it.
         """
         if self.callback_result is not None and self.callback_result.message:
-            return f"{self.callback_result.message}\n{self.policy.confirmation_message}"
-        return self.policy.confirmation_message
+            message = f"{self.callback_result.message}\n{self.policy.confirmation_message}"
+        else:
+            message = self.policy.confirmation_message
+        return message
 
     @property
     def requires_confirmation(self) -> bool:

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING, Callable
 
 from vre.core.models import DepthLevel
 from vre.core.policy import PolicyAction
-from vre.core.policy.callback import PolicyCallContext
+from vre.core.policy.callback import ToolCallContext
 from vre.core.policy.models import PolicyViolation
 
 if TYPE_CHECKING:
@@ -107,15 +107,14 @@ def vre_guard(
                 resolved_cardinality = (
                     cardinality(*args, **kwargs) if callable(cardinality) else cardinality
                 )
-                context = PolicyCallContext(
+                tool_call = ToolCallContext(
                     tool_name=tool_name,
-                    grounding=grounding,
                     call_args=args,
                     call_kwargs=kwargs,
                 )
 
                 policy = vre.check_policy(
-                    grounding, resolved_cardinality, context, on_policy=on_policy,
+                    grounding, resolved_cardinality, tool_call, on_policy=on_policy,
                 )
 
                 if policy.action == PolicyAction.BLOCK:

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -33,8 +33,8 @@ def _mock_vre(grounding: GroundingResult, policy: PolicyResult | None = None):
 
 def _violation(message="Confirm?", requires_confirmation=True) -> PolicyViolation:
     return PolicyViolation(
-        policy=Policy(name="Test", requires_confirmation=requires_confirmation),
-        message=message,
+        policy=Policy(name="Test", requires_confirmation=requires_confirmation,
+                      confirmation_message=message),
     )
 
 

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -258,3 +258,40 @@ def _cb_pass(context) -> PolicyCallbackResult:
 
 def _cb_fail(context) -> PolicyCallbackResult:
     return PolicyCallbackResult(passed=False, message="Failed by callback")
+
+
+# ---------------------------------------------------------------------------
+# New context type tests (Task 2)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_context_defaults():
+    """ToolCallContext carries the invocation; args/kwargs default to empty."""
+    from vre.core.policy.callback import ToolCallContext
+    tc = ToolCallContext(tool_name="write_file")
+    assert tc.tool_name == "write_file"
+    assert tc.call_args == ()
+    assert tc.call_kwargs == {}
+
+
+def test_grounding_context_defaults():
+    """GroundingContext defaults to no agent and no resolved concepts."""
+    from vre.core.policy.callback import GroundingContext
+    gc = GroundingContext()
+    assert gc.agent_id is None
+    assert gc.resolved_concepts == []
+
+
+def test_triggering_edge_fields():
+    """TriggeringEdge captures source/target name and the two depths."""
+    from vre.core.policy.callback import TriggeringEdge
+    edge = TriggeringEdge(
+        source_name="delete",
+        target_name="file",
+        source_depth=DepthLevel.CONSTRAINTS,
+        target_depth=DepthLevel.CAPABILITIES,
+    )
+    assert edge.source_name == "delete"
+    assert edge.target_name == "file"
+    assert edge.source_depth == DepthLevel.CONSTRAINTS
+    assert edge.target_depth == DepthLevel.CAPABILITIES

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -285,6 +285,14 @@ def _cb_block_if_protected(context) -> PolicyCallbackResult:
     return PolicyCallbackResult(passed=True)
 
 
+_RECORDED_TOOL_CALLS = []
+
+
+def _cb_record_tool_call(context) -> PolicyCallbackResult:
+    _RECORDED_TOOL_CALLS.append(context.tool_call)
+    return PolicyCallbackResult(passed=True)
+
+
 # ---------------------------------------------------------------------------
 # New capability-coverage tests (Task 4)
 # ---------------------------------------------------------------------------
@@ -368,6 +376,22 @@ def test_no_tool_call_skips_callback_and_fires():
     response = _make_step_result(primitive)
     violations = PolicyGate().evaluate(response, Cardinality.SINGLE)  # no tool_call
     assert len(violations) == 1
+
+
+def test_callback_receives_tool_call():
+    """The caller-supplied tool_call (name + args + kwargs) is threaded to the callback."""
+    from vre.core.policy.callback import ToolCallContext
+    policy = Policy(name="ToolAware", callback="tests.vre.test_policies._cb_record_tool_call")
+    primitive = _make_primitive_with_applies_to("write", [policy])
+    response = _make_step_result(primitive)
+    _RECORDED_TOOL_CALLS.clear()
+    tc = ToolCallContext(tool_name="write_file", call_args=("a.txt",), call_kwargs={"text": "hi"})
+    PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=tc)
+    assert len(_RECORDED_TOOL_CALLS) == 1
+    recorded = _RECORDED_TOOL_CALLS[0]
+    assert recorded.tool_name == "write_file"
+    assert recorded.call_args == ("a.txt",)
+    assert recorded.call_kwargs == {"text": "hi"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -15,7 +15,8 @@ from vre.core.models import (
     Relatum,
     RelationType,
 )
-from vre.core.policy import Cardinality, Policy, PolicyCallbackResult, parse_policy
+from vre.core.policy import Cardinality, Policy, PolicyCallbackResult, PolicyViolation, parse_policy
+from vre.core.policy.callback import GroundingContext, ToolCallContext, TriggeringEdge
 from vre.core.policy.gate import PolicyGate
 
 
@@ -189,7 +190,6 @@ def test_requires_confirmation_false_produces_violations():
 
 def test_callback_passed_true_suppresses_violation():
     """Callback returning passed=True — action passes the policy, no violation."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="WithCallback",
         callback="tests.vre.test_policies._cb_pass",
@@ -204,7 +204,6 @@ def test_callback_passed_true_suppresses_violation():
 
 def test_callback_passed_false_fires_violation():
     """Callback returning passed=False — action fails the policy, violation carries result."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="WithCallback",
         callback="tests.vre.test_policies._cb_fail",
@@ -221,7 +220,6 @@ def test_callback_passed_false_fires_violation():
 
 def test_callback_receives_triggering_edge():
     """The callback sees the source/target names and depths of the edge that fired it."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="EdgeAware",
         callback="tests.vre.test_policies._cb_record_edge",
@@ -319,7 +317,6 @@ def _make_two_edge_response(source_name, policies, target_a="file", target_b="di
 
 def test_callback_on_two_edges_receives_distinct_targets():
     """One callback on two edges is told which target each invocation is for."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(name="EdgeAware", callback="tests.vre.test_policies._cb_record_edge")
     response = _make_two_edge_response("delete", [policy])
     _RECORDED_EDGES.clear()
@@ -330,7 +327,6 @@ def test_callback_on_two_edges_receives_distinct_targets():
 
 def test_callback_reads_policy_metadata():
     """The callback can read its own parameters from the triggering policy's metadata."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="RateLimited",
         callback="tests.vre.test_policies._cb_record_metadata",
@@ -345,7 +341,6 @@ def test_callback_reads_policy_metadata():
 
 def test_callback_branches_on_resolved_concepts():
     """A callback can fail based on a co-occurring concept in the grounding facade."""
-    from vre.core.policy.callback import GroundingContext, ToolCallContext
     policy = Policy(name="ProtectedAware", callback="tests.vre.test_policies._cb_block_if_protected")
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
@@ -385,7 +380,6 @@ def test_no_tool_call_fires_with_unevaluated_callback():
 
 def test_failing_callback_message_leads_violation_message():
     """A callback that fires with a message → that message leads, then the confirmation_message."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="WithReason",
         callback="tests.vre.test_policies._cb_fail",  # returns passed=False, message="Failed by callback"
@@ -402,7 +396,6 @@ def test_failing_callback_message_leads_violation_message():
 
 def test_callback_receives_tool_call():
     """The caller-supplied tool_call (name + args + kwargs) is threaded to the callback."""
-    from vre.core.policy.callback import ToolCallContext
     policy = Policy(name="ToolAware", callback="tests.vre.test_policies._cb_record_tool_call")
     primitive = _make_primitive_with_applies_to("write", [policy])
     response = _make_step_result(primitive)
@@ -423,7 +416,6 @@ def test_callback_receives_tool_call():
 
 def test_tool_call_context_defaults():
     """ToolCallContext carries the invocation; args/kwargs default to empty."""
-    from vre.core.policy.callback import ToolCallContext
     tc = ToolCallContext(tool_name="write_file")
     assert tc.tool_name == "write_file"
     assert tc.call_args == ()
@@ -432,7 +424,6 @@ def test_tool_call_context_defaults():
 
 def test_grounding_context_defaults():
     """GroundingContext defaults to no agent and no resolved concepts."""
-    from vre.core.policy.callback import GroundingContext
     gc = GroundingContext()
     assert gc.agent_id is None
     assert gc.resolved_concepts == []
@@ -440,7 +431,6 @@ def test_grounding_context_defaults():
 
 def test_triggering_edge_fields():
     """TriggeringEdge captures source/target name and the two depths."""
-    from vre.core.policy.callback import TriggeringEdge
     edge = TriggeringEdge(
         source_name="delete",
         target_name="file",
@@ -451,3 +441,37 @@ def test_triggering_edge_fields():
     assert edge.target_name == "file"
     assert edge.source_depth == DepthLevel.CONSTRAINTS
     assert edge.target_depth == DepthLevel.CAPABILITIES
+
+
+# ---------------------------------------------------------------------------
+# Frozen 1.0 contract: model-owned composition
+# ---------------------------------------------------------------------------
+
+
+def test_policy_callback_result_unevaluable():
+    """unevaluable() is a fail-closed result naming the missing tool call."""
+    r = PolicyCallbackResult.unevaluable()
+    assert r.passed is False
+    assert "no tool call" in r.message
+
+
+def test_policy_violation_message_property():
+    """PolicyViolation.message composes the callback reason + confirmation, or falls back."""
+    p = Policy(name="P", confirmation_message="Confirm.")
+    assert PolicyViolation(policy=p).message == "Confirm."
+    assert PolicyViolation(
+        policy=p, callback_result=PolicyCallbackResult(passed=False, message="why")
+    ).message == "why\nConfirm."
+    # failing result with no message → falls back to confirmation_message
+    assert PolicyViolation(
+        policy=p, callback_result=PolicyCallbackResult(passed=False)
+    ).message == "Confirm."
+
+
+def test_grounding_context_from_grounding():
+    """from_grounding projects only agent_id + resolved from a GroundingResult."""
+    from vre.core.grounding import GroundingResult
+    gr = GroundingResult(grounded=True, resolved=["a", "b"], gaps=[])
+    gc = GroundingContext.from_grounding(gr)
+    assert gc.resolved_concepts == ["a", "b"]
+    assert gc.agent_id is None

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -365,8 +365,8 @@ def test_callback_branches_on_resolved_concepts():
     assert len(violations) == 1  # callback fired
 
 
-def test_no_tool_call_skips_callback_and_fires():
-    """Without a tool_call, the callback is not consulted and the policy fires (behavior preserved)."""
+def test_no_tool_call_fires_with_unevaluated_callback():
+    """Without a tool_call the callback can't be evaluated → conservative fire with an explicit reason."""
     policy = Policy(
         name="WouldPass",
         callback="tests.vre.test_policies._cb_pass",  # would suppress IF consulted
@@ -376,6 +376,28 @@ def test_no_tool_call_skips_callback_and_fires():
     response = _make_step_result(primitive)
     violations = PolicyGate().evaluate(response, Cardinality.SINGLE)  # no tool_call
     assert len(violations) == 1
+    v = violations[0]
+    assert v.callback_result is not None
+    assert v.callback_result.passed is False
+    assert "no tool call" in v.message
+    assert "Confirm." in v.message  # integrator confirmation_message always included
+
+
+def test_failing_callback_message_leads_violation_message():
+    """A callback that fires with a message → that message leads, then the confirmation_message."""
+    from vre.core.policy.callback import ToolCallContext
+    policy = Policy(
+        name="WithReason",
+        callback="tests.vre.test_policies._cb_fail",  # returns passed=False, message="Failed by callback"
+        confirmation_message="Confirm write.",
+    )
+    primitive = _make_primitive_with_applies_to("write", [policy])
+    response = _make_step_result(primitive)
+    violations = PolicyGate().evaluate(
+        response, Cardinality.SINGLE, tool_call=ToolCallContext(tool_name="w")
+    )
+    assert len(violations) == 1
+    assert violations[0].message == "Failed by callback\nConfirm write."
 
 
 def test_callback_receives_tool_call():

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -449,10 +449,10 @@ def test_triggering_edge_fields():
 
 
 def test_policy_callback_result_unevaluable():
-    """unevaluable() is a fail-closed result naming the missing tool call."""
-    r = PolicyCallbackResult.unevaluable()
+    """unevaluable(message) is a fail-closed result carrying the caller's reason."""
+    r = PolicyCallbackResult.unevaluable("could not evaluate: no tool call")
     assert r.passed is False
-    assert "no tool call" in r.message
+    assert r.message == "could not evaluate: no tool call"
 
 
 def test_policy_violation_message_property():

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -93,7 +93,7 @@ def test_step_cardinality_single_no_trigger():
     policy = Policy(
         name="BulkDelete",
         trigger_cardinality=Cardinality.MULTIPLE,
-        confirmation_message="Bulk {action} requires confirmation.",
+        confirmation_message="Bulk delete requires confirmation.",
     )
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
@@ -106,7 +106,7 @@ def test_step_cardinality_multiple_triggers():
     policy = Policy(
         name="BulkDelete",
         trigger_cardinality=Cardinality.MULTIPLE,
-        confirmation_message="Bulk {action} requires confirmation.",
+        confirmation_message="Bulk delete requires confirmation.",
     )
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
@@ -120,7 +120,7 @@ def test_policy_trigger_cardinality_none_always_fires():
     policy = Policy(
         name="AlwaysConfirm",
         trigger_cardinality=None,
-        confirmation_message="Always confirm {action}.",
+        confirmation_message="Always confirm write.",
     )
     primitive = _make_primitive_with_applies_to("write", [policy])
     response = _make_step_result(primitive)
@@ -134,7 +134,7 @@ def test_no_callback_fires_violation():
     policy = Policy(
         name="NoCallback",
         callback=None,
-        confirmation_message="Confirm {action}.",
+        confirmation_message="Confirm delete.",
     )
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
@@ -143,8 +143,8 @@ def test_no_callback_fires_violation():
     assert violations[0].message is not None
 
 
-def test_confirmation_message_formatted():
-    """{action} in confirmation_message is interpolated from primitive.name."""
+def test_confirmation_message_verbatim():
+    """confirmation_message is used verbatim — {action} is NOT interpolated."""
     policy = Policy(
         name="Confirm",
         confirmation_message="About to {action} — proceed?",
@@ -152,7 +152,7 @@ def test_confirmation_message_formatted():
     primitive = _make_primitive_with_applies_to("delete", [policy])
     response = _make_step_result(primitive)
     violations = PolicyGate().evaluate(response, Cardinality.SINGLE)
-    assert violations[0].message == "About to delete — proceed?"
+    assert violations[0].message == "About to {action} — proceed?"
 
 
 def test_non_applies_to_relata_ignored():

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -271,6 +271,105 @@ def _cb_record_edge(context) -> PolicyCallbackResult:
     return PolicyCallbackResult(passed=True)
 
 
+_RECORDED_META = []
+
+
+def _cb_record_metadata(context) -> PolicyCallbackResult:
+    _RECORDED_META.append(dict(context.policy.metadata))
+    return PolicyCallbackResult(passed=True)
+
+
+def _cb_block_if_protected(context) -> PolicyCallbackResult:
+    if "protected" in context.grounding.resolved_concepts:
+        return PolicyCallbackResult(passed=False, message="protected concept co-grounded")
+    return PolicyCallbackResult(passed=True)
+
+
+# ---------------------------------------------------------------------------
+# New capability-coverage tests (Task 4)
+# ---------------------------------------------------------------------------
+
+
+def _make_two_edge_response(source_name, policies, target_a="file", target_b="dir"):
+    """A source primitive with two APPLIES_TO edges (to target_a, target_b), all targets in the trace."""
+    a = Primitive(name=target_a)
+    b = Primitive(name=target_b)
+    depth = Depth(
+        level=DepthLevel.CAPABILITIES,
+        relata=[
+            Relatum(relation_type=RelationType.APPLIES_TO, target_id=a.id,
+                    target_depth=DepthLevel.CONSTRAINTS, policies=policies),
+            Relatum(relation_type=RelationType.APPLIES_TO, target_id=b.id,
+                    target_depth=DepthLevel.CONSTRAINTS, policies=policies),
+        ],
+    )
+    source = Primitive(name=source_name, depths=[depth])
+    query = EpistemicQuery(concept_ids=[source.id])
+    result = EpistemicResult(primitives=[source, a, b])
+    return EpistemicResponse(query=query, result=result)
+
+
+def test_callback_on_two_edges_receives_distinct_targets():
+    """One callback on two edges is told which target each invocation is for."""
+    from vre.core.policy.callback import ToolCallContext
+    policy = Policy(name="EdgeAware", callback="tests.vre.test_policies._cb_record_edge")
+    response = _make_two_edge_response("delete", [policy])
+    _RECORDED_EDGES.clear()
+    PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=ToolCallContext(tool_name="rm"))
+    targets = sorted(e.target_name for e in _RECORDED_EDGES)
+    assert targets == ["dir", "file"]
+
+
+def test_callback_reads_policy_metadata():
+    """The callback can read its own parameters from the triggering policy's metadata."""
+    from vre.core.policy.callback import ToolCallContext
+    policy = Policy(
+        name="RateLimited",
+        callback="tests.vre.test_policies._cb_record_metadata",
+        metadata={"limit": 5},
+    )
+    primitive = _make_primitive_with_applies_to("send", [policy])
+    response = _make_step_result(primitive)
+    _RECORDED_META.clear()
+    PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=ToolCallContext(tool_name="send"))
+    assert _RECORDED_META == [{"limit": 5}]
+
+
+def test_callback_branches_on_resolved_concepts():
+    """A callback can fail based on a co-occurring concept in the grounding facade."""
+    from vre.core.policy.callback import GroundingContext, ToolCallContext
+    policy = Policy(name="ProtectedAware", callback="tests.vre.test_policies._cb_block_if_protected")
+    primitive = _make_primitive_with_applies_to("delete", [policy])
+    response = _make_step_result(primitive)
+
+    safe = GroundingContext(resolved_concepts=["delete", "file"])
+    violations = PolicyGate().evaluate(
+        response, Cardinality.SINGLE,
+        tool_call=ToolCallContext(tool_name="rm"), grounding=safe,
+    )
+    assert len(violations) == 0  # callback passed
+
+    risky = GroundingContext(resolved_concepts=["delete", "file", "protected"])
+    violations = PolicyGate().evaluate(
+        response, Cardinality.SINGLE,
+        tool_call=ToolCallContext(tool_name="rm"), grounding=risky,
+    )
+    assert len(violations) == 1  # callback fired
+
+
+def test_no_tool_call_skips_callback_and_fires():
+    """Without a tool_call, the callback is not consulted and the policy fires (behavior preserved)."""
+    policy = Policy(
+        name="WouldPass",
+        callback="tests.vre.test_policies._cb_pass",  # would suppress IF consulted
+        confirmation_message="Confirm.",
+    )
+    primitive = _make_primitive_with_applies_to("write", [policy])
+    response = _make_step_result(primitive)
+    violations = PolicyGate().evaluate(response, Cardinality.SINGLE)  # no tool_call
+    assert len(violations) == 1
+
+
 # ---------------------------------------------------------------------------
 # New context type tests (Task 2)
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -189,50 +189,53 @@ def test_requires_confirmation_false_produces_violations():
 
 def test_callback_passed_true_suppresses_violation():
     """Callback returning passed=True — action passes the policy, no violation."""
+    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="WithCallback",
         callback="tests.vre.test_policies._cb_pass",
-        confirmation_message="Confirm {action}.",
+        confirmation_message="Confirm write.",
     )
     primitive = _make_primitive_with_applies_to("write", [policy])
     response = _make_step_result(primitive)
-
-    from vre.core.policy.callback import PolicyCallContext
-    from vre.core.grounding import GroundingResult
-
-    ctx = PolicyCallContext(
-        tool_name="test_fn",
-        grounding=GroundingResult(grounded=True, resolved=["write"], gaps=[]),
-        call_args=(),
-        call_kwargs={},
-    )
-    violations = PolicyGate().evaluate(response, Cardinality.SINGLE, ctx)
+    tool_call = ToolCallContext(tool_name="test_fn")
+    violations = PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=tool_call)
     assert len(violations) == 0
 
 
 def test_callback_passed_false_fires_violation():
     """Callback returning passed=False — action fails the policy, violation carries result."""
+    from vre.core.policy.callback import ToolCallContext
     policy = Policy(
         name="WithCallback",
         callback="tests.vre.test_policies._cb_fail",
-        confirmation_message="Confirm {action}.",
+        confirmation_message="Confirm write.",
     )
     primitive = _make_primitive_with_applies_to("write", [policy])
     response = _make_step_result(primitive)
-
-    from vre.core.policy.callback import PolicyCallContext
-    from vre.core.grounding import GroundingResult
-
-    ctx = PolicyCallContext(
-        tool_name="test_fn",
-        grounding=GroundingResult(grounded=True, resolved=["write"], gaps=[]),
-        call_args=(),
-        call_kwargs={},
-    )
-    violations = PolicyGate().evaluate(response, Cardinality.SINGLE, ctx)
+    tool_call = ToolCallContext(tool_name="test_fn")
+    violations = PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=tool_call)
     assert len(violations) == 1
     assert violations[0].callback_result is not None
     assert violations[0].callback_result.passed is False
+
+
+def test_callback_receives_triggering_edge():
+    """The callback sees the source/target names and depths of the edge that fired it."""
+    from vre.core.policy.callback import ToolCallContext
+    policy = Policy(
+        name="EdgeAware",
+        callback="tests.vre.test_policies._cb_record_edge",
+        confirmation_message="Confirm.",
+    )
+    primitive = _make_primitive_with_applies_to("delete", [policy])
+    response = _make_step_result(primitive)
+    _RECORDED_EDGES.clear()
+    PolicyGate().evaluate(response, Cardinality.SINGLE, tool_call=ToolCallContext(tool_name="rm"))
+    assert len(_RECORDED_EDGES) == 1
+    edge = _RECORDED_EDGES[0]
+    assert edge.source_name == "delete"
+    assert edge.source_depth == DepthLevel.CAPABILITIES   # _make_primitive_with_applies_to: D2 source
+    assert edge.target_depth == DepthLevel.CONSTRAINTS    # ...and D3 target
 
 
 def test_multiple_policies_on_same_relatum_all_collected():
@@ -258,6 +261,14 @@ def _cb_pass(context) -> PolicyCallbackResult:
 
 def _cb_fail(context) -> PolicyCallbackResult:
     return PolicyCallbackResult(passed=False, message="Failed by callback")
+
+
+_RECORDED_EDGES = []
+
+
+def _cb_record_edge(context) -> PolicyCallbackResult:
+    _RECORDED_EDGES.append(context.triggering_edge)
+    return PolicyCallbackResult(passed=True)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -247,8 +247,7 @@ def test_policy_str_block():
 def test_policy_str_block_with_violations():
     from vre.core.policy.models import PolicyViolation, Policy
     violation = PolicyViolation(
-        policy=Policy(name="TestPolicy"),
-        message="Confirm delete?",
+        policy=Policy(name="TestPolicy", confirmation_message="Confirm delete?"),
     )
     result = PolicyResult(
         action=PolicyAction.BLOCK,

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -254,7 +254,7 @@ class TestCheckPolicyOrchestration:
         policy = Policy(
             name="TestPolicy",
             requires_confirmation=requires_confirmation,
-            confirmation_message="Confirm {action}?",
+            confirmation_message="Confirm?",
         )
         src = _make_primitive_with_policy("write", target, policy)
         vre = _make_vre_with_stub([src, target])

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -20,6 +20,7 @@ from vre.core.models import (
     ResolvedSubgraph,
 )
 from vre.core.policy import Cardinality, Policy, PolicyAction, PolicyResult
+from vre.core.policy.callback import ToolCallContext
 from vre.core.grounding import GroundingResult
 from vre.learning import LearningEngine
 
@@ -450,7 +451,6 @@ class TestCheckPolicyGroundingFacade:
     """check_policy mints the GroundingContext facade from the GroundingResult."""
 
     def test_callback_sees_resolved_concepts(self):
-        from vre.core.policy.callback import ToolCallContext
         target = _make_fully_grounded("file")
         policy = Policy(
             name="FacadeAware",

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -430,3 +430,35 @@ def test_check_preserves_order_and_canonical_casing_across_list():
     # (Do NOT assert on `grounded` here — two unconnected roots legitimately
     #  produce a ReachabilityGap; this test is only about the resolved list.)
     assert result.resolved == ["file", "write"]
+
+
+# ---------------------------------------------------------------------------
+# Grounding facade derivation (Task 4)
+# ---------------------------------------------------------------------------
+
+
+_CAPTURED_RESOLVED = []
+
+
+def _cb_capture_resolved(context):
+    from vre.core.policy.models import PolicyCallbackResult
+    _CAPTURED_RESOLVED.append(list(context.grounding.resolved_concepts))
+    return PolicyCallbackResult(passed=True)
+
+
+class TestCheckPolicyGroundingFacade:
+    """check_policy mints the GroundingContext facade from the GroundingResult."""
+
+    def test_callback_sees_resolved_concepts(self):
+        from vre.core.policy.callback import ToolCallContext
+        target = _make_fully_grounded("file")
+        policy = Policy(
+            name="FacadeAware",
+            callback="tests.vre.test_vre._cb_capture_resolved",
+        )
+        src = _make_primitive_with_policy("write", target, policy)
+        vre = _make_vre_with_stub([src, target])
+        _CAPTURED_RESOLVED.clear()
+        vre.check_policy(["write", "file"], tool_call=ToolCallContext(tool_name="write_file"))
+        assert _CAPTURED_RESOLVED  # callback was invoked
+        assert set(_CAPTURED_RESOLVED[0]) == {"write", "file"}


### PR DESCRIPTION
## Summary

Redesigns the policy callback context (#58) to fix two flaws and make the callback contract honest:

- **Leak removed.** `PolicyCallContext` no longer exposes the full internal `GroundingResult`. It now *composes* four bounded pieces: `tool_call: ToolCallContext`, `grounding: GroundingContext` (just `agent_id` + `resolved_concepts`), `triggering_edge: TriggeringEdge`, and the triggering `Policy`. `callback.py` no longer imports `GroundingResult` at all.
- **Per-edge identity.** The gate builds a fresh context per APPLIES_TO edge (lazily), so a callback registered on multiple edges can tell which fired it (`triggering_edge`) and read its own parameters (`policy.metadata`).
- **Separation of concerns.** The gate stays trace-based; `check_policy` mints the `GroundingContext` facade from the authoritative `GroundingResult`. Policy *firing* is agent-agnostic — `agent_id` is callback pass-through, never a firing input (rationale documented in §2.7 of the design and inline).
- **Honest violation messages.** Dropped the `{action}` interpolation (the integrator's `confirmation_message` is used verbatim). A callback's failure reason now *leads* the violation message, followed by the confirmation message. When a callback can't be evaluated (no `tool_call`), the gate fails closed **by construction** and records an explicit reason instead of masquerading as a plain trigger.

Designed so the deferred follow-ups drop in at a single site each: **#81** (registry-resolved callbacks) replaces `policy.resolve_callback()`; **#97** (callback exception contract) wraps the `cb(context)` call.

## Test plan

- `poetry run pytest -q` → **305 passed**, coverage gate (70%) satisfied.
- New coverage: per-edge `triggering_edge` across two edges, `policy.metadata` read-through, `GroundingContext` facade derivation (end-to-end via `check_policy`), `tool_call` passthrough, no-`tool_call` conservative fire with explicit reason, verbatim `confirmation_message`, and failing-callback message composition.

## Migration (breaking, pre-1.0 — clean break, no shim)

- Callbacks read `context.tool_call.call_args` / `.call_kwargs` (was `context.call_args` / `.call_kwargs`).
- `context.grounding` is a bounded `GroundingContext`, not the full `GroundingResult`.
- **Runtime-only — no persistence change, no reseed.** The one example callback (`examples/langchain_ollama/policies.py`) and the README are updated.

## Also included (unrelated WIP, committed here to avoid losing it)

- `chore: gitignore docs/superpowers/` — Claude Code working artifacts.
- `docs(grounding): note open question on empty-concepts trace in ground()`.

Closes #58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)