### PR TITLE
fix: case-insensitive name identity, DB-enforced on both backends (#78, #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,24 @@ summarize major changes, refactors, and breaking changes — not every commit.
   that counts toward grounding). These express the vacuity floor in one place,
   read by `contiguous_max_depth`, the gap `missing_levels`, and the learning
   gate. (#80)
+- `Primitive.fold_name` (staticmethod) and `Primitive.name_lower` (derived,
+  read-only property): the single definition of case-insensitive name equality,
+  NFC normalization then `str.casefold()`, shared by every backend and call
+  site. The NFC pass collapses canonically-equivalent spellings (e.g.
+  precomposed `é` U+00E9 vs `e`+combining-acute) that `casefold()` alone would
+  keep apart. `name_lower` is not a model field and is not serialized — backends
+  persist it into their own `name_lower` column/property so it can never drift
+  from `name`. (#78, #99)
+- DB-level case-insensitive name uniqueness on Neo4j: a
+  `primitive_name_lower_unique` constraint on the materialized `name_lower`
+  property, mirroring SQLite's unique index. A new-id write whose name only
+  differs in case now raises `PersistenceError` on **both** backends. (#78)
+- Backend-conformance test suite (`tests/vre/test_repository_conformance.py`)
+  parameterized over every `Repository` via a new `repository` fixture, seeded
+  with the case-insensitive name-identity invariants. Neo4j runs against a live
+  instance from `VRE_TEST_NEO4J_URI` and skips cleanly when unavailable (the
+  `requires_neo4j` marker). Lays the foundation for migrating the SQLite-only
+  suite into shared cross-backend coverage. (#83)
 
 ### Changed
 
@@ -110,6 +128,15 @@ summarize major changes, refactors, and breaking changes — not every commit.
   knowledge, so a bare D0 still grounds. Structural floor only; provenance is not a
   factor. May change grounding results for graphs that contained empty non-D0
   depths. (#80)
+- **BREAKING (storage):** Both backends now persist a folded `name_lower` key
+  and match/resolve names against it — SQLite gains a `name_lower` column with a
+  plain unique index (replacing the `name COLLATE NOCASE` index); Neo4j gains a
+  `name_lower` property with a uniqueness constraint. Case-insensitivity is now
+  defined once by `Primitive.fold_name` (NFC + `casefold()`, Unicode-aware) instead of
+  per-engine — SQLite `NOCASE` (ASCII-only), Neo4j `toLower`, and ad-hoc Python
+  `.lower()` — so "the same name" resolves identically on every backend. Visible
+  consequence: `"Café"` and `"CAFÉ"` are now one concept everywhere (previously
+  two on SQLite, one on Neo4j). Pre-1.0: re-seed the graph. (#78, #99)
 
 ### Removed
 
@@ -130,10 +157,19 @@ summarize major changes, refactors, and breaking changes — not every commit.
   The learning-loop pattern it demonstrated is now documented inline in the
   README. (#114)
 
+### Fixed
+
+- Neo4j `find_by_name` no longer resolves a duplicate-name graph silently and
+  nondeterministically. It materializes matches and raises `GraphError` when more
+  than one primitive shares a folded name, instead of `.single()` returning an
+  arbitrary first row with only a warning (the installed driver's default
+  `strict=False`). `find_by_id` is unchanged — its `id` is unique by constraint.
+  Corrects the "fails loud" rationale #78's deferral rested on. (#96)
+
 ### Performance
 
-- `resolve_subgraph` hits the `NOCASE` name index, and the transitive cycle check
-  is batched into a single query per save (SQLite).
+- `resolve_subgraph` hits the `name_lower` unique index, and the transitive cycle
+  check is batched into a single query per save (SQLite).
 
 ### Migration
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,6 @@ line-length = 120
 
 [tool.pytest.ini_options]
 addopts = "--cov=src/vre --cov-fail-under=70"
+markers = [
+    "requires_neo4j: integration test that needs a live Neo4j (skipped if unavailable)",
+]

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -15,7 +15,7 @@ from typing import Any, LiteralString, cast
 from uuid import UUID
 
 from neo4j import GraphDatabase
-from neo4j.exceptions import Neo4jError
+from neo4j.exceptions import ConstraintError, Neo4jError
 
 from vre.core.backends.repository import Repository
 from vre.core.errors import (
@@ -68,7 +68,7 @@ class Neo4jRepository(Repository):
         self._driver.close()
 
     def _ensure_constraints(self) -> None:
-        logger.debug("Ensuring uniqueness constraint on Primitive.id")
+        logger.debug("Ensuring uniqueness constraints on Primitive")
         try:
             with self._driver.session(database=self._database) as session:
                 session.run(
@@ -76,6 +76,17 @@ class Neo4jRepository(Repository):
                         LiteralString,
                         "CREATE CONSTRAINT primitive_id_unique IF NOT EXISTS "
                         "FOR (p:Primitive) REQUIRE p.id IS UNIQUE",
+                    )
+                )
+                # Case-insensitive name uniqueness. Neo4j has no collation and
+                # no functional/expression constraints, so the only way to a
+                # DB-level guarantee is to constrain the materialized fold key
+                # (Primitive.name_lower), written by save_primitive (#78).
+                session.run(
+                    cast(
+                        LiteralString,
+                        "CREATE CONSTRAINT primitive_name_lower_unique IF NOT EXISTS "
+                        "FOR (p:Primitive) REQUIRE p.name_lower IS UNIQUE",
                     )
                 )
         except Neo4jError as exc:
@@ -303,11 +314,13 @@ class Neo4jRepository(Repository):
                 cast(
                     LiteralString,
                     "MERGE (p:Primitive {id: $id}) "
-                    "SET p.name = $name, p.depths_json = $depths_json, "
+                    "SET p.name = $name, p.name_lower = $name_lower, "
+                    "p.depths_json = $depths_json, "
                     "p.provenance_json = $provenance_json, p.metrics_json = $metrics_json",
                 ),
                 id=str(primitive.id),
                 name=primitive.name,
+                name_lower=primitive.name_lower,
                 depths_json=depths_json,
                 provenance_json=node_provenance,
                 metrics_json=node_metrics,
@@ -352,6 +365,14 @@ class Neo4jRepository(Repository):
                 session.execute_write(_tx)
         except CyclicRelationshipError:
             raise
+        except ConstraintError as exc:
+            # A different id already holds this case-insensitive name — mirrors
+            # SQLite's IntegrityError on the NOCASE unique index (#78).
+            logger.error("Neo4j name-uniqueness violation saving %r: %s", primitive.name, exc)
+            raise PersistenceError(
+                f"Failed to save primitive '{primitive.name}': a primitive with "
+                f"that name already exists (case-insensitive)"
+            ) from exc
         except Neo4jError as exc:
             logger.error("Neo4j error saving primitive %r: %s", primitive.name, exc)
             raise PersistenceError(f"Failed to save primitive '{primitive.name}': {exc}") from exc
@@ -484,7 +505,7 @@ class Neo4jRepository(Repository):
             LiteralString,
             """
             MATCH (p:Primitive)
-            WHERE toLower(p.name) = toLower($name)
+            WHERE p.name_lower = $name_lower
             OPTIONAL MATCH (p)-[r]->(t:Primitive)
             RETURN
               p.id AS id,
@@ -505,7 +526,17 @@ class Neo4jRepository(Repository):
 
         try:
             with self._driver.session(database=self._database) as session:
-                record = session.run(cypher, name=name).single()
+                # Materialize rather than .single(): a no-match returns 0 rows
+                # (-> None), but a duplicate must fail LOUD rather than return an
+                # arbitrary first row (#96). Note .single(strict=True) is wrong
+                # here — it would also raise on the 0-row not-found case.
+                records = list(session.run(cypher, name_lower=Primitive.fold_name(name)))
+                if len(records) > 1:
+                    raise GraphError(
+                        f"Multiple primitives ({len(records)}) share the "
+                        f"case-insensitive name '{name}' — graph integrity violation"
+                    )
+                record = records[0] if records else None
                 if record is None or record["id"] is None:
                     logger.debug("Primitive not found by name=%r", name)
                     primitive = None
@@ -556,14 +587,14 @@ class Neo4jRepository(Repository):
     ) -> ResolvedSubgraph:
         """Single-query Cypher traversal that resolves a subgraph for the given names."""
         logger.debug("Resolving subgraph for names=%s", names)
-        lowered = [n.lower() for n in names]
+        lowered = [Primitive.fold_name(n) for n in names]
 
         cypher = cast(
             LiteralString,
             """
-            // Phase 1: Resolve roots by name
+            // Phase 1: Resolve roots by name (matched on the stored fold key)
             MATCH (root:Primitive)
-            WHERE toLower(root.name) IN $names
+            WHERE root.name_lower IN $names
             WITH collect(root) AS roots
 
             // Phase 2: Recursive traversal from all roots (no depth ceiling)

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -14,12 +14,13 @@ Schema
     CREATE TABLE IF NOT EXISTS primitives (
         id              TEXT PRIMARY KEY,
         name            TEXT NOT NULL,
+        name_lower      TEXT NOT NULL,
         depths_json     TEXT NOT NULL,
         provenance_json TEXT,
         metrics_json    TEXT
     );
     CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
-        ON primitives(name COLLATE NOCASE);
+        ON primitives(name_lower);
 
     CREATE TABLE IF NOT EXISTS relata (
         id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -73,12 +74,13 @@ _SCHEMA = """
 CREATE TABLE IF NOT EXISTS primitives (
     id              TEXT PRIMARY KEY,
     name            TEXT NOT NULL,
+    name_lower      TEXT NOT NULL,
     depths_json     TEXT NOT NULL,
     provenance_json TEXT,
     metrics_json    TEXT
 );
 CREATE UNIQUE INDEX IF NOT EXISTS idx_primitives_name_lower
-    ON primitives(name COLLATE NOCASE);
+    ON primitives(name_lower);
 
 CREATE TABLE IF NOT EXISTS relata (
     id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -340,10 +342,11 @@ class SQLiteRepository(Repository):
             # UPSERT primitive row
             cursor.execute(
                 """
-                INSERT INTO primitives (id, name, depths_json, provenance_json, metrics_json)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO primitives (id, name, name_lower, depths_json, provenance_json, metrics_json)
+                VALUES (?, ?, ?, ?, ?, ?)
                 ON CONFLICT(id) DO UPDATE SET
                     name = excluded.name,
+                    name_lower = excluded.name_lower,
                     depths_json = excluded.depths_json,
                     provenance_json = excluded.provenance_json,
                     metrics_json = excluded.metrics_json
@@ -351,6 +354,7 @@ class SQLiteRepository(Repository):
                 (
                     str(primitive.id),
                     primitive.name,
+                    primitive.name_lower,
                     depths_json,
                     node_provenance,
                     node_metrics,
@@ -417,8 +421,8 @@ class SQLiteRepository(Repository):
         """Look up a primitive by name (case-insensitive). Returns None if not found."""
         row = self._conn.execute(
             "SELECT id, name, depths_json, provenance_json, metrics_json "
-            "FROM primitives WHERE name = ? COLLATE NOCASE",
-            (name,),
+            "FROM primitives WHERE name_lower = ?",
+            (Primitive.fold_name(name),),
         ).fetchone()
 
         if row is None:
@@ -557,14 +561,13 @@ class SQLiteRepository(Repository):
         transitive_placeholders = ",".join("?" for _ in _TRANSITIVE_RELS)
 
         # Phase 1: Find all transitively reachable node IDs from roots.
-        # The anchor uses `name COLLATE NOCASE` (mirroring find_by_name) so the
-        # case-insensitive idx_primitives_name_lower index can satisfy it; a
-        # LOWER(name) wrapper would force a full table scan. Raw names are passed
-        # as params -- the NOCASE collation handles case-folding in the engine.
+        # The anchor matches the stored fold key (Primitive.name_lower) so the
+        # unique idx_primitives_name_lower index can satisfy it, and so that
+        # "case-insensitive" means exactly Primitive.fold_name everywhere.
         reachable_ids_rows = self._conn.execute(
             f"""
             WITH RECURSIVE reachable(id) AS (
-                SELECT id FROM primitives WHERE name COLLATE NOCASE IN ({name_placeholders})
+                SELECT id FROM primitives WHERE name_lower IN ({name_placeholders})
                 UNION
                 SELECT r.target_id
                 FROM relata r
@@ -573,7 +576,7 @@ class SQLiteRepository(Repository):
             )
             SELECT id FROM reachable
             """,
-            list(names) + _TRANSITIVE_RELS,
+            [Primitive.fold_name(n) for n in names] + _TRANSITIVE_RELS,
         ).fetchall()
 
         reachable_ids = [row["id"] for row in reachable_ids_rows]
@@ -611,7 +614,7 @@ class SQLiteRepository(Repository):
             edges_by_source.setdefault(sid, []).append(ed)
 
         # Identify root names (case-insensitive) for root filtering
-        lowered_set = {n.lower() for n in names}
+        lowered_set = {Primitive.fold_name(n) for n in names}
 
         # Hydrate all nodes
         nodes: list[Primitive] = []
@@ -620,7 +623,7 @@ class SQLiteRepository(Repository):
             nd = dict(nr)
             prim = self._hydrate_primitive(nd, edges_by_source.get(nd["id"], []))
             nodes.append(prim)
-            if prim.name.lower() in lowered_set:
+            if prim.name_lower in lowered_set:
                 roots.append(prim)
 
         # Build EpistemicStep edges

--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -79,11 +79,11 @@ class GroundingEngine:
         """
         Identify root primitives for the query based on the input names.
         """
-        by_name: dict[str, Primitive] = {r.name.lower(): r for r in resolved_roots}
+        by_name: dict[str, Primitive] = {Primitive.fold_name(r.name): r for r in resolved_roots}
         all_roots: list[Primitive] = []
         transients: list[Primitive] = []
         for name in names:
-            matched = by_name.get(name.lower())
+            matched = by_name.get(Primitive.fold_name(name))
             if matched:
                 all_roots.append(matched)
             else:
@@ -373,9 +373,9 @@ class GroundingEngine:
             # nodes echo the raw input — either way the per-input mapping below
             # is correct. Unknown concepts remain ExistenceGaps in the result.
             canonical_by_lower = {
-                p.name.lower(): p.name for p in response.result.primitives
+                p.name_lower: p.name for p in response.result.primitives
             }
-            resolved = [canonical_by_lower.get(c.lower(), c) for c in concepts]
+            resolved = [canonical_by_lower.get(Primitive.fold_name(c), c) for c in concepts]
 
             grounded = len(response.result.gaps) == 0
             logger.info(

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -5,6 +5,7 @@
 Core epistemic models for the Volute Reasoning Engine.
 """
 
+import unicodedata
 from collections.abc import Iterable
 from datetime import datetime, timezone
 from enum import Enum, IntEnum
@@ -229,6 +230,39 @@ class Primitive(BaseModel):
     depths: list[Depth] = Field(default_factory=list)
     provenance: Provenance
     metrics: PrimitiveMetrics | None = None
+
+    @staticmethod
+    def fold_name(name: str) -> str:
+        """
+        The single definition of case-insensitive name equality, shared by
+        every backend and call site. `name` is stored verbatim for display;
+        the fold is the comparison key used for matching and uniqueness.
+
+        `casefold()` (not `lower()`) is Python's caseless-matching primitive
+        and is applied identically on both backends — so "case-insensitive"
+        means the same thing everywhere (closes the per-engine divergence: a
+        backend that folds at comparison time would otherwise use its own,
+        differing rule — and Neo4j cannot fold at comparison time at all).
+
+        NFC normalization precedes the fold so that canonically-equivalent
+        spellings collapse to one key: e.g. precomposed "é" (U+00E9) and
+        "e" + combining acute (U+0065 U+0301) render identically but are
+        distinct code points that `casefold()` alone would keep apart. We
+        normalize the key only — `name` is still stored verbatim for display.
+        (Full Unicode canonical-caseless matching also folds the rare chars
+        that `casefold` itself denormalizes; NFC+casefold covers realistic
+        name input — copy-paste, cross-OS — without that extra pass.)
+        """
+        return unicodedata.normalize("NFC", name).casefold()
+
+    @property
+    def name_lower(self) -> str:
+        """
+        Derived comparison key (`fold_name(name)`). Not a stored field and not
+        serialized — backends persist this value into their own `name_lower`
+        column/property so it can never drift from `name`.
+        """
+        return self.fold_name(self.name)
 
     @property
     def grounding_levels(self) -> set[DepthLevel]:

--- a/src/vre/learning/models.py
+++ b/src/vre/learning/models.py
@@ -16,7 +16,13 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, Field
 
 from vre.core.errors import CandidateValidationError
-from vre.core.models import DepthLevel, KnowledgeGap, RelationType, format_depth_label
+from vre.core.models import (
+    DepthLevel,
+    KnowledgeGap,
+    Primitive,
+    RelationType,
+    format_depth_label,
+)
 
 
 class ProposedDepth(BaseModel):
@@ -163,10 +169,10 @@ class ReachabilityCandidate(BaseModel):
                 f"ReachabilityCandidate for '{gap.primitive.name}' is missing "
                 f"source_depth_level or target_depth_level"
             )
-        gap_name = gap.primitive.name.lower()
+        gap_name = gap.primitive.name_lower
         if (
-            self.source_name.lower() != gap_name
-            and self.target_name.lower() != gap_name
+            Primitive.fold_name(self.source_name) != gap_name
+            and Primitive.fold_name(self.target_name) != gap_name
         ):
             raise CandidateValidationError(
                 f"ReachabilityCandidate must reference the gapped primitive "

--- a/src/vre/metrics.py
+++ b/src/vre/metrics.py
@@ -14,6 +14,7 @@ from uuid import UUID
 from vre.core.backends import Repository
 from vre.core.grounding.models import GroundingResult
 from vre.core.models import (
+    Primitive,
     PrimitiveMetrics,
     gap_primitive_ids,
 )
@@ -37,10 +38,10 @@ class MetricsManager:
         Batch-reads current metrics for all resolved root concepts, computes
         increments in-process, and batch-writes the results.
         """
-        resolved_lower = {r.lower() for r in result.resolved}
+        resolved_lower = {Primitive.fold_name(r) for r in result.resolved}
         target_prims = [
             prim for prim in result.get_primitives()
-            if prim.name.lower() in resolved_lower
+            if prim.name_lower in resolved_lower
         ]
 
         current_metrics: dict[UUID, PrimitiveMetrics | None] | None = None

--- a/tests/vre/conftest.py
+++ b/tests/vre/conftest.py
@@ -2,8 +2,11 @@
 Shared fixtures for the VRE test suite.
 """
 
+import os
+
 import pytest
 
+from vre.core.backends.sqlite import SQLiteRepository
 from vre.core.policy.registry import _DEFAULT_REGISTRY
 
 
@@ -19,3 +22,72 @@ def _clean_default_policy_registry():
     _DEFAULT_REGISTRY.clear()
     yield
     _DEFAULT_REGISTRY.clear()
+
+
+# ---------------------------------------------------------------------------
+# Backend-conformance fixtures (#83)
+#
+# The `repository` fixture is parameterized over every Repository backend so a
+# single test asserts parity across them. SQLite runs in-memory; Neo4j connects
+# to a live instance via VRE_TEST_NEO4J_URI and is skipped cleanly when absent,
+# so CI exercises it where Neo4j exists and skips visibly where it does not.
+# ---------------------------------------------------------------------------
+
+
+def _make_neo4j_repo():
+    """Construct a live Neo4jRepository from env, or pytest.skip the test."""
+    uri = os.environ.get("VRE_TEST_NEO4J_URI")
+    password = os.environ.get("VRE_TEST_NEO4J_PASSWORD")
+    if not uri or not password:
+        pytest.skip(
+            "VRE_TEST_NEO4J_URI / VRE_TEST_NEO4J_PASSWORD not set "
+            "— Neo4j conformance skipped"
+        )
+    try:
+        from vre.core.backends.neo4j import Neo4jRepository
+    except ImportError:
+        pytest.skip("neo4j driver not installed")
+    # Username/database default to Neo4j's conventional values — not secrets;
+    # the password is required from the env and never defaulted in code.
+    user = os.environ.get("VRE_TEST_NEO4J_USER", "neo4j")
+    database = os.environ.get("VRE_TEST_NEO4J_DATABASE", "neo4j")
+    try:
+        return Neo4jRepository(uri, user, password, database=database)
+    except Exception as exc:  # noqa: BLE001 — any connect/auth failure = skip
+        pytest.skip(f"Neo4j unavailable at {uri}: {exc}")
+
+
+@pytest.fixture(
+    params=[
+        pytest.param("sqlite", id="sqlite"),
+        pytest.param("neo4j", id="neo4j", marks=pytest.mark.requires_neo4j),
+    ]
+)
+def repository(request):
+    """A fresh, empty Repository per test, yielded once for each backend."""
+    if request.param == "sqlite":
+        repo = SQLiteRepository(":memory:")
+        try:
+            yield repo
+        finally:
+            repo.close()
+    else:
+        repo = _make_neo4j_repo()
+        repo.clear()
+        try:
+            yield repo
+        finally:
+            repo.clear()
+            repo.close()
+
+
+@pytest.fixture
+def neo4j_repository():
+    """A live Neo4jRepository for backend-specific tests (skips if unavailable)."""
+    repo = _make_neo4j_repo()
+    repo.clear()
+    try:
+        yield repo
+    finally:
+        repo.clear()
+        repo.close()

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -87,14 +87,14 @@ class StubRepository(Repository):
         self._by_name: dict[str, Primitive] = {}
         for p in primitives or []:
             self._by_id[p.id] = p
-            self._by_name[p.name.lower()] = p
+            self._by_name[Primitive.fold_name(p.name)] = p
         self.saved: list[Primitive] = []
 
     def find_by_id(self, id: UUID) -> Primitive | None:
         return self._by_id.get(id)
 
     def find_by_name(self, name: str) -> Primitive | None:
-        return self._by_name.get(name.lower())
+        return self._by_name.get(Primitive.fold_name(name))
 
     def save_primitive(self, primitive: Primitive) -> None:
         # Mirror the real backends' save contract: provenance is required on
@@ -132,7 +132,7 @@ class StubRepository(Repository):
                                 visited.add(r.target_id)
                                 queue.append(r.target_id)
         self._by_id[primitive.id] = primitive
-        self._by_name[primitive.name.lower()] = primitive
+        self._by_name[Primitive.fold_name(primitive.name)] = primitive
         self.saved.append(primitive)
 
     def list_names(self) -> list[str]:

--- a/tests/vre/test_repository_conformance.py
+++ b/tests/vre/test_repository_conformance.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Andrew Greene
+# Licensed under the Apache License, Version 2.0
+
+"""
+Backend-conformance suite (#83): one set of assertions run against every
+Repository implementation via the parameterized ``repository`` fixture, so
+parity is *verified* rather than asserted in the README.
+
+Seeded here with the case-insensitive name-identity invariants that #78/#96
+(uniqueness + loud detection) and #99 item 3 (Unicode folding) are about. The
+non-ASCII assertions are only meaningful because both backends now fold names
+through the single ``Primitive.fold_name`` (NFC + casefold) definition.
+
+Neo4j params skip cleanly when ``VRE_TEST_NEO4J_URI`` is unset (see conftest).
+"""
+
+import unicodedata
+from uuid import uuid4
+
+import pytest
+
+from vre.core.errors import GraphError, PersistenceError
+from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource
+
+# e + U+0301 (combining acute). Built via chr() so the code point is explicit in
+# pure-ASCII source and can't be silently re-normalized by an editor or git.
+_COMBINING_ACUTE = chr(0x0301)
+
+
+def _prov() -> Provenance:
+    return Provenance(source=ProvenanceSource.AUTHORED)
+
+
+def _make_primitive(name: str, max_depth: DepthLevel = DepthLevel.EXISTENCE) -> Primitive:
+    depths = [
+        Depth(level=DepthLevel(i), properties={}, provenance=_prov())
+        for i in range(max_depth + 1)
+    ]
+    return Primitive(name=name, depths=depths, provenance=_prov())
+
+
+class TestNameIdentityConformance:
+    """The 'one primitive per case-insensitive name' invariant, both backends."""
+
+    def test_save_and_find_by_id_round_trip(self, repository) -> None:
+        # Representative non-uniqueness assertion: proves the harness exercises
+        # a basic save/load on every backend, not just the uniqueness paths.
+        p = _make_primitive("file", DepthLevel.IDENTITY)
+        repository.save_primitive(p)
+        loaded = repository.find_by_id(p.id)
+        assert loaded is not None
+        assert loaded.id == p.id
+        assert loaded.name == "file"
+        assert {int(d.level) for d in loaded.depths} == {int(d.level) for d in p.depths}
+
+    def test_find_by_name_is_case_insensitive(self, repository) -> None:
+        repository.save_primitive(_make_primitive("File"))
+        assert repository.find_by_name("file") is not None
+        assert repository.find_by_name("FILE") is not None
+        assert repository.find_by_name("FiLe") is not None
+
+    def test_find_by_name_missing_returns_none(self, repository) -> None:
+        # The not-found contract preserved alongside the loud-on-duplicate guard.
+        assert repository.find_by_name("nonexistent") is None
+
+    def test_upsert_preserves_existing_id(self, repository) -> None:
+        existing = _make_primitive("file")
+        repository.save_primitive(existing)
+        incoming = _make_primitive("file")  # same name, new id
+        result = repository.upsert_primitive(incoming)
+        assert result.id == existing.id
+        assert result.id != incoming.id
+
+    def test_case_collision_new_id_is_rejected(self, repository) -> None:
+        # #78: a *new id* whose name only differs in case must be rejected loud on
+        # BOTH backends — SQLite via the NOCASE->name_lower unique index, Neo4j via
+        # the primitive_name_lower_unique constraint. save_primitive (not upsert)
+        # is the raw write path that has no id-reuse safety net.
+        repository.save_primitive(_make_primitive("File"))
+        with pytest.raises(PersistenceError):
+            repository.save_primitive(_make_primitive("file"))  # different id
+
+    def test_unicode_case_collision_is_rejected(self, repository) -> None:
+        # #99 item 3: with folding unified on casefold(), an accented name and its
+        # upper-case variant are the same concept on every backend. Previously
+        # SQLite NOCASE (ASCII-only) kept both while Neo4j toLower merged them.
+        # .upper() derives the capital form so the pair can't drift out of sync.
+        lower = "Cafe" + _COMBINING_ACUTE  # café
+        repository.save_primitive(_make_primitive(lower))
+        with pytest.raises(PersistenceError):
+            repository.save_primitive(_make_primitive(lower.upper()))  # CAFÉ, different id
+
+    def test_unicode_normalization_collision_is_rejected(self, repository) -> None:
+        # fold_name NFC-normalizes before casefolding, so two spellings that render
+        # identically but differ in code points are one concept. These differ ONLY
+        # in normalization form (same case): precomposed "é" (U+00E9) vs "e" +
+        # combining acute (U+0065 U+0301). Without the NFC pass, casefold() alone
+        # would keep these as two separate primitives.
+        base = "Cafe" + _COMBINING_ACUTE
+        decomposed = unicodedata.normalize("NFD", base)
+        precomposed = unicodedata.normalize("NFC", base)
+        assert precomposed != decomposed  # genuinely distinct code-point sequences
+        repository.save_primitive(_make_primitive(precomposed))
+        assert repository.find_by_name(decomposed) is not None
+        with pytest.raises(PersistenceError):
+            repository.save_primitive(_make_primitive(decomposed))  # different id
+
+
+@pytest.mark.requires_neo4j
+def test_find_by_name_fails_loud_on_duplicate(neo4j_repository) -> None:
+    """#96: if a folded-name duplicate ever exists (e.g. data predating the
+    constraint), find_by_name must raise rather than silently return the first
+    of multiple nodes. We manufacture that corrupt state by dropping the
+    constraint and inserting two colliding nodes via raw Cypher.
+
+    Neo4j-only by design: SQLite's find_by_name has no parallel loud-detection
+    test because its corrupt state is unreachable in practice — `.fetchone()`
+    can only return a duplicate if the unique idx_primitives_name_lower index
+    is first dropped, which the SQLite path never does. Neo4j needs the runtime
+    guard because its constraint backs a *materialized* key, so dupes can slip
+    in (raw Cypher, data predating the constraint) and must fail loud on read.
+    """
+    repo = neo4j_repository
+    prov = '{"source": "AUTHORED", "detail": null}'
+    with repo._driver.session(database=repo._database) as session:
+        session.run("DROP CONSTRAINT primitive_name_lower_unique IF EXISTS")
+        for _ in range(2):
+            session.run(
+                "CREATE (:Primitive {id: $id, name: 'File', name_lower: 'file', "
+                "depths_json: '[]', provenance_json: $prov, metrics_json: 'null'})",
+                id=str(uuid4()),
+                prov=prov,
+            )
+
+    with pytest.raises(GraphError, match="integrity"):
+        repo.find_by_name("file")
+
+    # Restore the invariant for subsequent tests: drop the dupes, re-add constraint.
+    repo.clear()
+    repo._ensure_constraints()

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -988,12 +988,13 @@ class TestResolveSubgraph:
     def test_anchor_uses_name_index_not_table_scan(self) -> None:
         """The resolve_subgraph CTE anchor must hit idx_primitives_name_lower
         rather than full-scanning primitives (issue #82). Mirrors the production
-        anchor in resolve_subgraph: a LOWER(name) wrapper would force a SCAN."""
+        anchor in resolve_subgraph: matching the stored name_lower fold key lets
+        the unique index satisfy the lookup; a LOWER(name) wrapper would SCAN."""
         with SQLiteRepository(":memory:") as repo:
             _seed_filesystem_graph(repo)
             plan = repo._conn.execute(
                 "EXPLAIN QUERY PLAN "
-                "SELECT id FROM primitives WHERE name COLLATE NOCASE IN (?, ?)",
+                "SELECT id FROM primitives WHERE name_lower IN (?, ?)",
                 ["file", "directory"],
             ).fetchall()
             detail = " ".join(row["detail"] for row in plan)


### PR DESCRIPTION
## Summary

#78 and #96 are two halves of one invariant — **at most one primitive per case-insensitive name** — so they're fixed together. The root cause was that "case-insensitive" was defined in 3+ places by 3 different engines (SQLite `NOCASE` = ASCII-only, Neo4j `toLower` = Unicode, ad-hoc Python `.lower()`), and Neo4j *cannot fold at comparison time* (no collation, no functional/expression constraints), so it could enforce uniqueness on a folded value only via a **stored** key.

This PR defines the fold **once** and enforces it at the DB layer on both backends.

## What changed

- **One definition** — `Primitive.fold_name(name) = str.casefold()` (staticmethod) + `Primitive.name_lower` (derived, read-only property; not a model field, not serialized). Every fold site routes through it (grounding, `resolve_subgraph`, metrics, learning validation, test stub).
- **#78 — write-time prevention (DB-enforced):** Neo4j gains a `primitive_name_lower_unique` constraint on a materialized `name_lower` property; SQLite swaps its `name COLLATE NOCASE` index for a plain unique index on a `name_lower` column. A new-id case-collision now raises `PersistenceError` on **both** backends.
- **#96 — read-time detection:** `find_by_name` materializes matches and raises `GraphError` on >1 instead of `.single()` silently returning the first (the driver's `strict=False` default). `find_by_id` is intentionally unchanged — its `id` is unique, and the literal `strict=True` proposed in #96 would have broken the not-found → `None` contract.
- **#99 item 3 — resolved as a consequence:** folding is now `casefold()` on both backends, so accented case-variants (e.g. `Café`/`CAFÉ`) are one concept everywhere (previously two on SQLite, one on Neo4j).
- **#83 — conformance foundation:** a parameterized `repository` fixture over every `Repository` backend (`requires_neo4j` marker; live Neo4j via `VRE_TEST_NEO4J_URI`, skips cleanly when absent), seeded with the name-identity invariants in `tests/vre/test_repository_conformance.py`.

Pre-1.0, no migration tooling: re-seed the graph (`name_lower` is a brand-new property/column, so the Neo4j constraint always creates cleanly).

## Issue dispositions

- Closes #78
- Closes #96
- #99 — **item 3 (Unicode case folding) is resolved** here; the remaining divergences (dangling-relatum drop, read-path error taxonomy, check-then-act cycle race) stay open and now have the Part-D harness to be pinned against.
- #83 — **foundation laid** (parameterized fixture + first cross-backend assertions); kept open for migrating the rest of the SQLite-only suite into shared coverage.

## Verification

Verified against **live Neo4j 6.2.0** (`bolt://localhost:7687`):

- Full suite: **383 passed** (the 7 Neo4j params now active).
- Total coverage 84% → **89%**; `neo4j.py` **16% → 50%** (the #83 goal: materially above its floor).
- Case-collision write → `PersistenceError` on both backends; duplicate `find_by_name` → `GraphError`; not-found still returns `None`; `Café`/`CAFÉ` collide on Neo4j.

Without `VRE_TEST_NEO4J_URI`, the Neo4j params skip cleanly and the SQLite parity assertions still run.

Run the live Neo4j path with:
```
VRE_TEST_NEO4J_URI=bolt://localhost:7687 VRE_TEST_NEO4J_PASSWORD=… \
  uv run pytest tests/vre/test_repository_conformance.py -m requires_neo4j -v
```

## Note (out of scope)

`neo4j.py:58` emits a pre-existing `DeprecationWarning` (`notifications_disabled_categories`). Renaming to `notifications_disabled_classifications` may break driver 5.x, which `pyproject.toml` still allows (`neo4j>=5.0,<7.0`) — worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)