### PR TITLE
fix(learning): enforce the vacuity floor on the existence path (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ## [Unreleased]
 
+### Fixed
+
+- The existence-learning path no longer bypasses the vacuity floor (#80). An
+  `ExistenceCandidate` whose D1 carried empty `properties` was accepted and
+  persisted, manufacturing a vacuous identity that does not ground — the quiet
+  degradation VRE exists to prevent. The proposed D1 now flows through the same
+  `_validate_depth_fill` gate the depth-fill path uses (with the auto-generated D0
+  modeled as the present floor), so the vacuity floor and contiguity rules are
+  single-sourced across both learning paths and the existence path can no longer
+  drift from the depth path. (#129)
+
 ## [1.0.0] - 2026-06-17
 
 ### Added

--- a/src/vre/learning/engine.py
+++ b/src/vre/learning/engine.py
@@ -242,6 +242,21 @@ class LearningEngine:
                 f"already resolved; nothing to learn"
             )
 
+        # Validate the agent-proposed D1 through the same gate the depth path uses,
+        # modeling the auto-generated D0 as the present floor (accepting an
+        # existence gap *is* the D0 confirmation). Routing both paths through one
+        # validator single-sources the vacuity floor (#80) and contiguity rules, so
+        # the existence path cannot drift from the depth path — which is exactly how
+        # an empty D1 slipped through before. D1 is non-None and IDENTITY here:
+        # learn_gap runs validate_for_gap before any persist.
+        _validate_depth_fill(
+            [candidate.d1],
+            DepthLevel.EXISTENCE,
+            DepthLevel.IDENTITY,
+            {DepthLevel.EXISTENCE},
+            f"ExistenceCandidate for '{candidate.name}'",
+        )
+
         d0 = Depth(
             level=DepthLevel.EXISTENCE,
             properties={"exists": True},
@@ -309,7 +324,9 @@ class LearningEngine:
         live_current = existing.contiguous_max_depth
         _raise_if_resolved(existing.name, live_current, required_depth)
         _validate_depth_fill(
-            new_depths, live_current, required_depth,
+            new_depths,
+            live_current,
+            required_depth,
             existing.grounding_levels,
             f"{label} for '{existing.name}'",
         )

--- a/tests/vre/test_learning.py
+++ b/tests/vre/test_learning.py
@@ -350,6 +350,24 @@ class TestPersistExistence:
             engine.learn_gap(gap, filled)
         assert repo.saved == []
 
+    def test_rejects_empty_d1_properties(self):
+        # An existence fill must carry content (#80): an empty D1 does not
+        # ground, so accepting it would persist a vacuous identity — exactly
+        # what the depth-fill gate refuses. The unmodified template seeds an
+        # empty D1, so this is the realistic path, not a contrived input.
+        repo = StubRepository()
+        engine = LearningEngine(repo)
+        gap = ExistenceGap(primitive=_primitive("Copy"))
+
+        filled = ExistenceCandidate(
+            name="Copy",
+            d1=ProposedDepth(level=DepthLevel.IDENTITY, properties={}),
+        )
+
+        with pytest.raises(CandidateValidationError, match="must carry content"):
+            engine.learn_gap(gap, filled)
+        assert repo.saved == []
+
 
 class TestPersistDepth:
     def test_merges_new_depth_into_existing(self):


### PR DESCRIPTION
## What

Closes #129. The existence-learning path accepted and persisted an `ExistenceCandidate` whose D1 carried empty `properties`, manufacturing a vacuous identity that does not ground (#80). The concept could then re-report as grounded with no gaps despite having an empty identity — the quiet degradation VRE exists to prevent.

The depth-fill path already rejected empty content (`_validate_depth_fill`: *"a fill must carry content"*); the existence path had silently re-implemented every check **but** that one. The bug was a drift between two copies of the same policy.

## Fix

Route the agent-proposed D1 through the **same** `_validate_depth_fill` gate the depth path uses, modeling the auto-generated D0 as the present floor (accepting an existence gap *is* the D0 confirmation):

```python
_validate_depth_fill(
    [candidate.d1],
    DepthLevel.EXISTENCE,   # current
    DepthLevel.IDENTITY,    # required
    {DepthLevel.EXISTENCE}, # present floor (auto D0)
    f"ExistenceCandidate for '{candidate.name}'",
)
```

This single-sources the vacuity floor (#80) and contiguity rules across both learning paths, so the existence path can no longer drift from the depth path.

**Design note — share the validator, not the persister.** The *validator* encodes a policy (the vacuity floor) whose duplication caused this bug, so unifying it has real safety value. Persistence stays distinct: existence is a **create** (`find_by_name` must be absent → build a fresh `[d0, d1]` node), depth-fill is an **append** (`find_by_id` must exist → mutate). Their live-state checks are inverted, so the persist wrapper is deliberately *not* shared.

## Why it's safe (verified)

`_persist_existence` is reachable only via `learn_gap → validate_for_gap → _persist`, so D1 is always non-`None` and `IDENTITY` by the time the validator runs. For the existence call, every validator branch was walked:

| Branch | Behavior | 
|--------|----------|
| empty `new_depths` / duplicates | never fire (always exactly `[d1]`) |
| **content / vacuity** | **fires iff D1 empty** — the fix; only branch doing new work |
| scope / holes-only | never fire (D1 == required; D1 ∉ {D0}) |
| contiguity | passes ({D0,D1} gapless from D0) |

- `present={D0}` is load-bearing: `present={}` would make `contiguous_max({D1})` return `None` and wrongly reject *every* valid candidate.
- Resolved-check ordering preserved: a stale gap whose concept already exists reports `GapResolvedError`, not a content error — even when the replayed candidate's D1 is empty.

## Tests

- New regression test `TestPersistExistence::test_rejects_empty_d1_properties` (the unmodified template seeds an empty D1, so this is the realistic path).
- Full suite: **396 passed, 11 skipped**; coverage 83%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)