### PR TITLE
docs: post-release documentation sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,9 +622,9 @@ existing connected node *back* to the orphan is just as valid as one originating
 
 ### Provenance
 
-`learn_gap` accepts an optional `source: ProvenanceSource` parameter (default `LEARNED`). The integrator decides
-how to stamp persisted knowledge based on its own loop semantics — `LEARNED` for agent-proposed fills approved at
-the persistence boundary, `AUTHORED` for content a human drafted directly. Both are human-attested by construction;
+Knowledge persisted through `learn_gap` is always stamped `LEARNED`: by construction it originates from an
+agent-proposed candidate that a human approved at the persistence boundary, so there is no way to forge `AUTHORED`
+provenance here — true from-scratch authoring goes through the repository directly. Both are human-attested;
 provenance is genealogy, not a trust gradient. The graph remembers not just what it knows, but how it came to know it.
 
 ### Reachability Prerequisites
@@ -846,6 +846,22 @@ its graph from a community of peers instead of authoring every concept from scra
 A new class of memory that stores not just information but the agent's epistemic relationship to that information.
 Memories are indexed by concept and depth, decay or are reinforced based on usage and
 grounding history, and affect the agent's confidence in related concepts.
+
+### Hero Demo
+
+A single agent-driven showcase that replaces the retired `examples/` directory — one real agent that grounds, plans,
+hits a knowledge gap, learns through failure, and only then acts, demonstrating epistemic honesty end to end rather
+than describing it. No framework dependency: a thin `Driver` protocol over whatever LLM the reader has, so the demo
+teaches VRE rather than a particular agent stack. The narrative follows VRE's own binding gradient — static knowledge,
+chosen policy, and live extraction layered in proportion to blast radius.
+
+### Authoring & Linting CLI
+
+An interactive graph console for building and auditing domain knowledge — seeding primitives and depths, linting a
+graph for vacuity holes and orphaned policy placements, and generating new domains. Knowledge packs ship the concepts
+and depths but *no placed edges*: knowledge is published, policy is chosen by the integrator. Suggested edges travel
+with a pack as counsel the operator can review and place deliberately, never as silent defaults — keeping graph
+structure, and therefore policy, an explicit authoring act.
 
 ---
 

--- a/src/vre/__init__.py
+++ b/src/vre/__init__.py
@@ -42,6 +42,7 @@ except ImportError:
 from vre.core.grounding import GroundingEngine, GroundingResult
 from vre.core.models import (
     DepthLevel,
+    Primitive,
     PrimitiveMetrics,
     Provenance,
     ProvenanceSource,
@@ -196,7 +197,7 @@ class VRE:
             result.agent_id = self._identity.agent_id
         return result
 
-    def _has_applies_to_edge(self, source, target_id: UUID, source_depth: DepthLevel) -> bool:
+    def _has_applies_to_edge(self, source: Primitive, target_id: UUID, source_depth: DepthLevel) -> bool:
         """
         Whether `source` has an APPLIES_TO relatum to `target_id` at `source_depth`.
         """

--- a/src/vre/core/errors.py
+++ b/src/vre/core/errors.py
@@ -41,8 +41,8 @@ class ProvenanceError(VREError):
     """Knowledge being persisted is missing required provenance.
 
     Provenance is required on every primitive, depth, and relatum at the
-    persistence boundary (CLAUDE.md §7.2). Raised by validate_provenance,
-    which the backends invoke before any save.
+    persistence boundary. Raised by validate_provenance, which the backends
+    invoke before any save.
     """
 
 

--- a/src/vre/core/models.py
+++ b/src/vre/core/models.py
@@ -170,6 +170,9 @@ class Relatum(BaseModel):
         """
         Raise ProvenanceError if provenance is missing.
         """
+        # Not dead code: `provenance` is required at construction, but Pydantic
+        # does not re-validate on assignment, so it can be nulled or spoofed
+        # afterward. This is the fail-closed backstop the backends run before any write.
         if self.provenance is None:
             raise ProvenanceError(
                 f"{context}relatum {self.relation_type.value} → "
@@ -209,6 +212,9 @@ class Depth(BaseModel):
         """
         Raise ProvenanceError if provenance is missing on this depth or any of its relata.
         """
+        # Not dead code: `provenance` is required at construction, but Pydantic
+        # does not re-validate on assignment, so it can be nulled or spoofed
+        # afterward. This is the fail-closed backstop the backends run before any write.
         if self.provenance is None:
             raise ProvenanceError(
                 f"{context}depth D{self.level.value} ({self.level.name}) "
@@ -284,6 +290,9 @@ class Primitive(BaseModel):
         """
         Raise ProvenanceError if provenance is missing on this primitive, any depth, or any relatum.
         """
+        # Not dead code: `provenance` is required at construction, but Pydantic
+        # does not re-validate on assignment, so it can be nulled or spoofed
+        # afterward. This is the fail-closed backstop the backends run before any write.
         if self.provenance is None:
             raise ProvenanceError(
                 f"Primitive '{self.name}' is missing provenance"


### PR DESCRIPTION
Post-release cleanup of stale/stray references plus two new Future entries.

## Findings fixed
- **README — stale `learn_gap` provenance param.** The Learning/Provenance section still described an optional `source: ProvenanceSource` argument. That parameter was removed in #95; `learn_gap` now always stamps `LEARNED` (from-scratch `AUTHORED` content goes through the repository). Rewrote the paragraph to match the actual contract.
- **`core/errors.py` — stray CLAUDE.md reference.** Dropped `(CLAUDE.md §7.2)` from the `ProvenanceError` docstring; an internal, unshipped project doc doesn't belong in library source.
- **`__init__.py` — untyped parameter.** Annotated `_has_applies_to_edge(source: Primitive, ...)` and added `Primitive` to the `vre.core.models` import (no `from __future__ import annotations` in this module, so the import is required at runtime).
- **`models.py` — `validate_provenance()` None-checks look like dead code.** Commented all three (Relatum, Depth, Primitive): `provenance` is required at construction, but Pydantic does not re-validate on assignment, so these are the fail-closed backstop against post-construction nulling/spoofing before a write.

## Future section
Added two planned subsystems to the README:
- **Hero Demo** — the single agent-driven showcase replacing the retired `examples/` (learning-through-failure narrative, framework-free `Driver` protocol, binding-gradient arc).
- **Authoring & Linting CLI** — the seeder/linter/domain-generation console ("knowledge ships, policy is chosen": packs ship no placed edges; suggested edges are reviewable counsel).

## Verification
- `import vre` / `vre.core.models` import cleanly with the new `Primitive` import.
- README ToC does not enumerate Future subsections, so no ToC change needed.
- No `CLAUDE.md`/`§` references remain in `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)