### PR TITLE
chore(release): v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to this project are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-While the project is pre-1.0, minor version bumps may introduce breaking changes.
+As of v1.0.0 the public API is stable: breaking changes land only in major
+releases and are preceded by a deprecation period.
 
 Sections for released versions are backfilled from tagged GitHub releases and
 summarize major changes, refactors, and breaking changes — not every commit.
 
 ## [Unreleased]
+
+## [1.0.0] - 2026-06-17
 
 ### Added
 
@@ -317,7 +320,8 @@ Initial PyPI release, bundling the early epistemic engine and tooling.
 
 - Initial public scaffold: the core epistemic model and project README.
 
-[Unreleased]: https://github.com/anormang1992/vre/compare/v0.9.1...HEAD
+[Unreleased]: https://github.com/anormang1992/vre/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/anormang1992/vre/compare/v0.9.1...v1.0.0
 [0.9.1]: https://github.com/anormang1992/vre/compare/v0.8.0...v0.9.1
 [0.8.0]: https://github.com/anormang1992/vre/compare/v0.6.0...v0.8.0
 [0.6.0]: https://github.com/anormang1992/vre/compare/v0.4.3...v0.6.0

--- a/README.md
+++ b/README.md
@@ -5,17 +5,14 @@
 
 ### Stability
 
-VRE is pre-1.0 and under active development. The **public API** is everything
-exported from the top-level `vre` package and `vre.core` — the `VRE` class, the
-`vre_guard` decorator, the repository backends, and the structured result and
-gap models they return. Anything reached through a private submodule path or a
-leading-underscore name is internal and may change without notice. While the
-project is pre-1.0, **minor version bumps may introduce breaking changes** to
-the public API; each is recorded in the [CHANGELOG](CHANGELOG.md). From v1.0.0
-onward the project follows [semantic versioning](https://semver.org/spec/v2.0.0.html):
-breaking changes to the public API land only in major releases, preceded by a
-deprecation period with runtime warnings. A stable v1.0.0 release is expected
-soon.
+As of **v1.0.0**, VRE is stable. The **public API** is everything exported from
+the top-level `vre` package and `vre.core` — the `VRE` class, the `vre_guard`
+decorator, the repository backends, and the structured result and gap models they
+return. Anything reached through a private submodule path or a leading-underscore
+name is internal and may change without notice. The project follows [semantic
+versioning](https://semver.org/spec/v2.0.0.html): breaking changes to the public
+API land only in major releases and are preceded by a deprecation period with
+runtime warnings. Every change is recorded in the [CHANGELOG](CHANGELOG.md).
 
 **Epistemic enforcement for autonomous agents.**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "0.9.1"
+version = "1.0.0"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}


### PR DESCRIPTION
First **stable** release. Release-prep only — **no code changes**, just version + docs.

## What's in this PR

- **`pyproject.toml`**: `version` `0.9.1` → `1.0.0`. This is the version `publish.yml` reads from pyproject at the tagged commit, so it must land before the tag exists.
- **CHANGELOG**: cut `[Unreleased]` → `[1.0.0] - 2026-06-17`, opened a fresh empty `[Unreleased]`, repointed the compare links (`[Unreleased]` → `v1.0.0...HEAD`, added `[1.0.0]` → `v0.9.1...v1.0.0`). Header caveat updated from the pre-1.0 wording to the post-1.0 semver contract.
- **README Stability section**: announces the stable line — public API under the semver contract, breaking changes only in major releases after a deprecation period.

## What this PR does *not* do

It does not tag or publish. After this merges, the release is cut by tagging the merge commit `v1.0.0` and publishing a GitHub Release — *that* triggers `publish.yml` (CI → `poetry build` → PyPI via OIDC). PyPI publishes are irreversible, hence the review gate here first.

## Verification

- `poetry build` → `Building vre (1.0.0)` ✓
- `poetry check` → "All set!" ✓
- `ruff check src/ tests/` → all passed ✓ (CI lint step)
- `pytest` → **395 passed, 11 skipped** (live-Neo4j integration tests), coverage 82.9% ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)