### PR TITLE
chore(packaging): 1.0-readiness trust signals (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ### Added
 
+- `py.typed` marker (PEP 561). The package is fully typed (Pydantic throughout)
+  but that was invisible to downstream `mypy`/`pyright` without the marker; it now
+  ships in both the wheel and sdist, so integrators get VRE's types when they
+  depend on it. (#105)
+- `[project.urls]` in package metadata (Homepage, Repository, Issues, Changelog),
+  so the PyPI page links back to the repo, issue tracker, and changelog instead of
+  having no project links at all. (#105)
+- A **Stability** section in the README stating the public-API surface (everything
+  exported from `vre` and `vre.core`), what semver means while pre-1.0 (minor bumps
+  may break), and the post-1.0 deprecation contract. (#105)
+- The package license is now declared as an SPDX expression (`license =
+  "Apache-2.0"`) rather than the deprecated table form, so the wheel carries a
+  `License-Expression` field (Metadata 2.4) and the `LICENSE` file is recorded as
+  a `License-File`. (#105)
 - `schema_version` persisted-format marker (`CURRENT_SCHEMA_VERSION = 1`, the
   single source of truth in `vre.core.backends.repository`). Both backends stamp
   it on a fresh store — SQLite via `PRAGMA user_version`, Neo4j via a
@@ -168,6 +182,8 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ### Fixed
 
+- README install commands for the Neo4j extra are now quoted (`pip install
+  'vre[neo4j]'`); unquoted, `zsh` globs the brackets and the install fails. (#105)
 - Neo4j `find_by_name` no longer resolves a duplicate-name graph silently and
   nondeterministically. It materializes matches and raises `GraphError` when more
   than one primitive shares a folded name, instead of `.single()` returning an

--- a/README.md
+++ b/README.md
@@ -3,9 +3,19 @@
 
 # VRE — Volute Reasoning Engine
 
-### Note
-This library is still in active development and is subject to breaking changes.
-However, a stable v1.0.0 release is expected soon.
+### Stability
+
+VRE is pre-1.0 and under active development. The **public API** is everything
+exported from the top-level `vre` package and `vre.core` — the `VRE` class, the
+`vre_guard` decorator, the repository backends, and the structured result and
+gap models they return. Anything reached through a private submodule path or a
+leading-underscore name is internal and may change without notice. While the
+project is pre-1.0, **minor version bumps may introduce breaking changes** to
+the public API; each is recorded in the [CHANGELOG](CHANGELOG.md). From v1.0.0
+onward the project follows [semantic versioning](https://semver.org/spec/v2.0.0.html):
+breaking changes to the public API land only in major releases, preceded by a
+deprecation period with runtime warnings. A stable v1.0.0 release is expected
+soon.
 
 **Epistemic enforcement for autonomous agents.**
 
@@ -207,7 +217,7 @@ The database defaults to `~/.vre/graph.db` and is created automatically on first
 For production deployments or larger graphs, an optional **Neo4j backend** is available:
 
 ```bash
-pip install vre[neo4j]
+pip install 'vre[neo4j]'
 ```
 
 ### Infrastructure
@@ -847,7 +857,7 @@ grounding history, and affect the agent's confidence in related concepts.
 | Concern            | Technology                                    |
 |--------------------|-----------------------------------------------|
 | Language           | Python 3.12+                                  |
-| Epistemic graph    | SQLite (default) or Neo4j (`pip install vre[neo4j]`) |
+| Epistemic graph    | SQLite (default) or Neo4j (`pip install 'vre[neo4j]'`) |
 | Concept resolution | Exact, case-insensitive name match (no NLP)   |
 | Data models        | Pydantic v2                                   |
 | Package management | Poetry                                        |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,18 @@ description = "Volute Reasoning Engine — decorator-based epistemic enforcement
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}
 ]
-license = {text = "Apache-2.0"}
+license = "Apache-2.0"
 readme = "README.md"
 requires-python = ">=3.12,<4.0"
 dependencies = [
     "pydantic>=2.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/anormang1992/vre"
+Repository = "https://github.com/anormang1992/vre"
+Issues = "https://github.com/anormang1992/vre/issues"
+Changelog = "https://github.com/anormang1992/vre/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 neo4j = ["neo4j>=5.0,<7.0"]


### PR DESCRIPTION
Sweep of the remaining stragglers from the v1.0 packaging punchlist in #105. The CHANGELOG was already in place and the `examples`-extra item was already resolved by #114, so this PR covers what was still missing.

## Changes

- **`py.typed` marker (PEP 561)** — the API is fully typed (Pydantic throughout) but that was invisible to downstream `mypy`/`pyright` without the marker. Verified it ships in both the wheel and sdist.
- **`[project.urls]`** — Homepage / Repository / Issues / Changelog, so the PyPI page links back to the repo, tracker, and changelog (previously `project_urls: None`).
- **Stability section in README** — replaces the one-line "Note" with the public-API surface (everything exported from `vre` / `vre.core`), what semver means while pre-1.0, and the post-1.0 deprecation contract.
- **zsh quoting** — `pip install 'vre[neo4j]'` at the two README install sites; unquoted, zsh globs the brackets.
- **SPDX license expression** — `license = "Apache-2.0"` instead of the deprecated table form; the wheel now carries `License-Expression` (Metadata 2.4) and records `LICENSE` as a `License-File`. (Found incidentally via `poetry check`; in the spirit of the punchlist.)

All logged under CHANGELOG `[Unreleased]`. No version bump (pyproject still tracks the last release per the release-versioning convention).

## Verification

- `poetry build` → confirmed `vre/py.typed` and all four `Project-URL` entries in both wheel METADATA and sdist PKG-INFO.
- `poetry check` → "All set!" (both prior warnings gone).
- `poetry run pytest` → **395 passed, 11 skipped** (skips are the live-Neo4j integration tests), coverage 82.9%.

Closes #105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)