### PR TITLE
feat(guard)!: GuardBlock return for blocked calls; document the contract (#88)

### DIFF
--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -61,6 +61,7 @@ from vre.core.policy.registry import (
     policy_callback,
     register_policy,
 )
+from vre.guard import GuardBlock, vre_guard
 from vre.identity import AgentIdentity, AgentRegistry
 from vre.learning import LearningEngine, template_for_gap
 from vre.metrics import MetricsManager
@@ -72,6 +73,8 @@ logger = logging.getLogger(__name__)
 
 __all__ = [
     "VRE",
+    "vre_guard",
+    "GuardBlock",
     "AgentIdentity",
     "AgentRegistry",
     "CandidateValidationError",

--- a/src/vre/guard.py
+++ b/src/vre/guard.py
@@ -18,17 +18,24 @@ Each call runs grounding -> policy -> execution in a single pass:
 
 1. VRE grounding is checked (depth derived from graph structure).
 2. `on_trace` is fired (if provided) with the `GroundingResult`.
-3. If grounding fails, returns `GroundingResult` immediately — the function
+3. If grounding fails, returns a `GuardBlock` immediately — the function
    is *not* called.
-4. Policy is evaluated. If BLOCK: returns `PolicyResult`.
-5. Otherwise, the original function is called and its return value is returned.
+4. Policy is evaluated. If BLOCK: returns a `GuardBlock`.
+5. Otherwise, the original function is called and its return value is
+   returned untouched.
+
+The guard returns a `GuardBlock` only when it intervened (grounding failed or
+policy blocked); on success it returns the wrapped function's own value. So a
+plain-Python caller distinguishes the two outcomes with a single
+`isinstance(..., GuardBlock)` check, while an LLM caller can `str()` either.
 """
 
 from __future__ import annotations
 
 import functools
 import logging
-from typing import TYPE_CHECKING, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Callable, Literal, ParamSpec, TypeVar
 
 from vre.core.models import DepthLevel
 from vre.core.policy import PolicyAction
@@ -38,6 +45,7 @@ from vre.core.policy.models import PolicyViolation
 if TYPE_CHECKING:
     from vre import VRE
     from vre.core.grounding import GroundingResult
+    from vre.core.policy.models import PolicyResult
 
 # `concepts` and `cardinality` may be static values or callables that receive
 # the same (*args, **kwargs) as the decorated function and return the value
@@ -45,7 +53,60 @@ if TYPE_CHECKING:
 ConceptsInput = list[str] | Callable[..., list[str]]
 CardinalityInput = str | None | Callable[..., str | None]
 
+# The wrapped function's parameter list (P) and return type (R) are preserved
+# through the guard: a caller keeps full argument type-checking and sees the
+# result as `GuardBlock | R`, where `isinstance(result, GuardBlock)` narrows to R.
+P = ParamSpec("P")
+R = TypeVar("R")
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GuardBlock:
+    """
+    Returned by `vre_guard` when the guard blocked execution — grounding failed,
+    or a policy returned BLOCK. The wrapped function was *not* called.
+
+    The guard returns this VRE-owned type only when VRE intervened; on success it
+    returns the wrapped function's own value untouched. So a plain-Python caller
+    distinguishes the two outcomes with a single, unambiguous check::
+
+        result = guarded_fn(...)
+        if isinstance(result, GuardBlock):
+            ...   # blocked — inspect `.grounding` / `.policy` / `.blocked_by`
+        else:
+            ...   # ran — `result` is the function's own return value
+
+    `__str__` delegates to the wrapped result, so a block still renders as a full
+    explanation for an LLM caller.
+    """
+
+    grounding: GroundingResult | None = None
+    policy: PolicyResult | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Enforce the invariant: a block wraps exactly one result. An empty or
+        double-wrapped GuardBlock would let `blocked_by` and `__str__` silently
+        misreport which layer intervened — precisely the quiet degradation VRE
+        exists to prevent.
+        """
+        if (self.grounding is None) == (self.policy is None):
+            raise ValueError("GuardBlock must wrap exactly one of grounding/policy")
+
+    @property
+    def blocked_by(self) -> Literal["grounding", "policy"]:
+        """
+        Which layer blocked — 'grounding' or 'policy'.
+        """
+        return "grounding" if self.grounding is not None else "policy"
+
+    def __str__(self) -> str:
+        """
+        Delegate to the wrapped result's explanation — keeps a block LLM-feedable.
+        """
+        return str(self.grounding if self.grounding is not None else self.policy)
 
 
 def vre_guard(
@@ -55,7 +116,7 @@ def vre_guard(
     min_depth: DepthLevel | None = None,
     on_trace: Callable[["GroundingResult"], None] | None = None,
     on_policy: Callable[[list[PolicyViolation]], bool] | None = None,
-) -> Callable:
+) -> Callable[[Callable[P, R]], Callable[P, GuardBlock | R]]:
     """
     Decorator that gates a function behind VRE grounding and policy checks.
 
@@ -81,15 +142,32 @@ def vre_guard(
         Optional callback called with the list of PolicyViolation when any
         violation requires confirmation. Should return True to proceed,
         False to block.
+
+    Returns
+    -------
+    On success — grounded and policy passed — returns the wrapped function's own
+    return value, untouched.
+
+    When the guard blocks — grounding failed, or a policy returned BLOCK —
+    returns a `GuardBlock` instead, and the wrapped function is *not* called.
+    `GuardBlock` renders via `str()` as a full explanation, so an LLM caller can
+    feed it straight back to the model. A plain-Python caller distinguishes the
+    two outcomes with a single check::
+
+        result = guarded_fn(...)
+        if isinstance(result, GuardBlock):
+            ...   # blocked — inspect .grounding / .policy / .blocked_by
+        else:
+            ...   # ran — `result` is the function's own return value
     """
-    def decorator(fn: Callable) -> Callable:
+    def decorator(fn: Callable[P, R]) -> Callable[P, GuardBlock | R]:
         """
         Bind the guard to a specific function.
         """
         tool_name = fn.__name__
 
         @functools.wraps(fn)
-        def wrapped(*args, **kwargs):
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> GuardBlock | R:
             """
             Run grounding -> policy -> execution on each call.
             """
@@ -104,8 +182,8 @@ def vre_guard(
                     logger.exception("Guard %r: on_trace raised; continuing", tool_name)
 
             if not grounding.grounded:
-                logger.info("Guard %r: not grounded, returning GroundingResult (%d gaps)", tool_name, len(grounding.gaps))
-                result = grounding
+                logger.info("Guard %r: not grounded, returning GuardBlock (%d gaps)", tool_name, len(grounding.gaps))
+                result = GuardBlock(grounding=grounding)
             else:
                 # Policy evaluation
                 resolved_cardinality = (
@@ -123,7 +201,7 @@ def vre_guard(
 
                 if policy.action == PolicyAction.BLOCK:
                     logger.info("Guard %r: policy BLOCKED — %s", tool_name, policy.reason)
-                    result = policy
+                    result = GuardBlock(policy=policy)
                 else:
                     logger.debug("Guard %r: grounded and policy passed, executing function", tool_name)
                     result = fn(*args, **kwargs)

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -5,11 +5,13 @@ Unit tests for vre.guard — vre_guard decorator.
 from unittest.mock import MagicMock
 from uuid import uuid4
 
+import pytest
+
 from vre.core.grounding import GroundingResult
 from vre.core.models import ExistenceGap, Primitive
 from vre.core.policy import PolicyAction, PolicyResult
 from vre.core.policy.models import PolicyViolation, Policy
-from vre.guard import vre_guard
+from vre.guard import GuardBlock, vre_guard
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -40,8 +42,8 @@ def _violation(message="Confirm?", requires_confirmation=True) -> PolicyViolatio
 
 # ── ungrounded path ───────────────────────────────────────────────────────────
 
-def test_vre_guard_returns_grounding_result_when_not_grounded():
-    """When grounding fails, vre_guard returns GroundingResult without calling fn."""
+def test_vre_guard_returns_guardblock_when_not_grounded():
+    """When grounding fails, vre_guard returns a GuardBlock without calling fn."""
     from vre.guard import vre_guard
 
     gap = ExistenceGap(primitive=Primitive(name="unknown", depths=[]))
@@ -53,13 +55,14 @@ def test_vre_guard_returns_grounding_result_when_not_grounded():
         return "executed"
 
     result = my_fn()
-    assert isinstance(result, GroundingResult)
-    assert result.grounded is False
+    assert isinstance(result, GuardBlock)
+    assert result.blocked_by == "grounding"
+    assert result.grounding.grounded is False
     assert "[VRE] Not grounded" in str(result)
 
 
 def test_vre_guard_blocks_on_existence_gap():
-    """Existence gap → grounded=False → returns GroundingResult without calling fn."""
+    """Existence gap → grounded=False → returns a GuardBlock without calling fn."""
     from vre.guard import vre_guard
     from vre.core.models import ExistenceGap, Primitive
 
@@ -71,9 +74,10 @@ def test_vre_guard_blocks_on_existence_gap():
         return "executed"
 
     result = my_fn()
-    assert isinstance(result, GroundingResult)
-    assert result.grounded is False
-    assert len(result.gaps) == 1
+    assert isinstance(result, GuardBlock)
+    assert result.blocked_by == "grounding"
+    assert result.grounding.grounded is False
+    assert len(result.grounding.gaps) == 1
     assert "[VRE] Not grounded" in str(result)
 
 
@@ -169,7 +173,7 @@ def test_vre_guard_grounding_called_once():
 # ── single-phase: policy gates ────────────────────────────────────────────────
 
 def test_vre_guard_blocks_when_no_handler():
-    """BLOCK policy with no on_policy handler → returns PolicyResult(BLOCK)."""
+    """BLOCK policy with no on_policy handler → returns a GuardBlock wrapping the PolicyResult."""
     from vre.guard import vre_guard
 
     mock_vre = _mock_vre(
@@ -186,8 +190,9 @@ def test_vre_guard_blocks_when_no_handler():
         return "executed"
 
     result = my_fn()
-    assert isinstance(result, PolicyResult)
-    assert result.action == PolicyAction.BLOCK
+    assert isinstance(result, GuardBlock)
+    assert result.blocked_by == "policy"
+    assert result.policy.action == PolicyAction.BLOCK
 
 
 def test_vre_guard_calls_fn_when_policy_passes():
@@ -208,7 +213,7 @@ def test_vre_guard_calls_fn_when_policy_passes():
 
 
 def test_vre_guard_blocks_on_block_policy():
-    """BLOCK policy → returns the PolicyResult."""
+    """BLOCK policy → returns a GuardBlock wrapping the PolicyResult."""
     from vre.guard import vre_guard
 
     mock_vre = _mock_vre(
@@ -221,9 +226,10 @@ def test_vre_guard_blocks_on_block_policy():
         return "executed"
 
     result = my_fn()
-    assert isinstance(result, PolicyResult)
-    assert result.action == PolicyAction.BLOCK
-    assert result.reason == "Forbidden"
+    assert isinstance(result, GuardBlock)
+    assert result.blocked_by == "policy"
+    assert result.policy.action == PolicyAction.BLOCK
+    assert result.policy.reason == "Forbidden"
 
 
 def test_vre_guard_passes_on_policy_through_to_check_policy():
@@ -412,7 +418,7 @@ def test_vre_guard_no_min_depth_passes_none():
 
 
 def test_vre_guard_on_policy_decline_returns_block():
-    """When on_policy returns False (inside check_policy), returns PolicyResult(BLOCK)."""
+    """When on_policy returns False (inside check_policy), returns a GuardBlock (policy)."""
     from vre.guard import vre_guard
 
     mock_vre = _mock_vre(
@@ -429,6 +435,45 @@ def test_vre_guard_on_policy_decline_returns_block():
         return "executed"
 
     result = my_fn()
-    assert isinstance(result, PolicyResult)
-    assert result.action == PolicyAction.BLOCK
-    assert result.reason == "User declined"
+    assert isinstance(result, GuardBlock)
+    assert result.blocked_by == "policy"
+    assert result.policy.action == PolicyAction.BLOCK
+    assert result.policy.reason == "User declined"
+
+
+# ── GuardBlock ────────────────────────────────────────────────────────────────
+
+def test_guard_block_blocked_by_reflects_wrapped_result():
+    """blocked_by is 'grounding' or 'policy' depending on which result is wrapped."""
+    assert GuardBlock(grounding=_grounding(grounded=False)).blocked_by == "grounding"
+    assert GuardBlock(policy=PolicyResult(action=PolicyAction.BLOCK)).blocked_by == "policy"
+
+
+def test_guard_block_requires_exactly_one_wrapped_result():
+    """A GuardBlock must wrap exactly one result — empty or double-wrapped raises."""
+    with pytest.raises(ValueError):
+        GuardBlock()
+    with pytest.raises(ValueError):
+        GuardBlock(grounding=_grounding(grounded=False),
+                   policy=PolicyResult(action=PolicyAction.BLOCK))
+
+
+def test_guard_block_str_delegates_to_wrapped_result():
+    """str(GuardBlock) renders the wrapped result's explanation (LLM-feedable)."""
+    grounding = _grounding(grounded=False)
+    policy = PolicyResult(action=PolicyAction.BLOCK, reason="nope")
+    assert str(GuardBlock(grounding=grounding)) == str(grounding)
+    assert str(GuardBlock(policy=policy)) == str(policy)
+
+
+def test_guard_passes_value_through_untouched_on_success():
+    """On success the guard returns the fn's own value, never a GuardBlock."""
+    mock_vre = _mock_vre(_grounding(grounded=True))  # policy defaults to PASS
+
+    @vre_guard(mock_vre, concepts=["file"])
+    def my_fn():
+        return {"data": 1}
+
+    result = my_fn()
+    assert not isinstance(result, GuardBlock)
+    assert result == {"data": 1}


### PR DESCRIPTION
## Summary

- `vre_guard` now returns a dedicated, VRE-owned `GuardBlock` **only when it intervenes** — grounding failed or a policy returned BLOCK. On success it returns the wrapped function's own value, untouched, so the decorator stays a transparent gate.
- Plain-Python callers discriminate the two outcomes with a single `isinstance(result, GuardBlock)` check — no three-way `isinstance`, and no collision with a function that itself returns a `GroundingResult`/`PolicyResult`.
- `GuardBlock.__str__` delegates to the wrapped result, so an LLM caller's `str(result)` path is unchanged.
- Documents the return contract on the `vre_guard` decorator itself (the required acceptance criterion of #88).

## Design

Closes #88. The issue floated a typed accessor for non-LLM callers. We considered three shapes:

- **Opt-in `isinstance` classifier** — leaves the union untouched but *guesses* the outcome from the value alone, carrying a blind spot when a guarded fn itself returns a result type (in tension with VRE's "never guess" law).
- **Always-wrap** — removes the blind spot but taxes every success caller with `.value` unwrapping and abandons success-path transparency.
- **`GuardBlock` (chosen)** — VRE tags only its own interventions; the guard *knows* which branch it took, so there is no guessing and no blind spot, and the success value passes through raw.

## Breaking change

The blocked paths previously returned a bare `GroundingResult` / `PolicyResult`; they now return a `GuardBlock` wrapping it. The **success path is unchanged**. In-repo examples `str()` the result and are unaffected; only callers `isinstance`-checking the bare result types need to switch to `GuardBlock`.

## Test plan

- [x] `poetry run pytest` → 336 passed, 84.25% coverage (gate met)
- [x] `poetry run ruff check src/vre/guard.py tests/vre/test_guard.py` → clean
- [x] No import cycle: `from vre.guard import vre_guard, GuardBlock`
- [x] Success-path tests unchanged (transparency); blocked-path tests assert `GuardBlock` + `.blocked_by`

🤖 Generated with [Claude Code](https://claude.com/claude-code)