### PR TITLE
feat: vacuity floor — empty depths do not count toward grounding (#80)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ summarize major changes, refactors, and breaking changes — not every commit.
   slot per missing level for depth/relational — so an integrator fills only the
   `properties`. VRE resolves *which* levels are missing; a dormant detached level
   (e.g. a D4 over a D1 chain) is never offered for re-authoring. (#95)
+- `Depth.is_empty` (no properties and no relata) and `Depth.grounds` (whether the
+  depth counts toward grounding), plus `Primitive.grounding_levels` (the level set
+  that counts toward grounding). These express the vacuity floor in one place,
+  read by `contiguous_max_depth`, the gap `missing_levels`, and the learning
+  gate. (#80)
 
 ### Changed
 
@@ -66,6 +71,15 @@ summarize major changes, refactors, and breaking changes — not every commit.
   first (closing the duplicate-node gap). Reachability prerequisites and edge
   placement gate on contiguous depth, not exact level membership, so an edge can
   no longer be placed where grounding would never see it. (#95)
+- Vacuity floor: an empty depth — **no properties and no relata** — no longer
+  counts toward grounding. `contiguous_max_depth` and the gap `missing_levels`
+  skip empty levels (an empty non-D0 level now surfaces as a hole to fill rather
+  than as already satisfied), and the learning gate rejects an empty proposed fill
+  ("a fill must carry content") and replaces a pre-existing empty placeholder
+  instead of duplicating it. **D0/Existence is exempt** — its mere presence is the
+  knowledge, so a bare D0 still grounds. Structural floor only; provenance is not a
+  factor. May change grounding results for graphs that contained empty non-D0
+  depths. (#80)
 
 ### Removed
 

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -93,7 +93,7 @@ def _fmt_primitive(primitive: Primitive, id_to_name: dict[UUID, str]) -> list[st
 
     if primitive.depths:
         # Compact single-line format when all depths have no properties or relata
-        all_empty = all(not d.properties and not d.relata for d in primitive.depths)
+        all_empty = all(d.is_empty for d in primitive.depths)
         if all_empty:
             labels = [
                 format_depth_label(d.level)

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -174,6 +174,24 @@ class Depth(BaseModel):
     relata: list[Relatum] = Field(default_factory=list)
     provenance: Provenance | None = None
 
+    @property
+    def is_empty(self) -> bool:
+        """
+        No properties and no relata — structurally vacuous content.
+        """
+        return not self.properties and not self.relata
+
+    @property
+    def grounds(self) -> bool:
+        """
+        Whether this depth counts toward grounding.
+
+        D0 (Existence) always grounds — its mere presence is the knowledge
+        ("this concept exists"). Any deeper level must carry properties or
+        relata; an empty one is treated as absent. See issue #80.
+        """
+        return self.level == DepthLevel.EXISTENCE or not self.is_empty
+
     def validate_provenance(self, context: str = "") -> None:
         """
         Raise ValueError if provenance is missing on this depth or any of its relata.
@@ -201,11 +219,20 @@ class Primitive(BaseModel):
     metrics: PrimitiveMetrics | None = None
 
     @property
+    def grounding_levels(self) -> set[DepthLevel]:
+        """
+        The depth levels that count toward grounding — empty non-D0 depths
+        excluded. The single expression of the vacuity floor (#80) shared by
+        contiguous_max_depth and the gap/learning hole-detection sites.
+        """
+        return {d.level for d in self.depths if d.grounds}
+
+    @property
     def contiguous_max_depth(self) -> DepthLevel | None:
         """
         Highest DepthLevel forming a contiguous chain from D0, or None if no depths.
         """
-        return contiguous_max({d.level for d in self.depths})
+        return contiguous_max(self.grounding_levels)
 
     def validate_provenance(self) -> None:
         """
@@ -240,8 +267,9 @@ class DepthGap(BaseModel):
     @property
     def missing_levels(self) -> list[DepthLevel]:
         """The specific levels a fill must author to close this gap (the holes)."""
-        present = {d.level for d in self.primitive.depths}
-        return missing_depth_levels(present, self.current_depth, self.required_depth)
+        return missing_depth_levels(
+            self.primitive.grounding_levels, self.current_depth, self.required_depth
+        )
 
 
 class ExistenceGap(BaseModel):
@@ -268,8 +296,9 @@ class RelationalGap(BaseModel):
     @property
     def missing_levels(self) -> list[DepthLevel]:
         """The levels a fill must author on the target to close this gap (the holes)."""
-        present = {d.level for d in self.target.depths}
-        return missing_depth_levels(present, self.current_depth, self.required_depth)
+        return missing_depth_levels(
+            self.target.grounding_levels, self.current_depth, self.required_depth
+        )
 
 
 class ReachabilityGap(BaseModel):

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -125,6 +125,16 @@ def _validate_depth_fill(
             f"each level may appear at most once"
         )
 
+    for proposed in new_depths:
+        # A ProposedDepth carries no relata, so empty properties = vacuous.
+        # Refuse to fill a gap with nothing — D0 is auto-generated during
+        # existence persist and never proposed here (#80).
+        if not proposed.properties:
+            raise CandidateValidationError(
+                f"{subject} proposes an empty "
+                f"{format_depth_label(proposed.level)} — a fill must carry content"
+            )
+
     def _holes() -> list[str]:
         """
         Helper function to lazily evaluate the missing depth levels at the raise sites instead of
@@ -251,20 +261,28 @@ class LearningEngine:
         self, primitive: Primitive, new_depths: list[ProposedDepth], provenance: Provenance,
     ) -> None:
         """
-        Append proposed depth levels to a primitive and persist.
+        Append proposed depth levels (replacing any empty placeholder) and persist.
 
         The gate (`_validate_depth_fill`) guarantees every proposed level is a
-        genuine hole — not already present — so this only ever appends, never
-        replaces. Pre-existing levels (including dormant ones the new contiguity
-        reactivates) are left exactly as authored.
+        genuine hole — either absent or a non-grounding empty record. A grounding
+        level is never re-proposed, so the only record that can already sit at a
+        proposed level is an empty one, which we replace (it has no properties or
+        relata to clobber); otherwise we append. Pre-existing grounding levels
+        (including dormant ones the new contiguity reactivates) are left exactly
+        as authored.
         """
         logger.debug(
             "Appending %d depth(s) to %r (existing levels: %s)",
             len(new_depths), primitive.name,
             sorted(int(d.level) for d in primitive.depths),
         )
-        for proposed in new_depths:
-            primitive.depths.append(_to_depth(proposed, provenance))
+        # Drop any record already sitting at a proposed level. The gate's
+        # holes-only check guarantees it's a non-grounding empty placeholder —
+        # nothing to clobber (no properties, no relata) — so this replaces
+        # rather than duplicates (#80).
+        proposed_levels = {proposed.level for proposed in new_depths}
+        primitive.depths = [d for d in primitive.depths if d.level not in proposed_levels]
+        primitive.depths.extend(_to_depth(proposed, provenance) for proposed in new_depths)
         primitive.depths.sort(key=lambda d: int(d.level))
         self._repo.save_primitive(primitive)
 
@@ -292,7 +310,7 @@ class LearningEngine:
         _raise_if_resolved(existing.name, live_current, required_depth)
         _validate_depth_fill(
             new_depths, live_current, required_depth,
-            {d.level for d in existing.depths},
+            existing.grounding_levels,
             f"{label} for '{existing.name}'",
         )
 

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -130,7 +130,9 @@ def _make_primitive(
 
 
 def _depth(level: DepthLevel, relata: list[Relatum] | None = None) -> Depth:
-    return Depth(level=level, relata=relata or [])
+    # Non-D0 depths carry content so they survive the vacuity floor (#80);
+    # D0 grounds bare regardless.
+    return Depth(level=level, properties={"_": level.name}, relata=relata or [])
 
 
 def _relatum(

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -70,7 +70,9 @@ def _depth(
 ) -> Depth:
     return Depth(
         level=level,
-        properties=properties or {},
+        # Default to content so fixtures ground under the vacuity floor (#80);
+        # tests that need an empty depth pass properties={} explicitly.
+        properties=properties if properties is not None else {"_": level.name},
         provenance=_prov(),
     )
 
@@ -1856,3 +1858,82 @@ class TestStubRepositoryCycleDetection:
         ], id=b.id)
         with pytest.raises(CyclicRelationshipError):
             repo.save_primitive(b_with_edge)
+
+
+class TestVacuityFloorLearning:
+    """The learning path treats a non-D0 empty depth as a fillable hole."""
+
+    def test_gate_rejects_empty_proposed_depth(self) -> None:
+        prim = _primitive("File", depths=[_depth(DepthLevel.EXISTENCE)])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+        gap = DepthGap(
+            primitive=prim,
+            required_depth=DepthLevel.IDENTITY,
+            current_depth=DepthLevel.EXISTENCE,
+        )
+        candidate = DepthCandidate(
+            new_depths=[ProposedDepth(level=DepthLevel.IDENTITY, properties={})],
+        )
+        with pytest.raises(CandidateValidationError, match="must carry content"):
+            engine.learn_gap(gap, candidate)
+
+    def test_fill_replaces_pre_existing_empty_depth(self) -> None:
+        prim = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY, properties={}, provenance=_prov()),
+        ])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+
+        # Grounding sees only D0; a gap surfaces for the empty D1.
+        assert prim.contiguous_max_depth == DepthLevel.EXISTENCE
+        gap = DepthGap(
+            primitive=prim,
+            required_depth=DepthLevel.IDENTITY,
+            current_depth=DepthLevel.EXISTENCE,
+        )
+        assert gap.missing_levels == [DepthLevel.IDENTITY]
+
+        candidate = DepthCandidate(
+            new_depths=[ProposedDepth(
+                level=DepthLevel.IDENTITY, properties={"is": "a file"},
+            )],
+        )
+        engine.learn_gap(gap, candidate)
+
+        saved = repo.find_by_id(prim.id)
+        d1s = [d for d in saved.depths if d.level == DepthLevel.IDENTITY]
+        assert len(d1s) == 1                       # replaced, not duplicated
+        assert d1s[0].properties == {"is": "a file"}
+        assert saved.contiguous_max_depth == DepthLevel.IDENTITY
+
+    def test_mixed_fill_replaces_empty_and_appends_fresh(self) -> None:
+        # D1 exists but is empty; D2 is absent. One fill closes both: the empty
+        # D1 is replaced, the fresh D2 appended — exactly one record per level.
+        prim = _primitive("File", depths=[
+            _depth(DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY, properties={}, provenance=_prov()),
+        ])
+        repo = StubRepository([prim])
+        engine = LearningEngine(repo)
+
+        gap = DepthGap(
+            primitive=prim,
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=prim.contiguous_max_depth,  # EXISTENCE (empty D1 doesn't ground)
+        )
+        assert gap.missing_levels == [DepthLevel.IDENTITY, DepthLevel.CAPABILITIES]
+
+        candidate = DepthCandidate(new_depths=[
+            ProposedDepth(level=DepthLevel.IDENTITY, properties={"is": "a file"}),
+            ProposedDepth(level=DepthLevel.CAPABILITIES, properties={"can": "read"}),
+        ])
+        engine.learn_gap(gap, candidate)
+
+        saved = repo.find_by_id(prim.id)
+        levels = sorted(int(d.level) for d in saved.depths)
+        assert levels == [0, 1, 2]  # exactly one record per level, no duplicate D1
+        d1 = next(d for d in saved.depths if d.level == DepthLevel.IDENTITY)
+        assert d1.properties == {"is": "a file"}
+        assert saved.contiguous_max_depth == DepthLevel.CAPABILITIES

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -112,9 +112,9 @@ class StubRepository(Repository):
 def _make_fully_grounded(name: str) -> Primitive:
     return Primitive(name=name, depths=[
         Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY),
-        Depth(level=DepthLevel.CAPABILITIES),
-        Depth(level=DepthLevel.CONSTRAINTS),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
     ])
 
 
@@ -213,7 +213,7 @@ class TestGroundingMetrics:
         file_p = _make_fully_grounded("file")
         create_p = Primitive(name="create", depths=[
             Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY),
+            Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
             Depth(level=DepthLevel.CAPABILITIES, relata=[
                 Relatum(
                     relation_type=RelationType.APPLIES_TO,
@@ -221,7 +221,7 @@ class TestGroundingMetrics:
                     target_depth=DepthLevel.CAPABILITIES,
                 ),
             ]),
-            Depth(level=DepthLevel.CONSTRAINTS),
+            Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
         ])
         vre, repo = _make_vre([file_p, create_p])
         vre.check(["file", "create"])

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -37,7 +37,11 @@ def _make_primitive(
     max_depth: DepthLevel = DepthLevel.EXISTENCE,
 ) -> Primitive:
     depths = [
-        Depth(level=DepthLevel(i), provenance=_prov())
+        Depth(
+            level=DepthLevel(i),
+            properties={} if i == DepthLevel.EXISTENCE else {"_": DepthLevel(i).name.lower()},
+            provenance=_prov(),
+        )
         for i in range(max_depth + 1)
     ]
     return Primitive(name=name, depths=depths, provenance=_prov())

--- a/tests/vre/test_tracing.py
+++ b/tests/vre/test_tracing.py
@@ -113,9 +113,9 @@ class StubRepository(Repository):
 def _make_fully_grounded(name: str) -> Primitive:
     return Primitive(name=name, depths=[
         Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY),
-        Depth(level=DepthLevel.CAPABILITIES),
-        Depth(level=DepthLevel.CONSTRAINTS),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
     ])
 
 

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -1,7 +1,10 @@
 """
-Unit tests for GroundingResult.__str__ and PolicyResult.__str__.
+Unit tests for GroundingResult.__str__ and PolicyResult.__str__, plus
+model-level depth predicate/grounding tests (e.g. `contiguous_max_depth`).
 """
 
+
+from uuid import uuid4
 
 from vre.core.models import (
     Depth,
@@ -201,6 +204,35 @@ def test_grounding_str_reachability_gap():
     assert "REACHABILITY: 'network' is not connected to other concepts" in s
 
 
+class TestDepthVacuity:
+    """is_empty is pure structure; grounds layers the D0 exemption on top."""
+
+    def test_empty_depth_is_empty_and_does_not_ground(self) -> None:
+        d = Depth(level=DepthLevel.IDENTITY)
+        assert d.is_empty is True
+        assert d.grounds is False
+
+    def test_properties_make_a_depth_ground(self) -> None:
+        d = Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"})
+        assert d.is_empty is False
+        assert d.grounds is True
+
+    def test_relata_alone_make_a_depth_ground(self) -> None:
+        rel = Relatum(
+            relation_type=RelationType.APPLIES_TO,
+            target_id=uuid4(),
+            target_depth=DepthLevel.IDENTITY,
+        )
+        d = Depth(level=DepthLevel.IDENTITY, relata=[rel])
+        assert d.is_empty is False
+        assert d.grounds is True
+
+    def test_bare_d0_is_empty_but_still_grounds(self) -> None:
+        d = Depth(level=DepthLevel.EXISTENCE)
+        assert d.is_empty is True
+        assert d.grounds is True
+
+
 def test_grounding_str_no_trace_renders_gracefully():
     result = GroundingResult(grounded=True, resolved=["file"], gaps=[], trace=None)
     s = str(result)
@@ -257,3 +289,63 @@ def test_policy_str_block_with_violations():
     s = str(result)
     assert "BLOCKED" in s
     assert "User declined" in s
+
+
+class TestContiguousMaxDepthVacuityFloor:
+    """contiguous_max_depth skips empty depths; D0 is exempt."""
+
+    def test_empty_depth_does_not_extend_grounding(self) -> None:
+        p = Primitive(name="X", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY),  # empty
+        ])
+        assert p.contiguous_max_depth == DepthLevel.EXISTENCE
+
+    def test_populated_depth_extends_grounding(self) -> None:
+        p = Primitive(name="X", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"}),
+        ])
+        assert p.contiguous_max_depth == DepthLevel.IDENTITY
+
+    def test_bare_d0_grounds_at_existence(self) -> None:
+        p = Primitive(name="X", depths=[Depth(level=DepthLevel.EXISTENCE)])
+        assert p.contiguous_max_depth == DepthLevel.EXISTENCE
+
+    def test_empty_middle_depth_breaks_chain(self) -> None:
+        p = Primitive(name="X", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY, properties={"x": 1}),
+            Depth(level=DepthLevel.CAPABILITIES),  # empty — chain stops here
+            Depth(level=DepthLevel.CONSTRAINTS, properties={"x": 1}),
+        ])
+        assert p.contiguous_max_depth == DepthLevel.IDENTITY
+
+
+class TestGapMissingLevelsVacuity:
+    """An empty depth is a hole the fill must author."""
+
+    def test_depth_gap_lists_empty_level_as_hole(self) -> None:
+        p = Primitive(name="X", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY),  # empty
+        ])
+        gap = DepthGap(
+            primitive=p,
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=p.contiguous_max_depth,  # EXISTENCE
+        )
+        assert gap.missing_levels == [DepthLevel.IDENTITY, DepthLevel.CAPABILITIES]
+
+    def test_relational_gap_lists_empty_level_as_hole(self) -> None:
+        target = Primitive(name="T", depths=[
+            Depth(level=DepthLevel.EXISTENCE),
+            Depth(level=DepthLevel.IDENTITY),  # empty
+        ])
+        gap = RelationalGap(
+            source=Primitive(name="S", depths=[Depth(level=DepthLevel.EXISTENCE)]),
+            target=target,
+            required_depth=DepthLevel.CAPABILITIES,
+            current_depth=target.contiguous_max_depth,  # EXISTENCE
+        )
+        assert gap.missing_levels == [DepthLevel.IDENTITY, DepthLevel.CAPABILITIES]

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -117,9 +117,9 @@ class StubRepository(Repository):
 def _make_fully_grounded(name: str) -> Primitive:
     return Primitive(name=name, depths=[
         Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY),
-        Depth(level=DepthLevel.CAPABILITIES),
-        Depth(level=DepthLevel.CONSTRAINTS),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
     ])
 
 
@@ -142,7 +142,14 @@ def _make_primitive_with_edge(
         target_depth=target_depth,
     )
     levels = [DepthLevel.EXISTENCE, DepthLevel.IDENTITY, DepthLevel.CAPABILITIES, DepthLevel.CONSTRAINTS]
-    depths = [Depth(level=lvl, relata=[relatum] if lvl == source_depth else []) for lvl in levels]
+    depths = [
+        Depth(
+            level=lvl,
+            properties={} if lvl == DepthLevel.EXISTENCE else {"_": lvl.name.lower()},
+            relata=[relatum] if lvl == source_depth else [],
+        )
+        for lvl in levels
+    ]
     return Primitive(name=name, depths=depths)
 
 


### PR DESCRIPTION
## Summary

Closes #80. A depth grounded a primitive merely by *existing* — its content was never inspected — so a human could approve a blank depth at the persistence boundary and it would count as understanding. This adds a structural **vacuity floor**: a depth counts toward grounding only if it carries content.

**Decision recorded:** empty = **no properties AND no relata**. **D0/Existence is exempt** — its mere presence is the knowledge ("this concept exists"), so a bare D0 always grounds. The rule is single-sourced via `Depth.grounds` and `Primitive.grounding_levels`, read by grounding, gap hole-detection, and the learning gate alike.

### Changes
- **models:** add `Depth.is_empty` (pure structure) + `Depth.grounds` (structure + D0 exemption); a `Primitive.grounding_levels` property is the one expression of the floor, consumed by `contiguous_max_depth` and both gaps' `missing_levels` (empty levels now surface as holes to fill, not as satisfied).
- **learning:** the gate's present-set is grounds-filtered so an empty non-D0 level is a fillable hole; a vacuity guard rejects empty proposed fills (*"a fill must carry content"*); `_append_depths` replaces a pre-existing empty placeholder rather than duplicating it (append-only otherwise preserved per #95 — only a content-free shell is ever replaced).
- **grounding:** route the display emptiness check through `Depth.is_empty`.

Structural floor only — it does not assess correctness or quality of populated content, and provenance is not a factor. Backend-agnostic (model/engine layer; no backend SQL).

## Test Plan
- [x] Empty non-D0 depth does not ground at that level; a populated one does (`test_types.py`)
- [x] A bare D0 still grounds (`test_types.py`)
- [x] Gap `missing_levels` lists an empty level as a hole — DepthGap and RelationalGap (`test_types.py`)
- [x] Learning gate rejects an empty proposed depth (`test_learning.py`)
- [x] Learning fills a pre-existing empty depth via replace — no duplicate record; mixed replace+append in one call (`test_learning.py`)
- [x] Full suite green: 373 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)