### PR TITLE
fix: fold policy-registry edge keys through Primitive.fold_name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -165,6 +165,12 @@ summarize major changes, refactors, and breaking changes — not every commit.
   arbitrary first row with only a warning (the installed driver's default
   `strict=False`). `find_by_id` is unchanged — its `id` is unique by constraint.
   Corrects the "fails loud" rationale #78's deferral rested on. (#96)
+- `PolicyRegistry` edge keys now fold primitive names through `Primitive.fold_name`
+  (NFC + casefold) instead of a bare `.lower()`, so a policy resolves "the same
+  name" identically to the primitive it guards. Previously the policy layer was
+  the one site that defined case-insensitivity differently, missing edges on
+  exactly the cases `fold_name` unifies (e.g. `straße`/`STRASSE`, decomposed vs
+  precomposed accents). (#78)
 
 ### Performance
 

--- a/src/vre/core/policy/registry.py
+++ b/src/vre/core/policy/registry.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, Iterable
 from pydantic import BaseModel
 
 from vre.core.errors import VREError
-from vre.core.models import DepthLevel
+from vre.core.models import DepthLevel, Primitive
 from vre.core.policy.callback import PolicyCallback
 from vre.core.policy.models import (
     Cardinality,
@@ -102,8 +102,18 @@ class PolicyRegistry:
     def _edge_key(source: str, target: str, source_depth: DepthLevel) -> tuple[str, str, DepthLevel]:
         """
         Normalize an edge identity to its case-insensitive lookup key.
+
+        Folds names through `Primitive.fold_name` (NFC + casefold) — the same
+        single definition the persistence/grounding layers use — so a policy
+        edge resolves "the same name" identically to the primitive it guards.
+        A bare `.lower()` here would diverge on exactly the cases fold_name
+        unifies (e.g. "straße"/"strasse", decomposed vs precomposed accents).
         """
-        return (source.lower(), target.lower(), source_depth)
+        return (
+            Primitive.fold_name(source),
+            Primitive.fold_name(target),
+            source_depth,
+        )
 
     def register(
         self,

--- a/tests/vre/test_policy_registry.py
+++ b/tests/vre/test_policy_registry.py
@@ -73,6 +73,17 @@ def test_placements_lookup_is_case_insensitive():
     assert not reg.placements_for("delete", "file", DepthLevel.CAPABILITIES)
 
 
+def test_placements_lookup_folds_like_primitive_identity():
+    """Edge keys fold through Primitive.fold_name (NFC + casefold), not .lower(),
+    so a policy resolves 'the same name' identically to the primitive it guards.
+    'straße' and 'STRASSE' are one primitive (both fold to 'strasse'); a bare
+    .lower() would keep them apart ('straße' vs 'strasse') and miss the edge."""
+    reg = PolicyRegistry()
+    reg.register(_cb, key="k", source_primitive="straße", target_primitive="File",
+                 source_depth=DepthLevel.CONSTRAINTS, name="Guard")
+    assert reg.placements_for("STRASSE", "file", DepthLevel.CONSTRAINTS)
+
+
 def test_freeze_blocks_further_registration():
     """Once frozen, register raises and names the import-order rule."""
     reg = PolicyRegistry()


### PR DESCRIPTION
## Summary

Follow-up to the single-fold work merged in #119 (#78/#99). That PR made `Primitive.fold_name` (NFC + casefold) the single definition of case-insensitive name identity and routed the persistence, grounding, metrics, and learning layers through it. **One site was missed:** `PolicyRegistry._edge_key` still folded primitive names with a bare `.lower()`.

So the policy layer defined "the same name" with a *different rule* than the primitive it guards. They agree for ASCII (where `.lower() == casefold()`), but diverge on exactly the cases `fold_name` exists to unify:

- **Sharp-s expansion** — `casefold()` maps `straße` → `strasse`; `.lower()` leaves `ß` alone. A policy registered on `straße` would miss a lookup for `STRASSE` (and vice versa), even though the DB treats them as one primitive.
- **Unicode normalization** — precomposed `é` (U+00E9) vs `e` + combining acute (U+0301) render identically but `.lower()` keeps them as distinct keys; the NFC pass in `fold_name` collapses them.

Net effect: a policy could silently fail to match the edge it was meant to guard.

## Change

- `PolicyRegistry._edge_key` now folds both names through `Primitive.fold_name`, so a policy resolves identity identically to the persistence/grounding layers. This makes the #119 CHANGELOG claim — "case-insensitivity is defined once by `Primitive.fold_name`" — actually true.

## Test

- New `test_placements_lookup_folds_like_primitive_identity`: registers a policy on `straße` and asserts a `STRASSE` lookup matches. **Verified to fail on the old `.lower()`** (`assert []`) and pass on the fix — a real regression guard, not a tautology.

## Verification

- Full suite: **378 passed, 8 skipped**, coverage 84%. Diff against `main` is exactly the three files of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
