### PR TITLE
chore(release): v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ summarize major changes, refactors, and breaking changes — not every commit.
 
 ## [Unreleased]
 
+## [1.0.1] - 2026-06-18
+
 ### Fixed
 
 - A concept appearing more than once in a single grounding query — repeated
@@ -343,7 +345,8 @@ Initial PyPI release, bundling the early epistemic engine and tooling.
 
 - Initial public scaffold: the core epistemic model and project README.
 
-[Unreleased]: https://github.com/anormang1992/vre/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/anormang1992/vre/compare/v1.0.1...HEAD
+[1.0.1]: https://github.com/anormang1992/vre/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/anormang1992/vre/compare/v0.9.1...v1.0.0
 [0.9.1]: https://github.com/anormang1992/vre/compare/v0.8.0...v0.9.1
 [0.8.0]: https://github.com/anormang1992/vre/compare/v0.6.0...v0.8.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "vre"
-version = "1.0.0"
+version = "1.0.1"
 description = "Volute Reasoning Engine — decorator-based epistemic enforcement"
 authors = [
     {name = "Andrew Greene",email = "anormang@gmail.com"}


### PR DESCRIPTION
Patch release cutting the two correctness fixes merged since v1.0.0.

## Changes
- Bump `pyproject` version `1.0.0` → `1.0.1`.
- Cut `CHANGELOG` `[Unreleased]` → `[1.0.1] - 2026-06-18`, add fresh empty `[Unreleased]`, update compare links.

## Included since v1.0.0
- **fix(grounding):** dedupe repeated concepts by folded name (#130)
- **fix(learning):** enforce the vacuity floor on the existence path (#129)

No API changes. Merging this, then publishing the `v1.0.1` GitHub Release, triggers the PyPI deploy (`publish.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)