### PR TITLE
feat(schema): add schema_version marker to persisted format (#116)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ### Added
 
+- `schema_version` persisted-format marker (`CURRENT_SCHEMA_VERSION = 1`, the
+  single source of truth in `vre.core.backends.repository`). Both backends stamp
+  it on a fresh store — SQLite via `PRAGMA user_version`, Neo4j via a
+  DB-enforced-singleton `:VREMeta` node — and verify it on connect, raising the
+  new `SchemaVersionError` (a `VREError`, exported from `vre` and `vre.core`)
+  when a store was written by a newer VRE than this build can read. This is
+  forward-compatibility insurance so future format changes (e.g. stable relata
+  identity, #90) are cleanly migratable rather than shape-sniffed; no migration
+  logic ships yet. (#116)
 - `ProvenanceError` (a `VREError`, exported from `vre` and `vre.core`):
   `Primitive`/`Depth`/`Relatum.validate_provenance()` — which both backends call
   before any save — raises this typed error instead of a bare `ValueError` when

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -30,6 +30,7 @@ from vre.core.errors import (
     PolicyPlacementError,
     ProvenanceError,
     RegistryError,
+    SchemaVersionError,
     VREError,
 )
 from vre.core.backends import Repository, SQLiteRepository
@@ -89,6 +90,7 @@ __all__ = [
     "PolicyPlacementError",
     "ProvenanceError",
     "RegistryError",
+    "SchemaVersionError",
     "VREError",
     "Neo4jRepository",
     "Repository",

--- a/src/vre/core/__init__.py
+++ b/src/vre/core/__init__.py
@@ -11,6 +11,7 @@ from vre.core.errors import (
     HydrationError,
     PersistenceError,
     ProvenanceError,
+    SchemaVersionError,
     VREError,
 )
 from vre.core.models import (
@@ -31,6 +32,7 @@ __all__ = [
     "ProvenanceError",
     "ProvenanceSource",
     "Repository",
+    "SchemaVersionError",
     "TRANSITIVE_RELATION_TYPES",
     "VREError",
 ]

--- a/src/vre/core/backends/neo4j.py
+++ b/src/vre/core/backends/neo4j.py
@@ -17,7 +17,11 @@ from uuid import UUID
 from neo4j import GraphDatabase
 from neo4j.exceptions import ConstraintError, Neo4jError
 
-from vre.core.backends.repository import Repository
+from vre.core.backends.repository import (
+    CURRENT_SCHEMA_VERSION,
+    Repository,
+    reconcile_schema_version,
+)
 from vre.core.errors import (
     CyclicRelationshipError,
     GraphError,
@@ -61,7 +65,15 @@ class Neo4jRepository(Repository):
             notifications_disabled_categories=["UNRECOGNIZED"],
         )
         self._database = database
-        self._ensure_constraints()
+        # If connect-time verification fails (e.g. a schema version newer than
+        # this build, or a constraint error), close the driver we just opened
+        # before propagating — a failed construction must not leak a connection.
+        try:
+            self._ensure_constraints()
+            self._ensure_schema_version()
+        except Exception:
+            self._driver.close()
+            raise
 
     def close(self) -> None:
         """Close the underlying Neo4j driver and release all connections."""
@@ -73,7 +85,7 @@ class Neo4jRepository(Repository):
         tx.run(ddl)
 
     def _ensure_constraints(self) -> None:
-        logger.debug("Ensuring uniqueness constraints on Primitive")
+        logger.debug("Ensuring uniqueness constraints on Primitive and VREMeta")
         # Each constraint is its own managed write (#108): managed so a stale
         # pooled connection retries rather than failing hard, and one-per-
         # transaction because Neo4j does not permit schema statements to share
@@ -101,9 +113,53 @@ class Neo4jRepository(Repository):
                         "FOR (p:Primitive) REQUIRE p.name_lower IS UNIQUE",
                     ),
                 )
+                # Singleton marker for the persisted schema version (#116). Neo4j
+                # cannot constrain "at most one node of a label" directly, but a
+                # uniqueness constraint on the always-true `singleton` property
+                # caps :VREMeta at one node — a second insert with singleton=true
+                # violates uniqueness. This is the DB-level enforcement of the
+                # single-marker invariant, mirroring primitive_name_lower_unique.
+                session.execute_write(
+                    self._create_constraint,
+                    cast(
+                        LiteralString,
+                        "CREATE CONSTRAINT vremeta_singleton IF NOT EXISTS "
+                        "FOR (m:VREMeta) REQUIRE m.singleton IS UNIQUE",
+                    ),
+                )
         except Neo4jError as exc:
             logger.error("Failed to ensure Neo4j constraints: %s", exc)
             raise GraphError(f"Failed to ensure constraints: {exc}") from exc
+
+    def _ensure_schema_version(self) -> None:
+        """Seed the schema-version marker on a fresh store; verify it otherwise.
+
+        One managed write: MERGE creates the singleton :VREMeta node and stamps
+        CURRENT_SCHEMA_VERSION only when absent (fresh store, or a pre-#116 graph
+        with no marker), then returns the stored value. reconcile_schema_version
+        proceeds when it matches and fails loud when the store is newer than this
+        build supports.
+        """
+
+        def _tx(tx: Any) -> int:
+            record = tx.run(
+                cast(
+                    LiteralString,
+                    "MERGE (m:VREMeta {singleton: true}) "
+                    "ON CREATE SET m.schema_version = $current "
+                    "RETURN m.schema_version AS v",
+                ),
+                current=CURRENT_SCHEMA_VERSION,
+            ).single()
+            return record["v"]
+
+        try:
+            with self._driver.session(database=self._database) as session:
+                disk = session.execute_write(_tx)
+        except Neo4jError as exc:
+            logger.error("Failed to ensure Neo4j schema version: %s", exc)
+            raise GraphError(f"Failed to ensure schema version: {exc}") from exc
+        reconcile_schema_version(disk)
 
     # ------------------------------------------------------------------
     # Serialization helpers
@@ -622,6 +678,9 @@ class Neo4jRepository(Repository):
         """Delete every Primitive node and its relationships. Returns the count deleted."""
 
         def _tx(tx: Any) -> int:
+            # Only :Primitive nodes are removed; the :VREMeta marker is left
+            # intact — intentional: the version describes the file format, not
+            # the data, so clearing the graph must not unstamp it.
             record = tx.run(
                 cast(
                     LiteralString,

--- a/src/vre/core/backends/repository.py
+++ b/src/vre/core/backends/repository.py
@@ -13,6 +13,7 @@ from abc import ABC, abstractmethod
 from typing import Any, Self
 from uuid import UUID
 
+from vre.core.errors import SchemaVersionError
 from vre.core.models import (
     Primitive,
     PrimitiveMetrics,
@@ -21,6 +22,32 @@ from vre.core.models import (
 
 
 logger = logging.getLogger(__name__)
+
+
+CURRENT_SCHEMA_VERSION = 1  # bump in the SAME commit that changes the persisted format
+
+
+def reconcile_schema_version(disk: int, current: int = CURRENT_SCHEMA_VERSION) -> None:
+    """Compare an on-disk schema version against the version this build expects.
+
+    Only `disk == current` proceeds. `disk > current` means the store was written
+    by a newer VRE than this build can safely read. `disk < current` is the future
+    migration hook: it is unreachable at v1 (the only sub-1 disk value is the
+    fresh/unstamped sentinel, which each backend handles as a seed before this
+    function is called), and it fails loud rather than silently load an old-format
+    store under new-format assumptions — when migration logic lands, it replaces
+    this raise. Both directions raise `SchemaVersionError`.
+    """
+    if disk > current:
+        raise SchemaVersionError(
+            f"On-disk schema version {disk} is newer than this build of VRE "
+            f"supports ({current}). Upgrade VRE to read this graph."
+        )
+    if disk < current:
+        raise SchemaVersionError(
+            f"On-disk schema version {disk} predates this build of VRE "
+            f"({current}) and no migration path is implemented yet."
+        )
 
 
 class Repository(ABC):

--- a/src/vre/core/backends/sqlite.py
+++ b/src/vre/core/backends/sqlite.py
@@ -44,7 +44,11 @@ from pathlib import Path
 from typing import Any
 from uuid import UUID
 
-from vre.core.backends.repository import Repository
+from vre.core.backends.repository import (
+    CURRENT_SCHEMA_VERSION,
+    Repository,
+    reconcile_schema_version,
+)
 from vre.core.errors import (
     CyclicRelationshipError,
     HydrationError,
@@ -120,6 +124,11 @@ class SQLiteRepository(Repository):
         self._conn.execute("PRAGMA foreign_keys = ON")
         self._conn.execute("PRAGMA journal_mode = WAL")
         self._conn.executescript(_SCHEMA)
+        disk = self._conn.execute("PRAGMA user_version").fetchone()[0]
+        if disk == 0:  # fresh database, or a pre-#116 unstamped store
+            self._conn.execute(f"PRAGMA user_version = {CURRENT_SCHEMA_VERSION}")
+        else:
+            reconcile_schema_version(disk)
 
     def close(self) -> None:
         """Close the underlying SQLite connection."""
@@ -469,6 +478,9 @@ class SQLiteRepository(Repository):
     def clear(self) -> int:
         """Delete every primitive. Relata are cascade-deleted by the FK constraint."""
         try:
+            # The schema-version marker lives in the DB header (PRAGMA user_version),
+            # not the primitives table, so clearing graph data leaves it intact —
+            # intentional: the version describes the file format, not the data.
             cursor = self._conn.execute("DELETE FROM primitives")
             return cursor.rowcount
         except sqlite3.Error as exc:

--- a/src/vre/core/errors.py
+++ b/src/vre/core/errors.py
@@ -76,3 +76,14 @@ class RegistryError(VREError):
 
 class PolicyPlacementError(VREError):
     """A declared policy references an APPLIES_TO edge absent from the graph."""
+
+
+class SchemaVersionError(VREError):
+    """The persisted schema version is newer than this build of VRE can read.
+
+    The on-disk marker records the format the data was written in; the code's
+    CURRENT_SCHEMA_VERSION records what this build knows how to read. When the
+    disk value is the larger of the two, the store was written by a newer VRE
+    and cannot be safely read through this build's assumptions — so we refuse
+    loudly rather than risk silent corruption.
+    """

--- a/tests/vre/test_graph.py
+++ b/tests/vre/test_graph.py
@@ -10,6 +10,8 @@ from uuid import UUID
 import pytest
 
 from vre.core.backends import Repository
+from vre.core.backends.repository import CURRENT_SCHEMA_VERSION, reconcile_schema_version
+from vre.core.errors import SchemaVersionError
 from vre.core.models import (
     Depth,
     DepthLevel,
@@ -98,3 +100,27 @@ def test_upsert_does_not_log_when_new(caplog: pytest.LogCaptureFixture) -> None:
         repo.upsert_primitive(incoming)
 
     assert not any("Upserting" in r.message for r in caplog.records)
+
+
+class TestReconcileSchemaVersion:
+    """Pure three-case comparator from repository.py — no DB involved."""
+
+    def test_equal_version_passes(self) -> None:
+        # disk == current: returns None, raises nothing.
+        assert reconcile_schema_version(CURRENT_SCHEMA_VERSION) is None
+
+    def test_newer_disk_version_fails_loud(self) -> None:
+        with pytest.raises(SchemaVersionError):
+            reconcile_schema_version(CURRENT_SCHEMA_VERSION + 1)
+
+    def test_older_disk_version_fails_loud(self) -> None:
+        # disk < current with no migration logic wired: must fail loud rather
+        # than silently load an old-format store under new-format assumptions.
+        # `current` is injected so the case is reachable while CURRENT is 1.
+        with pytest.raises(SchemaVersionError):
+            reconcile_schema_version(disk=1, current=2)
+
+    def test_constant_is_one(self) -> None:
+        # Pins the current format. Bump this (and the assertion) only when the
+        # persisted format actually changes.
+        assert CURRENT_SCHEMA_VERSION == 1

--- a/tests/vre/test_repository_conformance.py
+++ b/tests/vre/test_repository_conformance.py
@@ -14,12 +14,14 @@ through the single ``Primitive.fold_name`` (NFC + casefold) definition.
 Neo4j params skip cleanly when ``VRE_TEST_NEO4J_URI`` is unset (see conftest).
 """
 
+import os
 import unicodedata
 from uuid import uuid4
 
 import pytest
 
-from vre.core.errors import GraphError, PersistenceError
+from vre.core.backends.repository import CURRENT_SCHEMA_VERSION
+from vre.core.errors import GraphError, PersistenceError, SchemaVersionError
 from vre.core.models import Depth, DepthLevel, Primitive, Provenance, ProvenanceSource
 
 # e + U+0301 (combining acute). Built via chr() so the code point is explicit in
@@ -138,3 +140,57 @@ def test_find_by_name_fails_loud_on_duplicate(neo4j_repository) -> None:
     # Restore the invariant for subsequent tests: drop the dupes, re-add constraint.
     repo.clear()
     repo._ensure_constraints()
+
+
+@pytest.mark.requires_neo4j
+def test_schema_version_seeded_on_fresh_store(neo4j_repository) -> None:
+    repo = neo4j_repository
+    with repo._driver.session(database=repo._database) as session:
+        record = session.run(
+            "MATCH (m:VREMeta) RETURN m.schema_version AS v, count(m) AS n"
+        ).single()
+    assert record["v"] == 1
+    assert record["n"] == 1  # exactly one VREMeta node (singleton)
+
+
+@pytest.mark.requires_neo4j
+def test_schema_version_survives_clear(neo4j_repository) -> None:
+    repo = neo4j_repository
+    repo.save_primitive(_make_primitive("alpha"))
+    repo.clear()
+    # The marker describes the file format, not the data: clear() removes only
+    # :Primitive nodes, so the lone :VREMeta node must remain stamped.
+    with repo._driver.session(database=repo._database) as session:
+        record = session.run(
+            "MATCH (m:VREMeta) RETURN m.schema_version AS v, count(m) AS n"
+        ).single()
+    assert record["v"] == 1
+    assert record["n"] == 1
+
+
+@pytest.mark.requires_neo4j
+def test_schema_version_newer_fails_loud(neo4j_repository) -> None:
+    # Lazy import (not module top level) so this test module still collects when
+    # the optional neo4j driver is absent — the neo4j_repository fixture has
+    # already skipped in that case. Mirrors conftest._make_neo4j_repo.
+    from vre.core.backends.neo4j import Neo4jRepository
+
+    repo = neo4j_repository
+    # Simulate a store written by a newer VRE.
+    with repo._driver.session(database=repo._database) as session:
+        session.run("MATCH (m:VREMeta) SET m.schema_version = 99")
+    try:
+        uri = os.environ["VRE_TEST_NEO4J_URI"]
+        user = os.environ.get("VRE_TEST_NEO4J_USER", "neo4j")
+        password = os.environ["VRE_TEST_NEO4J_PASSWORD"]
+        database = os.environ.get("VRE_TEST_NEO4J_DATABASE", "neo4j")
+        with pytest.raises(SchemaVersionError):
+            Neo4jRepository(uri, user, password, database=database)
+    finally:
+        # CRITICAL: the marker survives clear(), so a leftover 99 would poison
+        # every subsequent Neo4j test (their connect would raise/skip). Restore it.
+        with repo._driver.session(database=repo._database) as session:
+            session.run(
+                "MATCH (m:VREMeta) SET m.schema_version = $v",
+                v=CURRENT_SCHEMA_VERSION,
+            )

--- a/tests/vre/test_sqlite.py
+++ b/tests/vre/test_sqlite.py
@@ -5,10 +5,13 @@
 Comprehensive test suite for SQLiteRepository.
 """
 
+import pathlib
+import sqlite3
+
 import pytest
 
 from vre.core.backends.sqlite import SQLiteRepository
-from vre.core.errors import CyclicRelationshipError
+from vre.core.errors import CyclicRelationshipError, SchemaVersionError
 from vre.core.grounding import GroundingEngine
 from vre.core.models import (
     Depth,
@@ -182,14 +185,53 @@ class TestSQLiteLifecycle:
         repo.close()
 
     def test_file_based_db(self, tmp_path: object) -> None:
-        import pathlib
-
         db_path = pathlib.Path(str(tmp_path)) / "sub" / "test.db"
         with SQLiteRepository(db_path) as repo:
             repo.save_primitive(_make_primitive("alpha"))
         # Reopen to verify persistence
         with SQLiteRepository(db_path) as repo:
             assert repo.find_by_name("alpha") is not None
+
+    def test_schema_version_seeded_on_fresh_store(self) -> None:
+        repo = SQLiteRepository(":memory:")
+        try:
+            version = repo._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == 1
+        finally:
+            repo.close()
+
+    def test_schema_version_persists_across_reopen(self, tmp_path: object) -> None:
+        db_path = pathlib.Path(str(tmp_path)) / "versioned.db"
+        SQLiteRepository(db_path).close()          # fresh: seeds version 1
+        repo = SQLiteRepository(db_path)           # reopen: must NOT raise
+        try:
+            version = repo._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == 1
+        finally:
+            repo.close()
+
+    def test_newer_schema_version_fails_loud(self, tmp_path: object) -> None:
+        db_path = pathlib.Path(str(tmp_path)) / "future.db"
+        SQLiteRepository(db_path).close()          # seed version 1
+        # Simulate a store written by a newer VRE.
+        raw = sqlite3.connect(str(db_path))
+        raw.execute("PRAGMA user_version = 99")
+        raw.close()
+        with pytest.raises(SchemaVersionError):
+            SQLiteRepository(db_path)
+
+    def test_schema_version_survives_clear(self, tmp_path: object) -> None:
+        db_path = pathlib.Path(str(tmp_path)) / "cleared.db"
+        repo = SQLiteRepository(db_path)
+        try:
+            repo.save_primitive(_make_primitive("alpha"))
+            repo.clear()
+            # The marker describes the file format, not the data, so clearing
+            # the graph must leave it stamped.
+            version = repo._conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == 1
+        finally:
+            repo.close()
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Plants a `schema_version` marker in both persisted backends **before 1.0**, so future format changes (e.g. stable relata identity, #90) are cleanly migratable rather than shape-sniffed. No migration logic ships yet — that arrives with the first format change. Closes #116.

## What's in it

- **Core:** `CURRENT_SCHEMA_VERSION = 1` + a pure `reconcile_schema_version()` comparator in `repository.py`, kept module-level (not on the `Repository` ABC, so the in-memory test doubles need no change). New `SchemaVersionError` (a `VREError`), exported from `vre` and `vre.core`.
- **SQLite:** seed/verify via `PRAGMA user_version` (`0` == fresh/unstamped → stamp; otherwise reconcile).
- **Neo4j:** seed/verify via a **DB-enforced-singleton** `:VREMeta` node — a uniqueness constraint on the always-`true` `singleton` property caps the label at one node, and `MERGE ... ON CREATE SET` means a reopen never overwrites a stored value.
- The marker **survives `clear()`** in both backends — it describes the file format, not the data.
- `Neo4jRepository.__init__` now closes its driver if connect-time verification fails, so a failed construction does not leak a connection.

## The three cases (from #116)

| disk vs constant | meaning | action |
| --- | --- | --- |
| `==` | data matches this build | proceed |
| `<` | data older than build | future migration hook (none today; unreachable at v1) |
| `>` | data newer than build | **fail loud** (`SchemaVersionError`) |

## Testing

- Pure comparator unit tests (no DB).
- SQLite: fresh store → v1; reopen of a versioned store succeeds; tampered (`user_version = 99`) → `SchemaVersionError`.
- Neo4j (live instance): fresh → exactly one `:VREMeta` @ v1; tampered → `SchemaVersionError` (with the marker restored in `finally` for test isolation).
- Full suite: **403 passed, 89% coverage, ruff clean.**

## Acceptance criteria (#116)

- [x] `CURRENT_SCHEMA_VERSION` (=1) as the single source of truth
- [x] `schema_version` persisted by both backends
- [x] seeded on fresh stores; read and compared on connect; **fail loud when newer than expected**
- [x] no behavior change for existing data beyond the marker
- [x] tests: fresh → v1, reopen succeeds, newer fails loud

🤖 Generated with [Claude Code](https://claude.com/claude-code)
