### PR TITLE
Grounding: justified envelope + fail-loud on graph integrity (#94)

### DIFF
--- a/src/vre/core/grounding/engine.py
+++ b/src/vre/core/grounding/engine.py
@@ -20,6 +20,7 @@ import logging
 from uuid import UUID
 
 from vre.core.backends import Repository
+from vre.core.errors import GraphIntegrityError
 from vre.core.grounding.models import GroundingResult
 from vre.core.models import (
     DepthGap,
@@ -105,6 +106,32 @@ class GroundingEngine:
         return all_roots, transients
 
     @staticmethod
+    def _validate_edge_endpoints(
+        edges: list[EpistemicStep],
+        id_to_prim: dict[UUID, Primitive],
+    ) -> None:
+        """
+        Fail loud if any resolved edge references a node absent from the set.
+
+        A conformant Repository returns edges only between nodes it also
+        returns. A dangling endpoint is a backend-contract violation, not a
+        depth gap, so it is surfaced as GraphIntegrityError rather than being
+        silently dropped (source side) or passed through as grounded (target
+        side). This keeps both sides of the same violation consistent and
+        fail-closed (#94 Finding C1). Running here, before any edge is
+        partitioned or interpreted, lets every downstream step index
+        id_to_prim directly instead of guarding each lookup.
+        """
+        for edge in edges:
+            for role, node_id in (("source", edge.source_id), ("target", edge.target_id)):
+                if node_id not in id_to_prim:
+                    raise GraphIntegrityError(
+                        f"Resolved {edge.relation_type.value} edge references a "
+                        f"{role} node {node_id} absent from the resolved subgraph; "
+                        f"the backend returned an edge whose {role} it did not return."
+                    )
+
+    @staticmethod
     def _partition_edges_by_source_depth(
         edges: list[EpistemicStep],
         id_to_prim: dict[UUID, Primitive],
@@ -114,14 +141,14 @@ class GroundingEngine:
 
         An edge is visible when the source node's contiguous max depth >= the
         edge's source_depth. Otherwise, the edge is gated — the source isn't
-        grounded deeply enough to see the relationship.
+        grounded deeply enough to see the relationship. Endpoints are
+        pre-validated by _validate_edge_endpoints, so the source lookup is a
+        direct index.
         """
         visible: list[EpistemicStep] = []
         gated: list[EpistemicStep] = []
         for edge in edges:
-            src = id_to_prim.get(edge.source_id)
-            if src is None:
-                continue
+            src = id_to_prim[edge.source_id]
             src_contiguous = src.contiguous_max_depth
             if src_contiguous is not None and src_contiguous >= edge.source_depth:
                 visible.append(edge)
@@ -141,6 +168,11 @@ class GroundingEngine:
     ) -> list[DepthGap | ExistenceGap | RelationalGap]:
         """
         Detect existence, depth, and relational gaps across the resolved subgraph.
+
+        The visible and gated edge lists are pre-restricted to the justified
+        frontier (source on a fully-visible path from a root), so no gap is ever
+        emitted about a node the agent cannot yet reach (#94). Edge endpoints are
+        pre-validated, so every id_to_prim lookup is a direct index.
         """
         gaps: list[DepthGap | ExistenceGap | RelationalGap] = []
         id_to_prim = {n.id: n for n in all_nodes}
@@ -158,8 +190,8 @@ class GroundingEngine:
 
         # (a) Gated edges → DepthGap on source primitive
         for edge in gated_edges:
-            src = id_to_prim.get(edge.source_id)
-            if src is None or src.id in transient_ids:
+            src = id_to_prim[edge.source_id]
+            if src.id in transient_ids:
                 continue
             src_contiguous = src.contiguous_max_depth
             existing = depth_gap_map.get(src.id)
@@ -178,22 +210,18 @@ class GroundingEngine:
                         depth_gap_map[node.id] = (min_depth, contiguous)
 
         for nid, (req, curr) in depth_gap_map.items():
-            prim = id_to_prim.get(nid)
-            if prim is not None:
-                gaps.append(DepthGap(
-                    primitive=prim,
-                    required_depth=req,
-                    current_depth=curr,
-                ))
+            gaps.append(DepthGap(
+                primitive=id_to_prim[nid],
+                required_depth=req,
+                current_depth=curr,
+            ))
 
         # Phase 3 — Relatum-depth relational gaps (visible edges only)
         relatum_depth_pairs: dict[tuple[UUID, UUID], DepthLevel] = {}
         for edge in visible_edges:
             if edge.target_id in transient_ids:
                 continue
-            tgt_prim = id_to_prim.get(edge.target_id)
-            if tgt_prim is None:
-                continue
+            tgt_prim = id_to_prim[edge.target_id]
             tgt_contiguous = tgt_prim.contiguous_max_depth
             if tgt_contiguous is not None and tgt_contiguous >= edge.target_depth:
                 continue
@@ -202,10 +230,8 @@ class GroundingEngine:
             if existing is None or edge.target_depth > existing:
                 relatum_depth_pairs[pair] = edge.target_depth
         for (src_id, tgt_id), max_req in relatum_depth_pairs.items():
-            src_prim = id_to_prim.get(src_id)
-            tgt_prim = id_to_prim.get(tgt_id)
-            if src_prim is None or tgt_prim is None:
-                continue
+            src_prim = id_to_prim[src_id]
+            tgt_prim = id_to_prim[tgt_id]
             curr = tgt_prim.contiguous_max_depth
             gaps.append(RelationalGap(
                 source=src_prim,
@@ -239,32 +265,68 @@ class GroundingEngine:
         return visited
 
     @staticmethod
-    def _filter_depths(all_nodes: list[Primitive]) -> list[Primitive]:
+    def _reachable_via_visible(
+        root_ids: set[UUID],
+        visible_edges: list[EpistemicStep],
+    ) -> set[UUID]:
         """
-        Return copies of all_nodes with relata filtered to targets present in the collected set.
+        Directed reachability from the query roots over visible edges only.
 
-        Uses model_copy(deep=True) to skip Pydantic re-validation while still
-        producing fully detached instances — downstream consumers (metrics
-        updates, tracing) can treat the result as independent of the source.
+        Returns every node id on a fully-visible directed path from some root
+        (roots included). This is the justified frontier: a node reached only
+        through a gated edge is excluded, so it never enters the response. The
+        direction matters — undirected reachability would keep more nodes than a
+        depth-aware closure in the Repository would, whereas this directed set is
+        exactly what such a closure returns, so #87 can later push the same
+        boundary into the query layer as a behavior-preserving no-op (#94).
         """
-        collected_ids = {n.id for n in all_nodes}
-        return [
-            p.model_copy(
-                update={
-                    "depths": [
-                        d.model_copy(
-                            update={
-                                "relata": [r for r in d.relata if r.target_id in collected_ids],
-                            },
-                            deep=True,
-                        )
-                        for d in p.depths
-                    ],
-                },
-                deep=True,
-            )
-            for p in all_nodes
-        ]
+        adjacency: dict[UUID, list[UUID]] = {}
+        for edge in visible_edges:
+            adjacency.setdefault(edge.source_id, []).append(edge.target_id)
+        reachable: set[UUID] = set(root_ids)
+        stack: list[UUID] = list(root_ids)
+        while stack:
+            current = stack.pop()
+            for nxt in adjacency.get(current, ()):
+                if nxt not in reachable:
+                    reachable.add(nxt)
+                    stack.append(nxt)
+        return reachable
+
+    @staticmethod
+    def _filter_depths(nodes: list[Primitive]) -> list[Primitive]:
+        """
+        Copy each node down to its justified epistemic envelope.
+
+        Two cuts, both honoring "the trace surfaces only what is grounded":
+          - depth content above the node's contiguous_max_depth is dropped, so a
+            node grounded to D1 never ships the properties or relata of a D3 it
+            cannot justify (#94 Finding D1);
+          - on the surviving depths, relata whose target was pruned from the
+            response are dropped, so a relatum never points outside the returned
+            set.
+
+        Returns fresh primitive and depth shells with deep-copied properties; the
+        surviving Relatum objects are referenced, not re-copied, so this is not a
+        deep clone of the relata graph. Downstream consumers (metrics, tracing)
+        treat the trace as read-only. (#87 owns the copy strategy; this states
+        what holds today rather than the prior "fully detached" claim, which was
+        false — #94 Finding D2.)
+        """
+        collected_ids = {n.id for n in nodes}
+        filtered: list[Primitive] = []
+        for p in nodes:
+            cmax = p.contiguous_max_depth
+            kept_depths = [] if cmax is None else [
+                d.model_copy(
+                    update={"relata": [r for r in d.relata if r.target_id in collected_ids]},
+                    deep=True,
+                )
+                for d in p.depths
+                if d.level <= cmax
+            ]
+            filtered.append(p.model_copy(update={"depths": kept_depths}, deep=True))
+        return filtered
 
     def query(
         self,
@@ -304,26 +366,40 @@ class GroundingEngine:
             )
 
             id_to_prim = {n.id: n for n in all_nodes}
+            # Fail loud on a backend that returns an edge dangling outside its own
+            # node set, before any edge is partitioned or interpreted (#94 C1).
+            self._validate_edge_endpoints(subgraph.edges, id_to_prim)
+
             visible_edges, gated_edges = self._partition_edges_by_source_depth(
                 subgraph.edges, id_to_prim,
             )
 
+            # The justified frontier: nodes on a fully-visible directed path from
+            # a root. A node reached only through a gated edge is not grounded
+            # enough to be surfaced, so it never enters the response, its gaps, or
+            # the pathway (#94 Findings A + D1). Edges are likewise restricted to
+            # those whose source is on the frontier, so no gap is emitted about a
+            # node the agent cannot yet reach.
+            frontier_ids = self._reachable_via_visible(root_ids, visible_edges)
+            frontier_visible = [e for e in visible_edges if e.source_id in frontier_ids]
+            frontier_gated = [e for e in gated_edges if e.source_id in frontier_ids]
+
             gaps: list[DepthGap | ExistenceGap | RelationalGap | ReachabilityGap] = self._detect_gaps(
                 all_nodes,
-                visible_edges,
-                gated_edges,
+                frontier_visible,
+                frontier_gated,
                 root_ids,
                 transient_ids,
                 min_depth=min_depth,
             )
 
             # Undirected connectivity check across all non-transient roots
-            # using only visible edges. Anchor on the root with the largest
-            # reachable component so truly isolated nodes get reported.
+            # using only frontier-visible edges. Anchor on the root with the
+            # largest reachable component so truly isolated nodes get reported.
             non_transient_roots = [r for r in roots if r.id not in transient_ids]
             if len(non_transient_roots) > 1:
                 neighbors: dict[UUID, set[UUID]] = {}
-                for edge in visible_edges:
+                for edge in frontier_visible:
                     neighbors.setdefault(edge.source_id, set()).add(edge.target_id)
                     neighbors.setdefault(edge.target_id, set()).add(edge.source_id)
                 anchor = max(
@@ -336,11 +412,12 @@ class GroundingEngine:
                         logger.warning("Reachability gap: %r is isolated from other query roots", root.name)
                         gaps.append(ReachabilityGap(primitive=root))
 
-            filtered = self._filter_depths(all_nodes)
+            surviving = [n for n in all_nodes if n.id in frontier_ids]
+            filtered = self._filter_depths(surviving)
 
             response = EpistemicResponse(
                 query=EpistemicQuery(concept_ids=[r.id for r in roots]),
-                result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=visible_edges),
+                result=EpistemicResult(primitives=filtered, gaps=gaps, pathway=frontier_visible),
             )
         return response
 

--- a/src/vre/core/policy/gate.py
+++ b/src/vre/core/policy/gate.py
@@ -7,6 +7,7 @@ PolicyGate — overlays code-resident policy placements onto an epistemic trace.
 
 import logging
 
+from vre.core.errors import GraphIntegrityError
 from vre.core.models import EpistemicResponse, RelationType, format_depth_label
 from vre.core.policy.callback import (
     GroundingContext,
@@ -96,7 +97,20 @@ class PolicyGate:
                 for relatum in depth.relata:
                     if relatum.relation_type != RelationType.APPLIES_TO:
                         continue
-                    target_name = id_to_name.get(relatum.target_id, str(relatum.target_id))
+                    if relatum.target_id not in id_to_name:
+                        # The engine guarantees every surviving relatum points
+                        # inside the returned set; an unresolvable target means an
+                        # internally inconsistent trace. Fail loud and closed
+                        # rather than fall back to str(uuid), which would never
+                        # match a placement and so silently disarm the gate
+                        # (#94 Finding C2).
+                        raise GraphIntegrityError(
+                            f"APPLIES_TO relatum on {primitive.name!r} @ "
+                            f"{format_depth_label(depth.level)} points to target "
+                            f"{relatum.target_id}, absent from the trace's primitives; "
+                            f"the trace is internally inconsistent."
+                        )
+                    target_name = id_to_name[relatum.target_id]
                     for placement in self._registry.placements_for(
                         primitive.name, target_name, depth.level
                     ):

--- a/tests/vre/test_engine.py
+++ b/tests/vre/test_engine.py
@@ -7,7 +7,10 @@ Uses a StubRepository to avoid Neo4j dependency.
 from collections import deque
 from uuid import UUID, uuid4
 
+import pytest
+
 from vre.core.backends import Repository
+from vre.core.errors import GraphIntegrityError
 from vre.core.grounding import GroundingEngine
 from vre.core.models import (
     Depth,
@@ -671,7 +674,9 @@ class TestSourceDepthGating:
 
     def test_gated_edges_excluded_from_pathway(self) -> None:
         """
-        Gated edges do not appear in the response pathway.
+        Gated edges do not appear in the pathway, and the queried roots are
+        preserved in primitives even when connected only by a gated edge
+        (#94: a queried root is never pruned).
         """
         delete_p, file_p = self._gated_delete_and_file()
         engine = GroundingEngine(StubRepository([delete_p, file_p]))
@@ -679,6 +684,221 @@ class TestSourceDepthGating:
         resp = engine.query(["delete", "file"])
 
         assert len(resp.result.pathway) == 0
+        assert {p.name for p in resp.result.primitives} == {"delete", "file"}
+
+
+class TestJustifiedEnvelope:
+    """The response surfaces only grounded content (#94 Findings A + D1)."""
+
+    @staticmethod
+    def _delete_constrained_by_permission(constraint_target_depth: DepthLevel):
+        """delete (D0,D1,D3) with a CONSTRAINED_BY @ D3 edge to a full permission."""
+        permission = _make_primitive("permission", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+            _depth(DepthLevel.CONSTRAINTS),
+        ])
+        delete = _make_primitive("delete", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CONSTRAINTS, [
+                _relatum(permission.id, RelationType.CONSTRAINED_BY, constraint_target_depth),
+            ]),
+        ])
+        return delete, permission
+
+    def test_gated_reached_nonroot_node_pruned_from_primitives(self) -> None:
+        """
+        A non-root node reached only through a gated edge never enters
+        result.primitives. The block is surfaced on the source (which the agent
+        can see), never as a gap that names the hidden target.
+        """
+        delete, permission = self._delete_constrained_by_permission(DepthLevel.CONSTRAINTS)
+        engine = GroundingEngine(StubRepository([delete, permission]))
+
+        resp = engine.query(["delete"])
+
+        assert {p.name for p in resp.result.primitives} == {"delete"}
+        depth_gaps = [g for g in resp.result.gaps if g.kind == "DEPTH"]
+        assert len(depth_gaps) == 1
+        assert depth_gaps[0].primitive.name == "delete"
+        assert depth_gaps[0].required_depth == DepthLevel.CONSTRAINTS
+        assert all(g.primitive.name != "permission" for g in resp.result.gaps)
+
+    def test_gated_reached_node_makes_result_ungrounded(self) -> None:
+        """The same case grounds False — the action is blocked, the target unseen."""
+        delete, permission = self._delete_constrained_by_permission(DepthLevel.IDENTITY)
+        engine = GroundingEngine(StubRepository([delete, permission]))
+
+        result = engine.ground(["delete"])
+
+        assert result.grounded is False
+        assert "permission" not in {p.name for p in result.trace.result.primitives}
+
+    def test_multihop_gated_chain_emits_only_frontier_gap(self) -> None:
+        """
+        a --gated--> b --gated--> c, querying a alone. Only the frontier gap
+        (on a) is emitted; b and c are pruned and neither is named by any gap,
+        so the agent never learns about structure it cannot yet reach.
+        """
+        c = _make_primitive("c", [_depth(DepthLevel.EXISTENCE), _depth(DepthLevel.IDENTITY)])
+        b = _make_primitive("b", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CONSTRAINTS, [
+                _relatum(c.id, RelationType.REQUIRES, DepthLevel.IDENTITY),
+            ]),
+        ])
+        a = _make_primitive("a", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CONSTRAINTS, [
+                _relatum(b.id, RelationType.REQUIRES, DepthLevel.IDENTITY),
+            ]),
+        ])
+        engine = GroundingEngine(StubRepository([a, b, c]))
+
+        resp = engine.query(["a"])
+
+        assert {p.name for p in resp.result.primitives} == {"a"}
+        assert len(resp.result.gaps) == 1
+        gap = resp.result.gaps[0]
+        assert gap.kind == "DEPTH"
+        assert gap.primitive.name == "a"
+
+    def test_visible_reached_nonroot_node_survives(self) -> None:
+        """A non-root node reached through a *visible* edge stays in the result."""
+        b = _make_primitive("b", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        a = _make_primitive("a", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CAPABILITIES, [
+                _relatum(b.id, RelationType.REQUIRES, DepthLevel.CAPABILITIES),
+            ]),
+        ])
+        engine = GroundingEngine(StubRepository([a, b]))
+
+        resp = engine.query(["a"])
+
+        assert {p.name for p in resp.result.primitives} == {"a", "b"}
+
+    def test_noncontiguous_depth_content_stripped_from_trace(self) -> None:
+        """
+        {D0, D1, D3} grounds green to D1, and the D3 content is absent from the
+        trace — nothing above contiguous_max_depth surfaces (#94 Finding D1).
+        """
+        widget = _make_primitive("widget", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY),
+            _depth(DepthLevel.CONSTRAINTS),  # D3 with D2 missing → above contiguous max
+        ])
+        engine = GroundingEngine(StubRepository([widget]))
+
+        resp = engine.query(["widget"])
+
+        assert len(resp.result.gaps) == 0
+        levels = {d.level for d in resp.result.primitives[0].depths}
+        assert levels == {DepthLevel.EXISTENCE, DepthLevel.IDENTITY}
+
+
+class _DanglingEdgeRepository(StubRepository):
+    """Returns one edge with an endpoint absent from the node set (#94 C1)."""
+
+    def __init__(self, dangle: str) -> None:
+        self._a = _make_primitive("a", [_depth(DepthLevel.EXISTENCE), _depth(DepthLevel.IDENTITY)])
+        super().__init__([self._a])
+        self._dangle = dangle
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        ghost = uuid4()
+        src, tgt = (self._a.id, ghost) if self._dangle == "target" else (ghost, self._a.id)
+        edge = EpistemicStep(
+            source_id=src,
+            target_id=tgt,
+            relation_type=RelationType.REQUIRES,
+            source_depth=DepthLevel.IDENTITY,
+            target_depth=DepthLevel.IDENTITY,
+        )
+        return ResolvedSubgraph(roots=[self._a], nodes=[self._a], edges=[edge])
+
+
+class TestBackendIntegrity:
+    """A non-conformant backend's dangling edge fails loud, both sides (#94 C1)."""
+
+    @pytest.mark.parametrize("dangle", ["target", "source"])
+    def test_dangling_edge_endpoint_raises(self, dangle: str) -> None:
+        engine = GroundingEngine(_DanglingEdgeRepository(dangle))
+        with pytest.raises(GraphIntegrityError):
+            engine.query(["a"])
+
+
+class _UpstreamLinkRepository(StubRepository):
+    """
+    Two query roots (a, b) whose only link is an *upstream* node x with visible
+    edges x->a and x->b. No visible path runs from either root to x, so x is off
+    the justified frontier. The real backends never return such a node (their
+    closure is forward-only, from roots along outgoing edges), so a hand-rolled
+    repository is the only way to exercise the engine's frontier-restricted
+    reachability check (#94).
+    """
+
+    def __init__(self) -> None:
+        self._a = _make_primitive("a", [_depth(DepthLevel.EXISTENCE), _depth(DepthLevel.IDENTITY)])
+        self._b = _make_primitive("b", [_depth(DepthLevel.EXISTENCE), _depth(DepthLevel.IDENTITY)])
+        # x is grounded to D2, so its D1 edges are visible (D2 >= D1).
+        self._x = _make_primitive("x", [
+            _depth(DepthLevel.EXISTENCE),
+            _depth(DepthLevel.IDENTITY, [
+                _relatum(self._a.id, RelationType.REQUIRES, DepthLevel.IDENTITY),
+                _relatum(self._b.id, RelationType.REQUIRES, DepthLevel.IDENTITY),
+            ]),
+            _depth(DepthLevel.CAPABILITIES),
+        ])
+        super().__init__([self._a, self._b, self._x])
+
+    def resolve_subgraph(self, names: list[str]) -> ResolvedSubgraph:
+        edges = [
+            EpistemicStep(
+                source_id=self._x.id,
+                target_id=target.id,
+                relation_type=RelationType.REQUIRES,
+                source_depth=DepthLevel.IDENTITY,
+                target_depth=DepthLevel.IDENTITY,
+            )
+            for target in (self._a, self._b)
+        ]
+        return ResolvedSubgraph(
+            roots=[self._a, self._b], nodes=[self._a, self._b, self._x], edges=edges,
+        )
+
+
+class TestFrontierReachability:
+    """The reachability check runs over frontier-visible edges, not raw visible
+    edges, so it stays consistent with the envelope actually returned (#94)."""
+
+    def test_roots_linked_only_through_offfrontier_node_are_disconnected(self) -> None:
+        """
+        When two roots' only link is an upstream node pruned from the response,
+        the roots are surfaced as isolated from each other. Reporting them as
+        connected would cite a node the trace never returns.
+        """
+        engine = GroundingEngine(_UpstreamLinkRepository())
+
+        resp = engine.query(["a", "b"])
+
+        # The upstream linking node never enters the response...
+        assert {p.name for p in resp.result.primitives} == {"a", "b"}
+        # ...so the only gap is the reachability gap on one of the two roots,
+        # and nothing names the pruned node.
+        assert len(resp.result.gaps) == 1
+        gap = resp.result.gaps[0]
+        assert gap.kind == "REACHABILITY"
+        assert gap.primitive.name in {"a", "b"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/vre/test_policies.py
+++ b/tests/vre/test_policies.py
@@ -2,6 +2,11 @@
 Unit tests for Policy models and PolicyGate (registry-based, code-resident policies).
 """
 
+from uuid import uuid4
+
+import pytest
+
+from vre.core.errors import GraphIntegrityError
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -146,6 +151,26 @@ def test_no_placements_proceed():
     """An APPLIES_TO edge with no registered placement → no violations."""
     violations = PolicyGate(PolicyRegistry()).evaluate(_trace("create"), Cardinality.SINGLE)
     assert len(violations) == 0
+
+
+def test_unresolvable_applies_to_target_raises_graph_integrity_error():
+    """
+    A trace whose APPLIES_TO relatum points outside its own primitives is
+    internally inconsistent; the gate fails loud rather than falling back to
+    str(uuid), which would never match a placement and so silently disarm the
+    gate (#94 Finding C2).
+    """
+    relatum = Relatum(relation_type=RelationType.APPLIES_TO, target_id=uuid4(),
+                      target_depth=TGT_DEPTH, provenance=_PROV)
+    source = Primitive(name="delete",
+                       depths=[Depth(level=SRC_DEPTH, relata=[relatum], provenance=_PROV)],
+                       provenance=_PROV)
+    # Source present, target absent → inconsistent trace.
+    response = EpistemicResponse(query=EpistemicQuery(concept_ids=[source.id]),
+                                 result=EpistemicResult(primitives=[source]))
+    reg = _registry(_cb_pass, source="delete", name="C2")  # non-empty so the trace walk runs
+    with pytest.raises(GraphIntegrityError):
+        PolicyGate(reg).evaluate(response, Cardinality.SINGLE, tool_call=ToolCallContext(tool_name="t"))
 
 
 def test_non_applies_to_relata_ignored():


### PR DESCRIPTION
Resolves the grounding-cases design questions in #94, per the decisions recorded on that issue. The grounding response now surfaces only what is grounded, and backend-contract violations fail closed instead of silently.

## What changed

**Justified envelope (Findings A + D1)** — `engine.py`
- Gate-aware closure, engine-side: after partitioning edges, the engine computes the justified frontier (nodes on a fully-visible directed path from a root) and drops every non-root node off it. A node reached only through a gated edge never enters `result.primitives`. Queried roots are never pruned.
- Gap detection is fed frontier-restricted edge lists, so no gap is emitted about a node the agent cannot yet reach. The single-hop motivating case suppresses nothing (the gap sits on the reachable root); only multi-hop gated chains drop a gap, and always at an off-frontier source.
- `_filter_depths` additionally drops depth levels above each node's `contiguous_max_depth`, so a node grounded to D1 no longer ships D3 content in a green-adjacent trace.

**Fail-loud on contract violations (Finding C)**
- C1 (`engine.py`): a dangling edge whose source or target is absent from the resolved set raises `GraphIntegrityError`, replacing the prior asymmetry (source-missing silently dropped the edge; target-missing silently passed it through as grounded). Validated up front, which also lets the downstream lookups index directly.
- C2 (`gate.py`): an unresolvable `APPLIES_TO` target raises `GraphIntegrityError` instead of falling back to `str(uuid)`, which would never match a placement and silently disarm the gate.

**Docstring honesty (Finding D2)** — `_filter_depths` no longer claims "fully detached"; it states what actually holds (fresh shells, deep-copied properties, referenced relata). The relata copy strategy stays with #87.

## Relationship to #87

Engine-level pruning computes the identical set a repository depth-aware closure would. When #87 pushes that boundary into the SQL/Cypher layer, this prune receives an already-pruned input and degrades to a no-op, acting as a correctness oracle in the meantime. Directed (not undirected) reachability is used precisely to keep the two boundaries identical.

## Tests

386 passing, ruff clean. New coverage: justified-envelope node pruning, multi-hop frontier gap suppression, D1 depth-content stripping, both dangling-edge sides (C1), and the gate C2 raise. A differential confirmed gap detection is otherwise byte-for-byte preserved (`new_gaps = old_gaps − {gaps sourced at off-frontier nodes}`).

## Deferred (unchanged scope)

- #123 — optional strict mode / `vre_guard` lint for under-declared policied edges (docs already cover it).
- #87 — repository-level depth-aware closure and the `_filter_depths` copy strategy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)