### PR TITLE
fix: require provenance at the model level; add SYNTHETIC genealogy (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,21 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ### Added
 
+- `ProvenanceError` (a `VREError`, exported from `vre` and `vre.core`):
+  `Primitive`/`Depth`/`Relatum.validate_provenance()` — which both backends call
+  before any save — raises this typed error instead of a bare `ValueError` when
+  provenance is missing, so integrators catching `VREError` no longer leak an
+  unstructured exception. With provenance now required at the model level (see
+  Changed), this validation is the deliberate fails-closed backstop against
+  provenance being nulled or spoofed *after* construction (Pydantic does not
+  re-validate on assignment). (#98)
+- `ProvenanceSource.SYNTHETIC`: a third provenance genealogy for engine-generated,
+  non-knowledge placeholders — specifically the transient primitive the grounding
+  engine manufactures for a queried concept absent from the graph (the
+  `ExistenceGap` root). Authored and Learned are human-attested by construction;
+  Synthetic is machine-attested. It is genealogy, not a trust tier — knowledge of
+  an *absence*, honestly sourced rather than left null or falsely stamped
+  `AUTHORED`. (#98)
 - Policy callback context types: `ToolCallContext`, `GroundingContext`, and a
   per-edge `TriggeringEdge`. Callback failure reasons now surface in the policy
   violation message. (#58)
@@ -53,6 +68,21 @@ summarize major changes, refactors, and breaking changes — not every commit.
   `tool_call` is supplied. (#58)
 - Policy `confirmation_message` is used verbatim; the `{action}` interpolation
   was dropped.
+- **BREAKING:** Provenance is now **required at the model level**. The
+  `provenance` field on `Primitive`, `Depth`, and `Relatum` is non-optional
+  (`provenance: Provenance`, no default), so constructing any of them without
+  provenance raises a Pydantic `ValidationError`. This replaces the previous
+  "optional for backward compatibility" framing (CLAUDE.md §7.2) — the contract
+  is now explicit and unavoidable at construction. Consequences: (1) integrator
+  code that builds these models directly must supply provenance; (2)
+  **legacy/unstamped graphs are no longer readable** — hydrating a stored
+  primitive, depth, or relatum that lacks provenance raises `HydrationError`
+  rather than degrading to `None` (pre-1.0, there are no such graphs to
+  preserve, so this is a deliberate fail-closed). The save-boundary
+  `validate_provenance()` check is retained as a second layer against
+  post-construction tampering (see Added: `ProvenanceError`). The learning-path
+  test `StubRepository` now calls `validate_provenance()` like the real backends,
+  closing a stub-vs-backend conformance gap. (#98, #83)
 - Provenance semantics documented for the knowledge-linter model: `AUTHORED` =
   a human drafted the content directly; `LEARNED` = an agent proposed it and a
   human approved it at the persistence boundary. Both are human-attested by

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -28,6 +28,7 @@ from vre.core.errors import (
     HydrationError,
     PersistenceError,
     PolicyPlacementError,
+    ProvenanceError,
     RegistryError,
     VREError,
 )
@@ -86,6 +87,7 @@ __all__ = [
     "HydrationError",
     "PersistenceError",
     "PolicyPlacementError",
+    "ProvenanceError",
     "RegistryError",
     "VREError",
     "Neo4jRepository",

--- a/src/vre/core/__init__.py
+++ b/src/vre/core/__init__.py
@@ -10,6 +10,7 @@ from vre.core.errors import (
     GraphIntegrityError,
     HydrationError,
     PersistenceError,
+    ProvenanceError,
     VREError,
 )
 from vre.core.models import (
@@ -27,6 +28,7 @@ __all__ = [
     "HydrationError",
     "PersistenceError",
     "Provenance",
+    "ProvenanceError",
     "ProvenanceSource",
     "Repository",
     "TRANSITIVE_RELATION_TYPES",

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -94,9 +94,8 @@ class Neo4jRepository(Repository):
             entry: dict[str, Any] = {
                 "level": int(depth.level),
                 "properties": depth.properties,
+                "provenance": depth.provenance.model_dump(mode="json"),
             }
-            if depth.provenance:
-                entry["provenance"] = depth.provenance.model_dump(mode="json")
             stripped.append(entry)
         return json.dumps(stripped)
 
@@ -147,12 +146,18 @@ class Neo4jRepository(Repository):
         """Reconstruct a Primitive from raw Neo4j node data and its relationship records."""
         try:
             raw_depths = json.loads(node_data["depths_json"])
+            name = node_data["name"]
             depths_by_level: dict[int, Depth] = {}
             for rd in raw_depths:
+                if not rd.get("provenance"):
+                    raise HydrationError(
+                        f"Depth D{rd['level']} of '{name}' is missing provenance — "
+                        f"provenance is required (no legacy/unstamped graphs)"
+                    )
                 depth = Depth(
                     level=DepthLevel(rd["level"]),
                     properties=rd.get("properties", {}),
-                    provenance=Provenance(**rd["provenance"]) if rd.get("provenance") else None,
+                    provenance=Provenance(**rd["provenance"]),
                 )
                 depths_by_level[int(depth.level)] = depth
 
@@ -164,9 +169,12 @@ class Neo4jRepository(Repository):
                 metadata = json.loads(metadata_json) if metadata_json else {}
 
                 rel_prov_json = rel_props.get("provenance_json")
-                rel_prov = None
-                if rel_prov_json:
-                    rel_prov = Provenance(**Neo4jRepository._parse_json_field(rel_prov_json))
+                if not rel_prov_json:
+                    raise HydrationError(
+                        f"Relatum {rel['rel_type']} on '{name}' is missing provenance — "
+                        f"provenance is required (no legacy/unstamped graphs)"
+                    )
+                rel_prov = Provenance(**Neo4jRepository._parse_json_field(rel_prov_json))
 
                 relatum = Relatum(
                     relation_type=RelationType(rel["rel_type"]),
@@ -182,9 +190,12 @@ class Neo4jRepository(Repository):
             sorted_depths = sorted(depths_by_level.values(), key=lambda d: int(d.level))
 
             node_prov_json = node_data.get("provenance_json")
-            node_prov = None
-            if node_prov_json:
-                node_prov = Provenance(**Neo4jRepository._parse_json_field(node_prov_json))
+            if not node_prov_json:
+                raise HydrationError(
+                    f"Primitive '{name}' is missing provenance — "
+                    f"provenance is required (no legacy/unstamped graphs)"
+                )
+            node_prov = Provenance(**Neo4jRepository._parse_json_field(node_prov_json))
 
             node_metrics_json = node_data.get("metrics_json")
             node_metrics = None

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -135,9 +135,8 @@ class SQLiteRepository(Repository):
             entry: dict[str, Any] = {
                 "level": int(depth.level),
                 "properties": depth.properties,
+                "provenance": depth.provenance.model_dump(mode="json"),
             }
-            if depth.provenance:
-                entry["provenance"] = depth.provenance.model_dump(mode="json")
             stripped.append(entry)
         return json.dumps(stripped)
 
@@ -155,11 +154,17 @@ class SQLiteRepository(Repository):
         try:
             raw_depths = json.loads(node_data["depths_json"])
             depths_by_level: dict[int, Depth] = {}
+            name = node_data["name"]
             for rd in raw_depths:
+                if not rd.get("provenance"):
+                    raise HydrationError(
+                        f"Depth D{rd['level']} of '{name}' is missing provenance — "
+                        f"provenance is required (no legacy/unstamped graphs)"
+                    )
                 depth = Depth(
                     level=DepthLevel(rd["level"]),
                     properties=rd.get("properties", {}),
-                    provenance=Provenance(**rd["provenance"]) if rd.get("provenance") else None,
+                    provenance=Provenance(**rd["provenance"]),
                 )
                 depths_by_level[int(depth.level)] = depth
 
@@ -170,9 +175,12 @@ class SQLiteRepository(Repository):
                 metadata = json.loads(metadata_raw) if metadata_raw else {}
 
                 rel_prov_raw = rel.get("provenance_json")
-                rel_prov = None
-                if rel_prov_raw:
-                    rel_prov = Provenance(**json.loads(rel_prov_raw))
+                if not rel_prov_raw:
+                    raise HydrationError(
+                        f"Relatum {rel['rel_type']} on '{name}' is missing provenance — "
+                        f"provenance is required (no legacy/unstamped graphs)"
+                    )
+                rel_prov = Provenance(**json.loads(rel_prov_raw))
 
                 relatum = Relatum(
                     relation_type=RelationType(rel["rel_type"]),
@@ -188,9 +196,12 @@ class SQLiteRepository(Repository):
             sorted_depths = sorted(depths_by_level.values(), key=lambda d: int(d.level))
 
             node_prov_raw = node_data.get("provenance_json")
-            node_prov = None
-            if node_prov_raw:
-                node_prov = Provenance(**json.loads(node_prov_raw))
+            if not node_prov_raw:
+                raise HydrationError(
+                    f"Primitive '{name}' is missing provenance — "
+                    f"provenance is required (no legacy/unstamped graphs)"
+                )
+            node_prov = Provenance(**json.loads(node_prov_raw))
 
             node_metrics_raw = node_data.get("metrics_json")
             node_metrics = None

--- a/src/vre/core/errors.py
+++ b/src/vre/core/errors.py
@@ -37,6 +37,15 @@ class HydrationError(VREError):
     """Failed to reconstruct a domain object from stored data."""
 
 
+class ProvenanceError(VREError):
+    """Knowledge being persisted is missing required provenance.
+
+    Provenance is required on every primitive, depth, and relatum at the
+    persistence boundary (CLAUDE.md §7.2). Raised by validate_provenance,
+    which the backends invoke before any save.
+    """
+
+
 class CandidateValidationError(VREError):
     """A learning candidate is missing required fields or references invalid data."""
 

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -30,6 +30,8 @@ from vre.core.models import (
     EpistemicStep,
     ExistenceGap,
     Primitive,
+    Provenance,
+    ProvenanceSource,
     ReachabilityGap,
     RelationalGap,
 )
@@ -85,7 +87,19 @@ class GroundingEngine:
             if matched:
                 all_roots.append(matched)
             else:
-                t = Primitive(name=name, depths=[])
+                # The concept is not in the graph. We manufacture a transient
+                # placeholder to anchor the traversal and the ExistenceGap. It
+                # carries no knowledge (depths=[]) and is never persisted, but it
+                # came from somewhere — the engine, surfacing the *absence* of the
+                # concept — so its provenance is SYNTHETIC, not a forged human one.
+                t = Primitive(
+                    name=name,
+                    depths=[],
+                    provenance=Provenance(
+                        source=ProvenanceSource.SYNTHETIC,
+                        detail=f"transient placeholder for concept '{name}' absent from the graph",
+                    ),
+                )
                 all_roots.append(t)
                 transients.append(t)
         return all_roots, transients

--- a/src/vre/core/grounding/models.py
+++ b/src/vre/core/grounding/models.py
@@ -56,9 +56,8 @@ def _fmt_relatum(r: Relatum, id_to_name: dict[UUID, str]) -> list[str]:
     if r.metadata:
         meta_str = ", ".join(f"{k}={v}" for k, v in r.metadata.items())
         lines.append(f"        metadata: {meta_str}")
-    if r.provenance:
-        date_str = r.provenance.created_at.strftime("%Y-%m-%d")
-        lines.append(f"        provenance: {r.provenance.source.value} ({date_str})")
+    date_str = r.provenance.created_at.strftime("%Y-%m-%d")
+    lines.append(f"        provenance: {r.provenance.source.value} ({date_str})")
     return lines
 
 
@@ -66,8 +65,7 @@ def _fmt_depth(depth: Depth, id_to_name: dict[UUID, str]) -> list[str]:
     """
     Format a single Depth level as display lines, including its relata.
     """
-    prov_tag = f"  [{depth.provenance.source.value}]" if depth.provenance else ""
-    lines = [f"  {format_depth_label(depth.level)}{prov_tag}"]
+    lines = [f"  {format_depth_label(depth.level)}  [{depth.provenance.source.value}]"]
     if depth.properties:
         lines.append("    properties:")
         for k, v in depth.properties.items():
@@ -87,9 +85,8 @@ def _fmt_primitive(primitive: Primitive, id_to_name: dict[UUID, str]) -> list[st
     header = f"═══ {name} {'═' * max(0, 50 - len(name))}"
     lines = [header]
 
-    if primitive.provenance:
-        date_str = primitive.provenance.created_at.strftime("%Y-%m-%d")
-        lines.append(f"  provenance: {primitive.provenance.source.value} ({date_str})")
+    date_str = primitive.provenance.created_at.strftime("%Y-%m-%d")
+    lines.append(f"  provenance: {primitive.provenance.source.value} ({date_str})")
 
     if primitive.depths:
         # Compact single-line format when all depths have no properties or relata

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -13,6 +13,8 @@ from uuid import UUID, uuid4
 
 from pydantic import BaseModel, Field
 
+from vre.core.errors import ProvenanceError
+
 
 class DepthLevel(IntEnum):
     """
@@ -93,20 +95,30 @@ class ProvenanceSource(str, Enum):
     """
     Origin category for knowledge in the epistemic graph.
 
-    Provenance is genealogy -- who drafted the content -- not a trust
-    gradient. As a knowledge linter, VRE only ever persists knowledge that
-    a human has attested at the persistence boundary, so the two categories
-    differ solely in who drafted the content:
+    Provenance is genealogy -- who (or what) drafted the content -- not a
+    trust gradient. The categories differ solely in origin:
 
     - AUTHORED: a human drafted the content from scratch.
     - LEARNED: an agent proposed the content and a human approved it at
       the point of persistence.
+    - SYNTHETIC: the engine itself generated the object. This is the
+      genealogy of a placeholder the system manufactures to represent the
+      *absence* of knowledge -- e.g. the transient primitive that stands in
+      for a queried concept not present in the graph (see the grounding
+      engine). It is knowledge of an absence, not knowledge of a concept.
 
-    Both are human-attested by construction.
+    AUTHORED and LEARNED are human-attested by construction; SYNTHETIC is
+    machine-attested and is set only by the engine -- integrators never assign
+    it. Provenance is genealogy, not an ordered trust score (there is no
+    authored > learned > synthetic ranking). But the human-attested vs
+    machine-attested boundary is real and deliberately audit-relevant: "is
+    anything in this graph not human-attested?" is a legitimate, answerable
+    query. That is a feature, not a backdoor trust gradient.
     """
 
     AUTHORED = "authored"
     LEARNED = "learned"
+    SYNTHETIC = "synthetic"
 
 
 class Provenance(BaseModel):
@@ -151,14 +163,14 @@ class Relatum(BaseModel):
     target_id: UUID
     target_depth: DepthLevel
     metadata: dict[str, Any] = Field(default_factory=dict)
-    provenance: Provenance | None = None
+    provenance: Provenance
 
     def validate_provenance(self, context: str = "") -> None:
         """
-        Raise ValueError if provenance is missing.
+        Raise ProvenanceError if provenance is missing.
         """
         if self.provenance is None:
-            raise ValueError(
+            raise ProvenanceError(
                 f"{context}relatum {self.relation_type.value} → "
                 f"{self.target_id} is missing provenance"
             )
@@ -172,7 +184,7 @@ class Depth(BaseModel):
     level: DepthLevel
     properties: dict[str, Any] = Field(default_factory=dict)
     relata: list[Relatum] = Field(default_factory=list)
-    provenance: Provenance | None = None
+    provenance: Provenance
 
     @property
     def is_empty(self) -> bool:
@@ -194,10 +206,10 @@ class Depth(BaseModel):
 
     def validate_provenance(self, context: str = "") -> None:
         """
-        Raise ValueError if provenance is missing on this depth or any of its relata.
+        Raise ProvenanceError if provenance is missing on this depth or any of its relata.
         """
         if self.provenance is None:
-            raise ValueError(
+            raise ProvenanceError(
                 f"{context}depth D{self.level.value} ({self.level.name}) "
                 f"is missing provenance"
             )
@@ -215,7 +227,7 @@ class Primitive(BaseModel):
     id: UUID = Field(default_factory=uuid4)
     name: str
     depths: list[Depth] = Field(default_factory=list)
-    provenance: Provenance | None = None
+    provenance: Provenance
     metrics: PrimitiveMetrics | None = None
 
     @property
@@ -236,10 +248,10 @@ class Primitive(BaseModel):
 
     def validate_provenance(self) -> None:
         """
-        Raise ValueError if provenance is missing on this primitive, any depth, or any relatum.
+        Raise ProvenanceError if provenance is missing on this primitive, any depth, or any relatum.
         """
         if self.provenance is None:
-            raise ValueError(
+            raise ProvenanceError(
                 f"Primitive '{self.name}' is missing provenance"
             )
         for depth in self.depths:

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -15,10 +15,14 @@ from vre.core.models import (
     EpistemicStep,
     Primitive,
     PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
     Relatum,
     RelationType,
     ResolvedSubgraph,
 )
+
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 # ---------------------------------------------------------------------------
@@ -73,7 +77,7 @@ class StubRepository(Repository):
             if p:
                 nodes.append(p)
             else:
-                nodes.append(Primitive(id=uid, name="<unknown>", depths=[]))
+                nodes.append(Primitive(id=uid, name="<unknown>", depths=[], provenance=_PROV))
 
         node_ids = {n.id for n in nodes}
         edges: list[EpistemicStep] = []
@@ -126,13 +130,13 @@ def _make_primitive(
     depths: list[Depth] | None = None,
     id: UUID | None = None,
 ) -> Primitive:
-    return Primitive(id=id or uuid4(), name=name, depths=depths or [])
+    return Primitive(id=id or uuid4(), name=name, depths=depths or [], provenance=_PROV)
 
 
 def _depth(level: DepthLevel, relata: list[Relatum] | None = None) -> Depth:
     # Non-D0 depths carry content so they survive the vacuity floor (#80);
     # D0 grounds bare regardless.
-    return Depth(level=level, properties={"_": level.name}, relata=relata or [])
+    return Depth(level=level, properties={"_": level.name}, relata=relata or [], provenance=_PROV)
 
 
 def _relatum(
@@ -144,6 +148,7 @@ def _relatum(
         relation_type=rel_type,
         target_id=target_id,
         target_depth=target_depth,
+        provenance=_PROV,
     )
 
 
@@ -269,6 +274,18 @@ class TestFlatQuery:
         assert any(g.primitive.name == "widget" for g in existence_gaps)
         reachability_gaps = [g for g in resp.result.gaps if g.kind == "REACHABILITY"]
         assert len(reachability_gaps) == 0
+
+    def test_unknown_concept_transient_carries_synthetic_provenance(self) -> None:
+        """The transient placeholder for an absent concept is stamped SYNTHETIC —
+        engine-generated knowledge of an absence, not a forged human genealogy."""
+        engine = GroundingEngine(StubRepository([]))
+
+        resp = engine.query(["frobnicate"])
+
+        gap = next(g for g in resp.result.gaps if g.kind == "EXISTENCE")
+        assert gap.primitive.name == "frobnicate"
+        assert gap.primitive.provenance.source == ProvenanceSource.SYNTHETIC
+        assert "frobnicate" in gap.primitive.provenance.detail
 
     def test_connected_concepts_grounded(self) -> None:
         """Two concepts connected by an edge → no ReachabilityGap."""

--- a/tests/vre/test_guard.py
+++ b/tests/vre/test_guard.py
@@ -8,10 +8,15 @@ from uuid import uuid4
 import pytest
 
 from vre.core.grounding import GroundingResult
-from vre.core.models import ExistenceGap, Primitive
+from vre.core.models import ExistenceGap, Primitive, Provenance, ProvenanceSource
 from vre.core.policy import PolicyAction, PolicyResult
 from vre.core.policy.models import PolicyViolation, Policy
 from vre.guard import GuardBlock, vre_guard
+
+
+# A transient placeholder for an absent concept, mirroring what the grounding
+# engine manufactures for an ExistenceGap (engine-generated, SYNTHETIC genealogy).
+_SYNTHETIC = Provenance(source=ProvenanceSource.SYNTHETIC)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -46,7 +51,7 @@ def test_vre_guard_returns_guardblock_when_not_grounded():
     """When grounding fails, vre_guard returns a GuardBlock without calling fn."""
     from vre.guard import vre_guard
 
-    gap = ExistenceGap(primitive=Primitive(name="unknown", depths=[]))
+    gap = ExistenceGap(primitive=Primitive(name="unknown", depths=[], provenance=_SYNTHETIC))
     mock_vre = _mock_vre(_grounding(grounded=False, gaps=[gap]))
 
     @vre_guard(mock_vre, concepts=["file"])
@@ -66,7 +71,7 @@ def test_vre_guard_blocks_on_existence_gap():
     from vre.guard import vre_guard
     from vre.core.models import ExistenceGap, Primitive
 
-    gap = ExistenceGap(primitive=Primitive(name="api", depths=[]))
+    gap = ExistenceGap(primitive=Primitive(name="api", depths=[], provenance=_SYNTHETIC))
     mock_vre = _mock_vre(_grounding(grounded=False, gaps=[gap]))
 
     @vre_guard(mock_vre, concepts=["file", "api"])

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -97,6 +97,12 @@ class StubRepository(Repository):
         return self._by_name.get(name.lower())
 
     def save_primitive(self, primitive: Primitive) -> None:
+        # Mirror the real backends' save contract: provenance is required on
+        # every primitive, depth, and relatum at the persistence boundary
+        # (neo4j.py / sqlite.py both call this before any write). Skipping it
+        # would let the learning-path tests pass against a contract the real
+        # graph enforces -- the #98 / #83 stub-vs-backend divergence.
+        primitive.validate_provenance()
         for depth in primitive.depths:
             for relatum in depth.relata:
                 if relatum.relation_type not in TRANSITIVE_RELATION_TYPES:
@@ -1314,6 +1320,7 @@ class TestPersistRelationalEdgeCases:
     def test_does_not_stamp_provenance_on_untouched_depths(self):
         """Relata on depths not being replaced should remain untouched."""
         source = _primitive("Create")
+        authored = _prov(ProvenanceSource.AUTHORED)
         target = _primitive("File", depths=[
             Depth(
                 level=DepthLevel.EXISTENCE,
@@ -1322,8 +1329,9 @@ class TestPersistRelationalEdgeCases:
                     relation_type=RelationType.APPLIES_TO,
                     target_id=uuid4(),
                     target_depth=DepthLevel.IDENTITY,
-                    provenance=None,
+                    provenance=authored,
                 )],
+                provenance=authored,
             ),
         ])
         repo = StubRepository([source, target])
@@ -1340,9 +1348,11 @@ class TestPersistRelationalEdgeCases:
 
         engine.learn_gap(gap, filled)
         saved = repo.saved[0]
-        # D0 was not touched -- its relatum provenance should remain None
+        # D0 was not touched -- its relatum keeps its original AUTHORED provenance;
+        # learning must not re-stamp knowledge it did not create as LEARNED.
         d0 = next(d for d in saved.depths if d.level == DepthLevel.EXISTENCE)
-        assert d0.relata[0].provenance is None
+        assert d0.relata[0].provenance is authored
+        assert d0.relata[0].provenance.source == ProvenanceSource.AUTHORED
 
     def test_rejects_re_authoring_present_target_depth(self):
         # The gate is wired on the relational path too (present_levels from the

--- a/tests/vre/test_metrics.py
+++ b/tests/vre/test_metrics.py
@@ -16,11 +16,16 @@ from vre.core.models import (
     EpistemicStep,
     Primitive,
     PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
     Relatum,
     RelationType,
     ResolvedSubgraph,
 )
 from vre.core.grounding import GroundingResult
+
+
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 # ---------------------------------------------------------------------------
@@ -110,11 +115,11 @@ class StubRepository(Repository):
 
 
 def _make_fully_grounded(name: str) -> Primitive:
-    return Primitive(name=name, depths=[
-        Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
-        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
-        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
+    return Primitive(name=name, provenance=_PROV, depths=[
+        Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}, provenance=_PROV),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}, provenance=_PROV),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}, provenance=_PROV),
     ])
 
 
@@ -158,7 +163,7 @@ class TestPrimitiveMetricsModel:
         assert m.last_exercised == late
 
     def test_metrics_none_backward_compatible(self):
-        p = Primitive(name="legacy")
+        p = Primitive(name="legacy", provenance=_PROV)
         assert p.metrics is None
 
 
@@ -181,8 +186,8 @@ class TestGroundingMetrics:
 
     def test_check_ungrounded_increments_failure_count(self):
         """min_depth forces a DepthGap when the primitive lacks that depth."""
-        file_p = Primitive(name="file", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
+        file_p = Primitive(name="file", provenance=_PROV, depths=[
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
         ])
         vre, repo = _make_vre([file_p])
         vre.check(["file"], min_depth=DepthLevel.CONSTRAINTS)
@@ -211,17 +216,18 @@ class TestGroundingMetrics:
 
     def test_multiple_concepts_per_concept_metrics(self):
         file_p = _make_fully_grounded("file")
-        create_p = Primitive(name="create", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
-            Depth(level=DepthLevel.CAPABILITIES, relata=[
+        create_p = Primitive(name="create", provenance=_PROV, depths=[
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}, provenance=_PROV),
+            Depth(level=DepthLevel.CAPABILITIES, provenance=_PROV, relata=[
                 Relatum(
                     relation_type=RelationType.APPLIES_TO,
                     target_id=file_p.id,
                     target_depth=DepthLevel.CAPABILITIES,
+                    provenance=_PROV,
                 ),
             ]),
-            Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
+            Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}, provenance=_PROV),
         ])
         vre, repo = _make_vre([file_p, create_p])
         vre.check(["file", "create"])
@@ -265,14 +271,14 @@ class TestMetricsSerialization:
         assert restored.last_failed == m.last_failed
 
     def test_roundtrip_none_metrics_on_primitive(self):
-        p = Primitive(name="test")
+        p = Primitive(name="test", provenance=_PROV)
         data = p.model_dump(mode="json")
         restored = Primitive(**data)
         assert restored.metrics is None
 
     def test_roundtrip_with_metrics_on_primitive(self):
         m = PrimitiveMetrics(grounding_count=10)
-        p = Primitive(name="test", metrics=m)
+        p = Primitive(name="test", provenance=_PROV, metrics=m)
         data = p.model_dump(mode="json")
         restored = Primitive(**data)
         assert restored.metrics is not None

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -9,6 +9,8 @@ from vre.core.models import (
     EpistemicResponse,
     EpistemicResult,
     Primitive,
+    Provenance,
+    ProvenanceSource,
     Relatum,
     RelationType,
 )
@@ -16,6 +18,8 @@ from vre.core.policy import Cardinality, Policy, PolicyCallbackResult, PolicyVio
 from vre.core.policy.callback import GroundingContext, ToolCallContext, TriggeringEdge
 from vre.core.policy.gate import PolicyGate
 from vre.core.policy.registry import PolicyRegistry
+
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
 
 # Edge geometry shared by the helpers: the APPLIES_TO edge lives on the source at D2,
 # and requires the target grounded to D3.
@@ -81,24 +85,25 @@ def _cb_record_tool_call(context) -> PolicyCallbackResult:
 
 def _trace(source_name, target_name="file", relation=RelationType.APPLIES_TO):
     """A source primitive with one `relation` edge to a target, both in the trace."""
-    target = Primitive(name=target_name)
-    relatum = Relatum(relation_type=relation, target_id=target.id, target_depth=TGT_DEPTH)
-    source = Primitive(name=source_name, depths=[Depth(level=SRC_DEPTH, relata=[relatum])])
+    target = Primitive(name=target_name, provenance=_PROV)
+    relatum = Relatum(relation_type=relation, target_id=target.id, target_depth=TGT_DEPTH, provenance=_PROV)
+    source = Primitive(name=source_name, depths=[Depth(level=SRC_DEPTH, relata=[relatum], provenance=_PROV)], provenance=_PROV)
     query = EpistemicQuery(concept_ids=[source.id])
     return EpistemicResponse(query=query, result=EpistemicResult(primitives=[source, target]))
 
 
 def _trace_two_edges(source_name, target_a="file", target_b="dir"):
     """A source primitive with two APPLIES_TO edges (to target_a, target_b), all in the trace."""
-    a, b = Primitive(name=target_a), Primitive(name=target_b)
+    a, b = Primitive(name=target_a, provenance=_PROV), Primitive(name=target_b, provenance=_PROV)
     depth = Depth(
         level=SRC_DEPTH,
         relata=[
-            Relatum(relation_type=RelationType.APPLIES_TO, target_id=a.id, target_depth=TGT_DEPTH),
-            Relatum(relation_type=RelationType.APPLIES_TO, target_id=b.id, target_depth=TGT_DEPTH),
+            Relatum(relation_type=RelationType.APPLIES_TO, target_id=a.id, target_depth=TGT_DEPTH, provenance=_PROV),
+            Relatum(relation_type=RelationType.APPLIES_TO, target_id=b.id, target_depth=TGT_DEPTH, provenance=_PROV),
         ],
+        provenance=_PROV,
     )
-    source = Primitive(name=source_name, depths=[depth])
+    source = Primitive(name=source_name, depths=[depth], provenance=_PROV)
     query = EpistemicQuery(concept_ids=[source.id])
     return EpistemicResponse(query=query, result=EpistemicResult(primitives=[source, a, b]))
 

--- a/tests/vre/test_provenance.py
+++ b/tests/vre/test_provenance.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from vre.core.models import (
     Depth,
@@ -19,6 +20,7 @@ from vre.core.models import (
     RelationType,
 )
 from vre.core.backends.sqlite import SQLiteRepository
+from vre.core.errors import HydrationError, ProvenanceError
 from vre.core.grounding.models import _fmt_depth, _fmt_primitive, _fmt_relatum
 
 
@@ -37,11 +39,14 @@ def test_provenance_defaults():
 
 def test_provenance_enum_values():
     """
-    ProvenanceSource enum maps to the two canonical string values from CLAUDE.md §7.2.
+    ProvenanceSource enum maps to the canonical string values from CLAUDE.md §7.2:
+    two human-attested genealogies (authored, learned) plus one system genealogy
+    (synthetic) for engine-generated, non-knowledge placeholders.
     """
     assert ProvenanceSource.AUTHORED.value == "authored"
     assert ProvenanceSource.LEARNED.value == "learned"
-    assert [s.value for s in ProvenanceSource] == ["authored", "learned"]
+    assert ProvenanceSource.SYNTHETIC.value == "synthetic"
+    assert [s.value for s in ProvenanceSource] == ["authored", "learned", "synthetic"]
 
 
 def test_provenance_with_detail():
@@ -63,32 +68,33 @@ def test_provenance_timestamps_auto_set():
     assert before <= p.updated_at <= after
 
 
-def test_primitive_provenance_optional():
+def test_primitive_requires_provenance():
     """
-    Primitive without provenance defaults to None for backward compatibility.
+    Primitive constructed without provenance is rejected at the model level —
+    the contract is explicit and unavoidable, not optional (#98).
     """
-    p = Primitive(name="test")
-    assert p.provenance is None
+    with pytest.raises(ValidationError):
+        Primitive(name="test")
 
 
-def test_depth_provenance_optional():
+def test_depth_requires_provenance():
     """
-    Depth without provenance defaults to None for backward compatibility.
+    Depth constructed without provenance is rejected at the model level (#98).
     """
-    d = Depth(level=DepthLevel.EXISTENCE)
-    assert d.provenance is None
+    with pytest.raises(ValidationError):
+        Depth(level=DepthLevel.EXISTENCE)
 
 
-def test_relatum_provenance_optional():
+def test_relatum_requires_provenance():
     """
-    Relatum without provenance defaults to None for backward compatibility.
+    Relatum constructed without provenance is rejected at the model level (#98).
     """
-    r = Relatum(
-        relation_type=RelationType.APPLIES_TO,
-        target_id=uuid4(),
-        target_depth=DepthLevel.CAPABILITIES,
-    )
-    assert r.provenance is None
+    with pytest.raises(ValidationError):
+        Relatum(
+            relation_type=RelationType.APPLIES_TO,
+            target_id=uuid4(),
+            target_depth=DepthLevel.CAPABILITIES,
+        )
 
 
 def test_primitive_with_provenance():
@@ -125,33 +131,43 @@ def test_relatum_with_provenance():
 
 
 # ── Persistence boundary validation ──────────────────────────────────────────
+# The model now requires provenance at construction (above), so these guard the
+# save-boundary defense against an integrator nulling/spoofing provenance *after*
+# construction — Pydantic does not re-validate on assignment, so validate_provenance
+# is the fails-closed check the backends run before any write (#98).
 
 def test_validate_provenance_rejects_primitive_without_provenance():
     """
-    validate_provenance raises ValueError when the primitive itself has no provenance.
+    validate_provenance raises ProvenanceError when the primitive's provenance
+    is nulled after construction.
     """
-    p = Primitive(name="test")
-    with pytest.raises(ValueError, match=re.escape("Primitive 'test' is missing provenance")):
+    prov = Provenance(source=ProvenanceSource.AUTHORED)
+    p = Primitive(name="test", provenance=prov)
+    p.provenance = None
+    with pytest.raises(ProvenanceError, match=re.escape("Primitive 'test' is missing provenance")):
         p.validate_provenance()
 
 
 def test_validate_provenance_rejects_depth_without_provenance():
     """
-    validate_provenance raises ValueError when a depth is missing provenance.
+    validate_provenance raises ProvenanceError when a depth's provenance is
+    nulled after construction.
     """
     prov = Provenance(source=ProvenanceSource.AUTHORED)
     p = Primitive(
         name="file",
         provenance=prov,
-        depths=[Depth(level=DepthLevel.EXISTENCE)],
+        depths=[Depth(level=DepthLevel.EXISTENCE, provenance=prov)],
     )
-    with pytest.raises(ValueError, match="depth D0 .EXISTENCE. is missing provenance"):
+    p.depths[0].provenance = None
+    with pytest.raises(ProvenanceError, match="depth D0 .EXISTENCE. is missing provenance"):
         p.validate_provenance()
 
 
 def test_validate_provenance_rejects_relatum_without_provenance():
     """
-    validate_provenance raises ValueError when a relatum is missing provenance.
+    validate_provenance raises ProvenanceError when a relatum's provenance is
+    nulled after construction.
     """
     prov = Provenance(source=ProvenanceSource.AUTHORED)
     target_id = uuid4()
@@ -167,12 +183,14 @@ def test_validate_provenance_rejects_relatum_without_provenance():
                         relation_type=RelationType.APPLIES_TO,
                         target_id=target_id,
                         target_depth=DepthLevel.CAPABILITIES,
+                        provenance=prov,
                     ),
                 ],
             ),
         ],
     )
-    with pytest.raises(ValueError, match="relatum APPLIES_TO"):
+    p.depths[0].relata[0].provenance = None
+    with pytest.raises(ProvenanceError, match="relatum APPLIES_TO"):
         p.validate_provenance()
 
 
@@ -218,15 +236,6 @@ def test_depths_to_json_includes_provenance():
     assert len(result) == 1
     assert "provenance" in result[0]
     assert result[0]["provenance"]["source"] == "authored"
-
-
-def test_depths_to_json_omits_provenance_when_none():
-    """
-    _depths_to_json omits the provenance key entirely when provenance is None.
-    """
-    depths = [Depth(level=DepthLevel.EXISTENCE)]
-    result = json.loads(SQLiteRepository._depths_to_json(depths))
-    assert "provenance" not in result[0]
 
 
 def test_hydrate_primitive_with_provenance():
@@ -305,9 +314,10 @@ def test_hydrate_primitive_with_provenance():
     assert d2.relata[0].provenance.source == ProvenanceSource.LEARNED
 
 
-def test_hydrate_primitive_without_provenance():
+def test_hydrate_primitive_without_provenance_fails_closed():
     """
-    Hydrating node data with no provenance fields yields None — backward compatible.
+    Hydrating a legacy/unstamped node (no provenance) raises HydrationError —
+    provenance is required, so such graphs are read-only-fail, not silently None (#98).
     """
     node_data = {
         "id": str(uuid4()),
@@ -316,9 +326,8 @@ def test_hydrate_primitive_without_provenance():
         "provenance_json": None,
         "metrics_json": None,
     }
-    hydrated = SQLiteRepository._hydrate_primitive(node_data, [])
-    assert hydrated.provenance is None
-    assert hydrated.depths[0].provenance is None
+    with pytest.raises(HydrationError, match="missing provenance"):
+        SQLiteRepository._hydrate_primitive(node_data, [])
 
 
 # ── Display formatting ───────────────────────────────────────────────────────
@@ -341,21 +350,6 @@ def test_fmt_relatum_with_provenance():
     assert f"provenance: authored ({date_str})" in joined
 
 
-def test_fmt_relatum_without_provenance():
-    """
-    _fmt_relatum omits provenance line when provenance is None.
-    """
-    target_id = uuid4()
-    r = Relatum(
-        relation_type=RelationType.APPLIES_TO,
-        target_id=target_id,
-        target_depth=DepthLevel.CAPABILITIES,
-    )
-    lines = _fmt_relatum(r, {target_id: "file"})
-    joined = "\n".join(lines)
-    assert "provenance" not in joined
-
-
 def test_fmt_depth_with_provenance():
     """
     _fmt_depth appends an inline [source] tag when provenance is set.
@@ -364,15 +358,6 @@ def test_fmt_depth_with_provenance():
     d = Depth(level=DepthLevel.CAPABILITIES, provenance=prov)
     lines = _fmt_depth(d, {})
     assert lines[0] == "  D2 CAPABILITIES  [authored]"
-
-
-def test_fmt_depth_without_provenance():
-    """
-    _fmt_depth renders without a provenance tag when provenance is None.
-    """
-    d = Depth(level=DepthLevel.CAPABILITIES)
-    lines = _fmt_depth(d, {})
-    assert lines[0] == "  D2 CAPABILITIES"
 
 
 def test_fmt_primitive_with_provenance():
@@ -387,11 +372,3 @@ def test_fmt_primitive_with_provenance():
     assert f"provenance: authored ({date_str})" in joined
 
 
-def test_fmt_primitive_without_provenance():
-    """
-    _fmt_primitive omits provenance line when provenance is None.
-    """
-    p = Primitive(name="file")
-    lines = _fmt_primitive(p, {})
-    joined = "\n".join(lines)
-    assert "provenance" not in joined

--- a/tests/vre/test_tracing.py
+++ b/tests/vre/test_tracing.py
@@ -20,11 +20,15 @@ from vre.core.models import (
     EpistemicStep,
     Primitive,
     PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
     RelationType,
     ResolvedSubgraph,
 )
 import vre.tracing as tracing_module
 from vre.tracing import TraceWriter, build_trace_entry
+
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 # ---------------------------------------------------------------------------
@@ -111,11 +115,11 @@ class StubRepository(Repository):
 # ---------------------------------------------------------------------------
 
 def _make_fully_grounded(name: str) -> Primitive:
-    return Primitive(name=name, depths=[
-        Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
-        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
-        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
+    return Primitive(name=name, provenance=_PROV, depths=[
+        Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}, provenance=_PROV),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}, provenance=_PROV),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}, provenance=_PROV),
     ])
 
 
@@ -145,8 +149,8 @@ def _grounding_result(
             query=EpistemicQuery(concept_ids=[file_id, write_id]),
             result=EpistemicResult(
                 primitives=[
-                    Primitive(id=file_id, name="file"),
-                    Primitive(id=write_id, name="write"),
+                    Primitive(id=file_id, name="file", provenance=_PROV),
+                    Primitive(id=write_id, name="write", provenance=_PROV),
                 ],
                 gaps=gaps,
                 pathway=[step],
@@ -199,7 +203,7 @@ class TestBuildTraceEntry:
     def test_gaps_preserve_kind_discriminator(self):
         from vre.core.models import ExistenceGap
 
-        gap_prim = Primitive(name="unknown")
+        gap_prim = Primitive(name="unknown", provenance=_PROV)
         gap = ExistenceGap(primitive=gap_prim)
         result = _grounding_result(grounded=False, gaps=[gap])
         entry = build_trace_entry("check", ["unknown"], result)

--- a/tests/vre/test_types.py
+++ b/tests/vre/test_types.py
@@ -15,6 +15,8 @@ from vre.core.models import (
     EpistemicStep,
     ExistenceGap,
     DepthGap,
+    Provenance,
+    ProvenanceSource,
     RelationalGap,
     ReachabilityGap,
     Primitive,
@@ -25,10 +27,13 @@ from vre.core.grounding import GroundingResult
 from vre.core.policy import PolicyAction, PolicyResult
 
 
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
+
+
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
 def _make_primitive(name: str, depths: list | None = None) -> Primitive:
-    return Primitive(name=name, depths=depths or [])
+    return Primitive(name=name, depths=depths or [], provenance=_PROV)
 
 
 def _make_depth(
@@ -36,7 +41,7 @@ def _make_depth(
     properties: dict | None = None,
     relata: list | None = None,
 ) -> Depth:
-    return Depth(level=level, properties=properties or {}, relata=relata or [])
+    return Depth(level=level, properties=properties or {}, relata=relata or [], provenance=_PROV)
 
 
 def _make_trace(
@@ -92,6 +97,7 @@ def test_grounding_str_shows_relatum_with_metadata():
         target_id=permission.id,
         target_depth=DepthLevel.CONSTRAINTS,
         metadata={"enforcement": "kernel-level"},
+        provenance=_PROV,
     )
     file_p = _make_primitive("file", [
         _make_depth(DepthLevel.EXISTENCE),
@@ -208,12 +214,12 @@ class TestDepthVacuity:
     """is_empty is pure structure; grounds layers the D0 exemption on top."""
 
     def test_empty_depth_is_empty_and_does_not_ground(self) -> None:
-        d = Depth(level=DepthLevel.IDENTITY)
+        d = Depth(level=DepthLevel.IDENTITY, provenance=_PROV)
         assert d.is_empty is True
         assert d.grounds is False
 
     def test_properties_make_a_depth_ground(self) -> None:
-        d = Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"})
+        d = Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"}, provenance=_PROV)
         assert d.is_empty is False
         assert d.grounds is True
 
@@ -222,13 +228,14 @@ class TestDepthVacuity:
             relation_type=RelationType.APPLIES_TO,
             target_id=uuid4(),
             target_depth=DepthLevel.IDENTITY,
+            provenance=_PROV,
         )
-        d = Depth(level=DepthLevel.IDENTITY, relata=[rel])
+        d = Depth(level=DepthLevel.IDENTITY, relata=[rel], provenance=_PROV)
         assert d.is_empty is False
         assert d.grounds is True
 
     def test_bare_d0_is_empty_but_still_grounds(self) -> None:
-        d = Depth(level=DepthLevel.EXISTENCE)
+        d = Depth(level=DepthLevel.EXISTENCE, provenance=_PROV)
         assert d.is_empty is True
         assert d.grounds is True
 
@@ -296,29 +303,29 @@ class TestContiguousMaxDepthVacuityFloor:
 
     def test_empty_depth_does_not_extend_grounding(self) -> None:
         p = Primitive(name="X", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY),  # empty
-        ])
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, provenance=_PROV),  # empty
+        ], provenance=_PROV)
         assert p.contiguous_max_depth == DepthLevel.EXISTENCE
 
     def test_populated_depth_extends_grounding(self) -> None:
         p = Primitive(name="X", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"}),
-        ])
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, properties={"is": "a thing"}, provenance=_PROV),
+        ], provenance=_PROV)
         assert p.contiguous_max_depth == DepthLevel.IDENTITY
 
     def test_bare_d0_grounds_at_existence(self) -> None:
-        p = Primitive(name="X", depths=[Depth(level=DepthLevel.EXISTENCE)])
+        p = Primitive(name="X", depths=[Depth(level=DepthLevel.EXISTENCE, provenance=_PROV)], provenance=_PROV)
         assert p.contiguous_max_depth == DepthLevel.EXISTENCE
 
     def test_empty_middle_depth_breaks_chain(self) -> None:
         p = Primitive(name="X", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY, properties={"x": 1}),
-            Depth(level=DepthLevel.CAPABILITIES),  # empty — chain stops here
-            Depth(level=DepthLevel.CONSTRAINTS, properties={"x": 1}),
-        ])
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, properties={"x": 1}, provenance=_PROV),
+            Depth(level=DepthLevel.CAPABILITIES, provenance=_PROV),  # empty — chain stops here
+            Depth(level=DepthLevel.CONSTRAINTS, properties={"x": 1}, provenance=_PROV),
+        ], provenance=_PROV)
         assert p.contiguous_max_depth == DepthLevel.IDENTITY
 
 
@@ -327,9 +334,9 @@ class TestGapMissingLevelsVacuity:
 
     def test_depth_gap_lists_empty_level_as_hole(self) -> None:
         p = Primitive(name="X", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY),  # empty
-        ])
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, provenance=_PROV),  # empty
+        ], provenance=_PROV)
         gap = DepthGap(
             primitive=p,
             required_depth=DepthLevel.CAPABILITIES,
@@ -339,11 +346,11 @@ class TestGapMissingLevelsVacuity:
 
     def test_relational_gap_lists_empty_level_as_hole(self) -> None:
         target = Primitive(name="T", depths=[
-            Depth(level=DepthLevel.EXISTENCE),
-            Depth(level=DepthLevel.IDENTITY),  # empty
-        ])
+            Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+            Depth(level=DepthLevel.IDENTITY, provenance=_PROV),  # empty
+        ], provenance=_PROV)
         gap = RelationalGap(
-            source=Primitive(name="S", depths=[Depth(level=DepthLevel.EXISTENCE)]),
+            source=Primitive(name="S", depths=[Depth(level=DepthLevel.EXISTENCE, provenance=_PROV)], provenance=_PROV),
             target=target,
             required_depth=DepthLevel.CAPABILITIES,
             current_depth=target.contiguous_max_depth,  # EXISTENCE

--- a/tests/vre/test_vre.py
+++ b/tests/vre/test_vre.py
@@ -15,6 +15,8 @@ from vre.core.models import (
     EpistemicStep,
     Primitive,
     PrimitiveMetrics,
+    Provenance,
+    ProvenanceSource,
     Relatum,
     RelationType,
     ResolvedSubgraph,
@@ -27,6 +29,9 @@ from vre.core.policy.callback import ToolCallContext
 from vre.core.policy.registry import OrphanedPlacement, PolicyRegistry
 from vre.core.grounding import GroundingResult
 from vre.learning import LearningEngine
+
+
+_PROV = Provenance(source=ProvenanceSource.AUTHORED)
 
 
 def _cb_always_fail(context) -> PolicyCallbackResult:
@@ -115,11 +120,11 @@ class StubRepository(Repository):
 
 
 def _make_fully_grounded(name: str) -> Primitive:
-    return Primitive(name=name, depths=[
-        Depth(level=DepthLevel.EXISTENCE),
-        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}),
-        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}),
-        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}),
+    return Primitive(name=name, provenance=_PROV, depths=[
+        Depth(level=DepthLevel.EXISTENCE, provenance=_PROV),
+        Depth(level=DepthLevel.IDENTITY, properties={"_": "identity"}, provenance=_PROV),
+        Depth(level=DepthLevel.CAPABILITIES, properties={"_": "capabilities"}, provenance=_PROV),
+        Depth(level=DepthLevel.CONSTRAINTS, properties={"_": "constraints"}, provenance=_PROV),
     ])
 
 
@@ -140,6 +145,7 @@ def _make_primitive_with_edge(
         relation_type=RelationType.APPLIES_TO,
         target_id=target.id,
         target_depth=target_depth,
+        provenance=_PROV,
     )
     levels = [DepthLevel.EXISTENCE, DepthLevel.IDENTITY, DepthLevel.CAPABILITIES, DepthLevel.CONSTRAINTS]
     depths = [
@@ -147,10 +153,11 @@ def _make_primitive_with_edge(
             level=lvl,
             properties={} if lvl == DepthLevel.EXISTENCE else {"_": lvl.name.lower()},
             relata=[relatum] if lvl == source_depth else [],
+            provenance=_PROV,
         )
         for lvl in levels
     ]
-    return Primitive(name=name, depths=depths)
+    return Primitive(name=name, provenance=_PROV, depths=depths)
 
 
 def _registry_with(
@@ -559,7 +566,7 @@ class TestCheckPolicyFailClosed:
         from vre.core.models import ExistenceGap
         ungrounded = GroundingResult(
             grounded=False, resolved=["nope"],
-            gaps=[ExistenceGap(primitive=Primitive(name="nope", depths=[]))],
+            gaps=[ExistenceGap(primitive=Primitive(name="nope", depths=[], provenance=_PROV))],
         )
         result = _make_vre_with_stub([]).check_policy(ungrounded)
         assert result.action == PolicyAction.BLOCK


### PR DESCRIPTION
Resolves #98.

## Problem
CLAUDE.md §7.2 framed provenance as *"optional for backward compatibility,"* yet both backends enforced it at save (`validate_provenance()`), via a bare `ValueError` outside the `VREError` hierarchy. "Optional" was read-only compatibility, and the learning-path test stub diverged from the real save contract (#83). After review, the decision was to make the contract explicit rather than soften the docs.

## Changes
- **`provenance` required at the model level** — non-optional on `Primitive`, `Depth`, `Relatum` (no default). Constructing any without it raises `ValidationError`. The contract is now unavoidable at construction, not enforced after the fact.
- **Fail-closed hydration** *(BREAKING)* — a stored primitive/depth/relatum lacking provenance now raises `HydrationError` instead of degrading to `None`. Pre-1.0, there are no legacy graphs to preserve.
- **Typed `ProvenanceError`** (a `VREError`, exported from `vre` and `vre.core`) replaces the bare `ValueError` at the save boundary. Retained as the deliberate fails-closed defense against post-construction tampering (Pydantic does not re-validate on assignment).
- **`ProvenanceSource.SYNTHETIC`** — a third, machine-attested genealogy for the grounding engine's transient placeholder representing a concept *absent* from the graph. Honest sourcing for knowledge-of-an-absence rather than a forged `AUTHORED` stamp or an impossible `None`. Public and auditable; the `authorable()` authoring restriction is deferred to the seeding/validator work.
- Removed now-dead provenance-`None` branches in display formatters and depth serializers.
- Learning-path `StubRepository` now calls `validate_provenance()`, closing the stub-vs-backend conformance gap (#83).
- Docs: CLAUDE.md §7.2 rewritten (required-at-model-level, SYNTHETIC, "audit-relevant partition, not a trust gradient"); CHANGELOG marks the breaking changes.

## Doctrine notes
- Provenance is genealogy, **not an ordered trust score** — but the human-attested vs machine-attested boundary is real and intentionally audit-relevant ("is anything here not human-attested?" is answerable). That's a feature, not a backdoor trust gradient.
- Single authorized producer per source: AUTHORED ← human authoring, LEARNED ← `learn_gap`, SYNTHETIC ← engine only (never persisted by core).

## Tests
370 passed, ruff clean. Test-fixture churn across 8 files (≈76 construction sites) to supply the now-required field; new tests cover model-level rejection, fail-closed hydration, the typed error, and the transient's SYNTHETIC provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)